### PR TITLE
Container services (AKS) - Fix for #1989

### DIFF
--- a/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/KubernetesCluster.java
+++ b/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/KubernetesCluster.java
@@ -137,7 +137,7 @@ public interface KubernetesCluster extends
              *
              * @return the next stage of the definition
              */
-            WithDnsPrefix withVersion(KubernetesVersion kubernetesVersion);
+            WithLinuxRootUsername withVersion(KubernetesVersion kubernetesVersion);
 
             /**
              * Uses the latest version for the Kubernetes cluster.


### PR DESCRIPTION
 Can't specify all the options when selecting .withVersion()