### PR TITLE
Renaming Local MSI to SystemAssigned MSI

### DIFF
--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/VirtualMachine.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/VirtualMachine.java
@@ -406,18 +406,18 @@ public interface VirtualMachine extends
     boolean isManagedServiceIdentityEnabled();
 
     /**
-     * @return the Local Managed Service Identity specific Active Directory tenant ID assigned to the
-     * virtual machine.
-     */
-    @Beta // TODO Add since version 1.5
-    String localManagedServiceIdentityTenantId();
-
-    /**
-     * @return the Local Managed Service Identity specific Active Directory service principal ID assigned
+     * @return the System Assigned (Local) Managed Service Identity specific Active Directory tenant ID assigned
      * to the virtual machine.
      */
     @Beta // TODO Add since version 1.5
-    String localManagedServiceIdentityPrincipalId();
+    String systemAssignedManagedServiceIdentityTenantId();
+
+    /**
+     * @return the System Assigned (Local) Managed Service Identity specific Active Directory service principal ID
+     * assigned to the virtual machine.
+     */
+    @Beta // TODO Add since version 1.5
+    String systemAssignedManagedServiceIdentityPrincipalId();
 
     /**
      * @return the type of Managed Service Identity used for the virtual machine.
@@ -1508,79 +1508,80 @@ public interface VirtualMachine extends
         }
 
         /**
-         * The stage of the virtual machine definition allowing to enable Local Managed Service Identity.
+         * The stage of the virtual machine definition allowing to enable System Assigned (Local) Managed Service Identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalManagedServiceIdentity {
+        interface WithSystemAssignedManagedServiceIdentity {
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in the virtual machine.
              *
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalManagedServiceIdentity();
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedManagedServiceIdentity();
 
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in the virtual machine.
              *
              * @param tokenPort the port on the virtual machine where access token is available
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalManagedServiceIdentity(int tokenPort);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedManagedServiceIdentity(int tokenPort);
         }
 
         /**
-         * The stage of the Local Managed Service Identity enabled virtual machine allowing to set access
-         * role for the identity.
+         * The stage of the System Assigned (Local) Managed Service Identity enabled virtual machine allowing to
+         * set access role for the identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalIdentityBasedAccessOrCreate extends WithCreate {
+        interface WithSystemAssignedIdentityBasedAccessOrCreate extends WithCreate {
             /**
-             * Specifies that virtual machine's local identity should have the given access (described
-             * by the role) on an ARM resource identified by the resource ID. Applications running on
-             * the virtual machine will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine's system assigned (local) identity should have the given access
+             * (described by the role) on an ARM resource identified by the resource ID. Applications running
+             * on the virtual machine will have the same permission (role) on the ARM resource.
              *
              * @param resourceId the ARM identifier of the resource
              * @param role access role to assigned to the virtual machine's local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role);
 
             /**
-             * Specifies that virtual machine's local identity should have the given access (described by
-             * the role) on the resource group that virtual machine resides. Applications running on the
-             * virtual machine will have the same permission (role) on the resource group.
+             * Specifies that virtual machine's system assigned (local) identity should have the given access
+             * (described by the role) on the resource group that virtual machine resides. Applications running
+             * on the virtual machine will have the same permission (role) on the resource group.
              *
              * @param role access role to assigned to the virtual machine's local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
 
             /**
-             * Specifies that virtual machine's local identity should have the access (described by the
-             * role definition) on an ARM resource identified by the resource ID.  Applications running
-             * on the virtual machine will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine's system assigned (local) identity should have the access
+             * (described by the role definition) on an ARM resource identified by the resource ID.
+             * Applications running on the virtual machine will have the same permission (role) on the ARM resource.
              *
              * @param resourceId scope of the access represented in ARM resource ID format
              * @param roleDefinitionId access role definition to assigned to the virtual machine's local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
 
             /**
-             * Specifies that virtual machine's local identity should have the access (described by the
-             * role definition) on the resource group that virtual machine resides. Applications running
-             * on the virtual machine will have the same permission (role) on the resource group.
+             * Specifies that virtual machine's system assigned (local) identity should have the access
+             * (described by the role definition) on the resource group that virtual machine resides.
+             * Applications running on the virtual machine will have the same permission (role) on the
+             * resource group.
              *
              * @param roleDefinitionId access role definition to assigned to the virtual machine's local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
         }
 
         /**
@@ -1665,7 +1666,7 @@ public interface VirtualMachine extends
                 DefinitionStages.WithExtension,
                 DefinitionStages.WithPlan,
                 DefinitionStages.WithBootDiagnostics,
-                DefinitionStages.WithLocalManagedServiceIdentity {
+                DefinitionStages.WithSystemAssignedManagedServiceIdentity {
         }
     }
 
@@ -1972,71 +1973,75 @@ public interface VirtualMachine extends
         }
 
         /**
-         * The stage of the virtual machine update allowing to enable Local Managed Service Identity.
+         * The stage of the virtual machine update allowing to enable System Assigned (Local) Managed Service Identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalManagedServiceIdentity {
+        interface WithSystemAssignedManagedServiceIdentity {
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in the
+             * virtual machine.
              *
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalManagedServiceIdentity();
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedManagedServiceIdentity();
 
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in
+             * the virtual machine.
              *
              * @param tokenPort the port on the virtual machine where access token is available
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalManagedServiceIdentity(int tokenPort);
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedManagedServiceIdentity(int tokenPort);
         }
 
         /**
-         * The stage of the Local Managed Service Identity enabled virtual machine allowing to set access
-         * role for the identity.
+         * The stage of the System Assigned (Local) Managed Service Identity enabled virtual machine allowing
+         * to set access role for the identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalIdentityBasedAccessOrUpdate extends Update {
+        interface WithSystemAssignedIdentityBasedAccessOrUpdate extends Update {
             /**
-             * Specifies that virtual machine's local identity should have the given access (described
-             * by the role) on an ARM resource identified by the resource ID. Applications running on
-             * the virtual machine will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine's system assigned (local) identity should have the given
+             * access (described by the role) on an ARM resource identified by the resource ID.
+             * Applications running on the virtual machine will have the same permission (role) on
+             * the ARM resource.
              *
              * @param resourceId the ARM identifier of the resource
              * @param role access role to assigned to the virtual machine's local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role);
 
             /**
-             * Specifies that virtual machine's local identity should have the given access (described
-             * by the role) on the resource group that virtual machine resides. Applications running
+             * Specifies that virtual machine's system assigned (local) identity should have the given access
+             * (described by the role) on the resource group that virtual machine resides. Applications running
              * on the virtual machine will have the same permission (role) on the resource group.
              *
              * @param role access role to assigned to the virtual machine's local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
 
             /**
-             * Specifies that virtual machine's local identity should have the access (described by the
-             * role definition) on an ARM resource identified by the resource ID.  Applications running
-             * on the virtual machine will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine's system assigned (local) identity should have the access
+             * (described by the role definition) on an ARM resource identified by the resource ID.
+             * Applications running on the virtual machine will have the same permission (role) on
+             * the ARM resource.
              *
              * @param resourceId scope of the access represented in ARM resource ID format
              * @param roleDefinitionId access role definition to assigned to the virtual machine's local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
 
             /**
-             * Specifies that virtual machine's local identity should have the access (described by the
+             * Specifies that virtual machine's system assigned (local) identity should have the access (described by the
              * role definition) on the resource group that virtual machine resides. Applications running
              * on the virtual machine will have the same permission (role) on the resource group.
              *
@@ -2044,7 +2049,7 @@ public interface VirtualMachine extends
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrUpdate withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrUpdate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
         }
     }
 
@@ -2059,7 +2064,7 @@ public interface VirtualMachine extends
             UpdateStages.WithSecondaryNetworkInterface,
             UpdateStages.WithExtension,
             UpdateStages.WithBootDiagnostics,
-            UpdateStages.WithLocalManagedServiceIdentity {
+            UpdateStages.WithSystemAssignedManagedServiceIdentity {
 
         /**
          * Specifies the encryption settings for the OS Disk.

--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/VirtualMachineScaleSet.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/VirtualMachineScaleSet.java
@@ -318,18 +318,18 @@ public interface VirtualMachineScaleSet extends
     boolean isManagedServiceIdentityEnabled();
 
     /**
-     * @return the Local Managed Service Identity specific Active Directory tenant ID assigned to the
-     * virtual machine scale set.
+     * @return the System Assigned (Local) Managed Service Identity specific Active Directory tenant ID
+     * assigned to the virtual machine scale set.
      */
     @Beta // TODO Add since version 1.5
-    String localManagedServiceIdentityTenantId();
+    String systemAssignedManagedServiceIdentityTenantId();
 
     /**
-     * @return the Local Managed Service Identity specific Active Directory service principal ID assigned
-     * to the virtual machine scale set.
+     * @return the System Assigned (Local) Managed Service Identity specific Active Directory service principal ID
+     * assigned to the virtual machine scale set.
      */
     @Beta // TODO Add since version 1.5
-    String localManagedServiceIdentityPrincipalId();
+    String systemAssignedManagedServiceIdentityPrincipalId();
 
     /**
      * @return the type of Managed Service Identity used for the virtual machine scale set.
@@ -1337,45 +1337,48 @@ public interface VirtualMachineScaleSet extends
         }
 
         /**
-         * The stage of the virtual machine scale set definition allowing to enable Local Managed Service Identity.
+         * The stage of the virtual machine scale set definition allowing to enable System Assigned (Local) Managed
+         * Service Identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalManagedServiceIdentity {
+        interface WithSystemAssignedManagedServiceIdentity {
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine scale set.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in the virtual
+             * machine scale set.
              *
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalManagedServiceIdentity();
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedManagedServiceIdentity();
 
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine scale set.
+             * Specifies that System Assigned (Local) Managed Service Identity needs to be enabled in the virtual
+             * machine scale set.
              *
              * @param tokenPort the port on the virtual machine scale set instance where access token is available
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalManagedServiceIdentity(int tokenPort);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedManagedServiceIdentity(int tokenPort);
         }
 
         /**
-         * The stage of the Local Managed Service Identity enabled virtual machine scale set allowing to set access
-         * for the identity.
+         * The stage of the System Assigned (Local) Managed Service Identity enabled virtual machine scale set
+         * allowing to set access for the identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalIdentityBasedAccessOrCreate extends WithCreate {
+        interface WithSystemAssignedIdentityBasedAccessOrCreate extends WithCreate {
             /**
-             * Specifies that virtual machine scale set's local identity should have the given access
-             * (described by the role) on an ARM resource identified by the resource ID. Applications running
-             * on the scale set VM instance will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine scale set's system assigned (local) identity should have the given
+             * access (described by the role) on an ARM resource identified by the resource ID. Applications
+             * running on the scale set VM instance will have the same permission (role) on the ARM resource.
              *
              * @param resourceId the ARM identifier of the resource
              * @param role access role to assigned to the scale set local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role);
 
             /**
              * Specifies that virtual machine scale set's local identity should have the given access
@@ -1386,30 +1389,30 @@ public interface VirtualMachineScaleSet extends
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
 
             /**
-             * Specifies that virtual machine scale set's local identity should have the access (described by
-             * the role definition) on an ARM resource identified by the resource ID.  Applications running on
-             * the scale set VM instance will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine scale set's system assigned (local) identity should have the access
+             * (described by the role definition) on an ARM resource identified by the resource ID.  Applications
+             * running on the scale set VM instance will have the same permission (role) on the ARM resource.
              *
              * @param resourceId scope of the access represented in ARM resource ID format
              * @param roleDefinitionId access role definition to assigned to the scale set local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
 
             /**
-             * Specifies that virtual machine scale set's local identity should have the access (described by
-             * the role definition) on the resource group that virtual machine resides. Applications running
-             * on the scale set VM instance will have the same permission (role) on the resource group.
+             * Specifies that virtual machine scale set's system assigned (local) identity should have the access
+             * (described by the role definition) on the resource group that virtual machine resides. Applications
+             * running on the scale set VM instance will have the same permission (role) on the resource group.
              *
              * @param roleDefinitionId access role definition to assigned to the scale set local identity
              * @return the next stage of the definition
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrCreate withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrCreate withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
         }
 
         /**
@@ -1468,7 +1471,7 @@ public interface VirtualMachineScaleSet extends
                 DefinitionStages.WithStorageAccount,
                 DefinitionStages.WithCustomData,
                 DefinitionStages.WithExtension,
-                DefinitionStages.WithLocalManagedServiceIdentity,
+                WithSystemAssignedManagedServiceIdentity,
                 DefinitionStages.WithBootDiagnostics,
                 Resource.DefinitionWithTags<VirtualMachineScaleSet.DefinitionStages.WithCreate> {
         }
@@ -1720,79 +1723,82 @@ public interface VirtualMachineScaleSet extends
         }
 
         /**
-         * The stage of the virtual machine scale set update allowing to enable Local Managed Service Identity.
+         * The stage of the virtual machine scale set update allowing to enable System Assigned (Local) Managed Service Identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalManagedServiceIdentity {
+        interface WithSystemAssignedManagedServiceIdentity {
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine scale set.
+             * Specifies that System assigned (Local) Managed Service Identity needs to be enabled in the
+             * virtual machine scale set.
              *
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalManagedServiceIdentity();
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedManagedServiceIdentity();
 
             /**
-             * Specifies that Local Managed Service Identity needs to be enabled in the virtual machine scale set.
+             * Specifies that System assigned (Local) Managed Service Identity needs to be enabled in the
+             * virtual machine scale set.
              *
              * @param tokenPort the port on the virtual machine scale set instance where access token is available
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalManagedServiceIdentity(int tokenPort);
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedManagedServiceIdentity(int tokenPort);
         }
 
         /**
-         * The stage of the Local Managed Service Identity enabled virtual machine scale set allowing to
-         * set access for the identity.
+         * The stage of the System Assigned (Local) Managed Service Identity enabled virtual machine scale set
+         * allowing to set access for the identity.
          */
         @Beta // TODO Add since version 1.5
-        interface WithLocalIdentityBasedAccessOrApply extends WithApply {
+        interface WithSystemAssignedIdentityBasedAccessOrApply extends WithApply {
             /**
-             * Specifies that virtual machine's local identity should have the given access (described
-             * by the role) on an ARM resource identified by the resource ID. Applications running on
-             * the scale set VM instance will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine's system assigned (local) identity should have the given
+             * access (described by the role) on an ARM resource identified by the resource ID.
+             * Applications running on the scale set VM instance will have the same permission (role)
+             * on the ARM resource.
              *
              * @param resourceId the ARM identifier of the resource
              * @param role access role to assigned to the scale set local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role);
 
             /**
-             * Specifies that virtual machine scale set's local identity should have the given access (described
-             * by the role) on the resource group that virtual machine resides. Applications running on the
-             * scale set VM instance will have the same permission (role) on the resource group.
+             * Specifies that virtual machine scale set's system assigned (local) identity should have the given
+             * access (described by the role) on the resource group that virtual machine resides. Applications
+             * running on the scale set VM instance will have the same permission (role) on the resource group.
              *
              * @param role access role to assigned to the scale set local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role);
 
             /**
-             * Specifies that virtual machine scale set 's local identity should have the access (described by the
-             * role definition) on an ARM resource identified by the resource ID.  Applications running on the
-             * scale set VM instance will have the same permission (role) on the ARM resource.
+             * Specifies that virtual machine scale set 's system assigned (local) identity should have the access
+             * (described by the role definition) on an ARM resource identified by the resource ID.  Applications
+             * running on the scale set VM instance will have the same permission (role) on the ARM resource.
              *
              * @param resourceId scope of the access represented in ARM resource ID format
              * @param roleDefinitionId access role definition to assigned to the scale set local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedIdentityBasedAccessTo(String resourceId, String roleDefinitionId);
 
             /**
-             * Specifies that virtual machine scale set's local identity should have the access (described by the
-             * role definition) on the resource group that virtual machine resides. Applications running on the
-             * scale set VM instance will have the same permission (role) on the resource group.
+             * Specifies that virtual machine scale set's system assigned (local) identity should have the access
+             * (described by the role definition) on the resource group that virtual machine resides. Applications
+             * running on the scale set VM instance will have the same permission (role) on the resource group.
              *
              * @param roleDefinitionId access role definition to assigned to the scale set local identity
              * @return the next stage of the update
              */
             @Beta // TODO Add since version 1.5
-            WithLocalIdentityBasedAccessOrApply withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
+            WithSystemAssignedIdentityBasedAccessOrApply withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId);
         }
 
         /**
@@ -1960,7 +1966,7 @@ public interface VirtualMachineScaleSet extends
                 UpdateStages.WithoutPrimaryLoadBalancer,
                 UpdateStages.WithoutPrimaryLoadBalancerBackend,
                 UpdateStages.WithoutPrimaryLoadBalancerNatPool,
-                UpdateStages.WithLocalManagedServiceIdentity,
+                WithSystemAssignedManagedServiceIdentity,
                 UpdateStages.WithBootDiagnostics,
                 UpdateStages.WithAvailabilityZone {
         }

--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineImpl.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineImpl.java
@@ -104,8 +104,8 @@ class VirtualMachineImpl
         VirtualMachine.DefinitionManaged,
         VirtualMachine.DefinitionUnmanaged,
         VirtualMachine.Update,
-        VirtualMachine.DefinitionStages.WithLocalIdentityBasedAccessOrCreate,
-        VirtualMachine.UpdateStages.WithLocalIdentityBasedAccessOrUpdate {
+        VirtualMachine.DefinitionStages.WithSystemAssignedIdentityBasedAccessOrCreate,
+        VirtualMachine.UpdateStages.WithSystemAssignedIdentityBasedAccessOrUpdate {
     // Clients
     private final StorageManager storageManager;
     private final NetworkManager networkManager;
@@ -1273,38 +1273,38 @@ class VirtualMachineImpl
     }
 
     @Override
-    public VirtualMachineImpl withLocalManagedServiceIdentity() {
+    public VirtualMachineImpl withSystemAssignedManagedServiceIdentity() {
         this.virtualMachineMsiHelper.withLocalManagedServiceIdentity();
         return this;
     }
 
     @Override
-    public VirtualMachineImpl withLocalManagedServiceIdentity(int tokenPort) {
+    public VirtualMachineImpl withSystemAssignedManagedServiceIdentity(int tokenPort) {
         this.virtualMachineMsiHelper.withLocalManagedServiceIdentity(tokenPort);
         return this;
     }
 
 
     @Override
-    public VirtualMachineImpl withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role) {
+    public VirtualMachineImpl withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role) {
         this.virtualMachineMsiHelper.withAccessTo(resourceId, role);
         return this;
     }
 
     @Override
-    public VirtualMachineImpl withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role) {
+    public VirtualMachineImpl withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole role) {
         this.virtualMachineMsiHelper.withAccessToCurrentResourceGroup(role);
         return this;
     }
 
     @Override
-    public VirtualMachineImpl withLocalIdentityBasedAccessTo(String resourceId, String roleDefinitionId) {
+    public VirtualMachineImpl withSystemAssignedIdentityBasedAccessTo(String resourceId, String roleDefinitionId) {
         this.virtualMachineMsiHelper.withAccessTo(resourceId, roleDefinitionId);
         return this;
     }
 
     @Override
-    public VirtualMachineImpl withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId) {
+    public VirtualMachineImpl withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId) {
         this.virtualMachineMsiHelper.withAccessToCurrentResourceGroup(roleDefinitionId);
         return this;
     }
@@ -1568,12 +1568,12 @@ class VirtualMachineImpl
 
     @Override
     public boolean isManagedServiceIdentityEnabled() {
-        return this.localManagedServiceIdentityPrincipalId() != null
-                && this.localManagedServiceIdentityTenantId() != null;
+        return this.systemAssignedManagedServiceIdentityPrincipalId() != null
+                && this.systemAssignedManagedServiceIdentityTenantId() != null;
     }
 
     @Override
-    public String localManagedServiceIdentityTenantId() {
+    public String systemAssignedManagedServiceIdentityTenantId() {
         if (this.inner().identity() != null) {
             return this.inner().identity().tenantId();
         }
@@ -1581,7 +1581,7 @@ class VirtualMachineImpl
     }
 
     @Override
-    public String localManagedServiceIdentityPrincipalId() {
+    public String systemAssignedManagedServiceIdentityPrincipalId() {
         if (this.inner().identity() != null) {
             return this.inner().identity().principalId();
         }

--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineScaleSetImpl.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineScaleSetImpl.java
@@ -95,8 +95,8 @@ public class VirtualMachineScaleSetImpl
         VirtualMachineScaleSet.DefinitionManaged,
         VirtualMachineScaleSet.DefinitionUnmanaged,
         VirtualMachineScaleSet.Update,
-        VirtualMachineScaleSet.DefinitionStages.WithLocalIdentityBasedAccessOrCreate,
-        VirtualMachineScaleSet.UpdateStages.WithLocalIdentityBasedAccessOrApply {
+        VirtualMachineScaleSet.DefinitionStages.WithSystemAssignedIdentityBasedAccessOrCreate,
+        VirtualMachineScaleSet.UpdateStages.WithSystemAssignedIdentityBasedAccessOrApply {
     // Clients
     private final StorageManager storageManager;
     private final NetworkManager networkManager;
@@ -1010,12 +1010,12 @@ public class VirtualMachineScaleSetImpl
 
     @Override
     public boolean isManagedServiceIdentityEnabled() {
-        return this.localManagedServiceIdentityPrincipalId() != null
-                && this.localManagedServiceIdentityTenantId() != null;
+        return this.systemAssignedManagedServiceIdentityPrincipalId() != null
+                && this.systemAssignedManagedServiceIdentityTenantId() != null;
     }
 
     @Override
-    public String localManagedServiceIdentityTenantId() {
+    public String systemAssignedManagedServiceIdentityTenantId() {
         if (this.inner().identity() != null) {
             return this.inner().identity().tenantId();
         }
@@ -1023,7 +1023,7 @@ public class VirtualMachineScaleSetImpl
     }
 
     @Override
-    public String localManagedServiceIdentityPrincipalId() {
+    public String systemAssignedManagedServiceIdentityPrincipalId() {
         if (this.inner().identity() != null) {
             return this.inner().identity().principalId();
         }
@@ -1244,37 +1244,37 @@ public class VirtualMachineScaleSetImpl
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalManagedServiceIdentity() {
+    public VirtualMachineScaleSetImpl withSystemAssignedManagedServiceIdentity() {
         this.virtualMachineScaleSetMsiHelper.withLocalManagedServiceIdentity(this.inner());
         return this;
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalManagedServiceIdentity(int tokenPort) {
+    public VirtualMachineScaleSetImpl withSystemAssignedManagedServiceIdentity(int tokenPort) {
         this.virtualMachineScaleSetMsiHelper.withLocalManagedServiceIdentity(tokenPort, this.inner());
         return this;
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalIdentityBasedAccessTo(String resourceId, BuiltInRole role) {
+    public VirtualMachineScaleSetImpl withSystemAssignedIdentityBasedAccessTo(String resourceId, BuiltInRole role) {
         this.virtualMachineScaleSetMsiHelper.withAccessTo(resourceId, role);
         return this;
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole asRole) {
+    public VirtualMachineScaleSetImpl withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole asRole) {
         this.virtualMachineScaleSetMsiHelper.withAccessToCurrentResourceGroup(asRole);
         return this;
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalIdentityBasedAccessTo(String scope, String roleDefinitionId) {
+    public VirtualMachineScaleSetImpl withSystemAssignedIdentityBasedAccessTo(String scope, String roleDefinitionId) {
         this.virtualMachineScaleSetMsiHelper.withAccessTo(scope, roleDefinitionId);
         return this;
     }
 
     @Override
-    public VirtualMachineScaleSetImpl withLocalIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId) {
+    public VirtualMachineScaleSetImpl withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(String roleDefinitionId) {
         this.virtualMachineScaleSetMsiHelper.withAccessToCurrentResourceGroup(roleDefinitionId);
         return this;
     }

--- a/azure-mgmt-compute/src/test/java/com/microsoft/azure/management/compute/VirtualMachineManagedServiceIdentityOperationsTests.java
+++ b/azure-mgmt-compute/src/test/java/com/microsoft/azure/management/compute/VirtualMachineManagedServiceIdentityOperationsTests.java
@@ -55,14 +55,14 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
                 .withRootPassword("abc!@#F0orL")
                 .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                 .withOSDiskCaching(CachingTypes.READ_WRITE)
-                .withLocalManagedServiceIdentity()
+                .withSystemAssignedManagedServiceIdentity()
                 .create();
 
         Assert.assertNotNull(virtualMachine);
         Assert.assertNotNull(virtualMachine.inner());
         Assert.assertTrue(virtualMachine.isManagedServiceIdentityEnabled());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityPrincipalId());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityTenantId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityTenantId());
 
         // Ensure the MSI extension is set
         //
@@ -93,7 +93,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(rgRoleAssignments1);
         boolean found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments1) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -101,14 +101,14 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertFalse("Resource group should not have a role assignment with virtual machine MSI principal", found);
 
         virtualMachine = virtualMachine.update()
-                .withLocalManagedServiceIdentity(50343)
+                .withSystemAssignedManagedServiceIdentity(50343)
                 .apply();
 
         Assert.assertNotNull(virtualMachine);
         Assert.assertNotNull(virtualMachine.inner());
         Assert.assertTrue(virtualMachine.isManagedServiceIdentityEnabled());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityPrincipalId());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityTenantId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityTenantId());
 
         extensions = virtualMachine.listExtensions();
         msiExtension = null;
@@ -136,7 +136,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(rgRoleAssignments1);
         found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments1) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -158,8 +158,8 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
                 .withRootPassword("abc!@#F0orL")
                 .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                 .withOSDiskCaching(CachingTypes.READ_WRITE)
-                .withLocalManagedServiceIdentity()
-                .withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedManagedServiceIdentity()
+                .withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
                 .createAsync();
 
         final VirtualMachine[] virtualMachines = new VirtualMachine[1];
@@ -187,14 +187,14 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(virtualMachine);
         Assert.assertNotNull(virtualMachine.inner());
         Assert.assertTrue(virtualMachine.isManagedServiceIdentityEnabled());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityPrincipalId());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityTenantId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityTenantId());
 
         // Validate service created service principal
         //
         ServicePrincipal servicePrincipal = rbacManager
                 .servicePrincipals()
-                .getById(virtualMachine.localManagedServiceIdentityPrincipalId());
+                .getById(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
 
         Assert.assertNotNull(servicePrincipal);
         Assert.assertNotNull(servicePrincipal.inner());
@@ -218,7 +218,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         PagedList<RoleAssignment> rgRoleAssignments = rbacManager.roleAssignments().listByScope(resourceGroup.id());
         boolean found = false;
         for (RoleAssignment rgRoleAssignment : rgRoleAssignments) {
-            if (rgRoleAssignment.principalId() != null && rgRoleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (rgRoleAssignment.principalId() != null && rgRoleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -274,16 +274,16 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
                 .withRootPassword("abc!@#F0orL")
                 .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                 .withOSDiskCaching(CachingTypes.READ_WRITE)
-                .withLocalManagedServiceIdentity()
-                .withLocalIdentityBasedAccessTo(resourceGroup.id(), BuiltInRole.CONTRIBUTOR)
-                .withLocalIdentityBasedAccessTo(storageAccount.id(), BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedManagedServiceIdentity()
+                .withSystemAssignedIdentityBasedAccessTo(resourceGroup.id(), BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedIdentityBasedAccessTo(storageAccount.id(), BuiltInRole.CONTRIBUTOR)
                 .create();
 
         // Validate service created service principal
         //
         ServicePrincipal servicePrincipal = rbacManager
                 .servicePrincipals()
-                .getById(virtualMachine.localManagedServiceIdentityPrincipalId());
+                .getById(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
 
         Assert.assertNotNull(servicePrincipal);
         Assert.assertNotNull(servicePrincipal.inner());
@@ -307,7 +307,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(rgRoleAssignments);
         boolean found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -320,7 +320,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(stgRoleAssignments);
         found = false;
         for (RoleAssignment roleAssignment : stgRoleAssignments) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -342,14 +342,14 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
                 .withRootPassword("abc!@#F0orL")
                 .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                 .withOSDiskCaching(CachingTypes.READ_WRITE)
-                .withLocalManagedServiceIdentity()
+                .withSystemAssignedManagedServiceIdentity()
                 .create();
 
         Assert.assertNotNull(virtualMachine);
         Assert.assertNotNull(virtualMachine.inner());
         Assert.assertTrue(virtualMachine.isManagedServiceIdentityEnabled());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityPrincipalId());
-        Assert.assertNotNull(virtualMachine.localManagedServiceIdentityTenantId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId());
+        Assert.assertNotNull(virtualMachine.systemAssignedManagedServiceIdentityTenantId());
 
         Assert.assertNotNull(virtualMachine.managedServiceIdentityType());
         Assert.assertTrue(virtualMachine.managedServiceIdentityType().equals(ResourceIdentityType.SYSTEM_ASSIGNED));
@@ -374,7 +374,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertNotNull(rgRoleAssignments1);
         boolean found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments1) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -382,8 +382,8 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         Assert.assertFalse("Resource group should not have a role assignment with virtual machine MSI principal", found);
 
         virtualMachine.update()
-                .withLocalManagedServiceIdentity()
-                .withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedManagedServiceIdentity()
+                .withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
                 .apply();
 
         // Ensure role assigned for resource group
@@ -391,7 +391,7 @@ public class VirtualMachineManagedServiceIdentityOperationsTests extends Compute
         PagedList<RoleAssignment> roleAssignments2 = rbacManager.roleAssignments().listByScope(resourceGroup.id());
         Assert.assertNotNull(roleAssignments2);
         for (RoleAssignment roleAssignment : roleAssignments2) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }

--- a/azure-mgmt-compute/src/test/java/com/microsoft/azure/management/compute/VirtualMachineScaleSetOperationsTests.java
+++ b/azure-mgmt-compute/src/test/java/com/microsoft/azure/management/compute/VirtualMachineScaleSetOperationsTests.java
@@ -696,14 +696,14 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
                 .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
                 .withRootUsername("jvuser")
                 .withRootPassword("123OData!@#123")
-                .withLocalManagedServiceIdentity()
+                .withSystemAssignedManagedServiceIdentity()
                 .create();
 
         // Validate service created service principal
         //
         ServicePrincipal servicePrincipal = rbacManager
                 .servicePrincipals()
-                .getById(virtualMachineScaleSet.localManagedServiceIdentityPrincipalId());
+                .getById(virtualMachineScaleSet.systemAssignedManagedServiceIdentityPrincipalId());
 
         Assert.assertNotNull(servicePrincipal);
         Assert.assertNotNull(servicePrincipal.inner());
@@ -727,7 +727,7 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
         Assert.assertNotNull(rgRoleAssignments);
         boolean found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -780,9 +780,9 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
                 .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
                 .withRootUsername("jvuser")
                 .withRootPassword("123OData!@#123")
-                .withLocalManagedServiceIdentity()
-                .withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
-                .withLocalIdentityBasedAccessTo(storageAccount.id(), BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedManagedServiceIdentity()
+                .withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
+                .withSystemAssignedIdentityBasedAccessTo(storageAccount.id(), BuiltInRole.CONTRIBUTOR)
                 .create();
 
         Assert.assertNotNull(virtualMachineScaleSet.managedServiceIdentityType());
@@ -792,7 +792,7 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
         //
         ServicePrincipal servicePrincipal = rbacManager
                 .servicePrincipals()
-                .getById(virtualMachineScaleSet.localManagedServiceIdentityPrincipalId());
+                .getById(virtualMachineScaleSet.systemAssignedManagedServiceIdentityPrincipalId());
 
         Assert.assertNotNull(servicePrincipal);
         Assert.assertNotNull(servicePrincipal.inner());
@@ -816,7 +816,7 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
         Assert.assertNotNull(rgRoleAssignments);
         boolean found = false;
         for (RoleAssignment roleAssignment : rgRoleAssignments) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }
@@ -829,7 +829,7 @@ public class VirtualMachineScaleSetOperationsTests extends ComputeManagementTest
         Assert.assertNotNull(stgRoleAssignments);
         found = false;
         for (RoleAssignment roleAssignment : stgRoleAssignments) {
-            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.localManagedServiceIdentityPrincipalId())) {
+            if (roleAssignment.principalId() != null && roleAssignment.principalId().equalsIgnoreCase(virtualMachineScaleSet.systemAssignedManagedServiceIdentityPrincipalId())) {
                 found = true;
                 break;
             }

--- a/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup.java
+++ b/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup.java
@@ -109,7 +109,7 @@ public final class ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup {
                         .withRootPassword(password)
                         .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                         .withOSDiskCaching(CachingTypes.READ_WRITE)
-                        .withLocalManagedServiceIdentity()
+                        .withSystemAssignedManagedServiceIdentity()
                         .create();
 
             System.out.println("Created virtual machine with MSI enabled");
@@ -121,7 +121,7 @@ public final class ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup {
             System.out.println("Adding virtual machine MSI service principal to the AAD group");
 
             activeDirectoryGroup.update()
-                    .withMember(virtualMachine.localManagedServiceIdentityPrincipalId())
+                    .withMember(virtualMachine.systemAssignedManagedServiceIdentityPrincipalId())
                     .apply();
 
             System.out.println("Added virtual machine MSI service principal to the AAD group");

--- a/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageStorageFromMSIEnabledVirtualMachine.java
+++ b/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageStorageFromMSIEnabledVirtualMachine.java
@@ -67,8 +67,8 @@ public final class ManageStorageFromMSIEnabledVirtualMachine {
                         .withRootPassword(password)
                         .withSize(VirtualMachineSizeTypes.STANDARD_DS2_V2)
                         .withOSDiskCaching(CachingTypes.READ_WRITE)
-                        .withLocalManagedServiceIdentity()
-                        .withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
+                        .withSystemAssignedManagedServiceIdentity()
+                        .withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
                         .create();
 
             System.out.println("Created virtual machine with MSI enabled");

--- a/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageVirtualMachineFromMSIEnabledVirtualMachine.java
+++ b/azure-samples/src/main/java/com/microsoft/azure/management/compute/samples/ManageVirtualMachineFromMSIEnabledVirtualMachine.java
@@ -53,8 +53,8 @@ public final class ManageVirtualMachineFromMSIEnabledVirtualMachine {
 //                    .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
 //                    .withRootUsername("<user-name>")
 //                    .withRootPassword("<password>")
-//                    .withLocalManagedServiceIdentity()
-//                    .withLocalIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
+//                    .withSystemAssignedManagedServiceIdentity()
+//                    .withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(BuiltInRole.CONTRIBUTOR)
 //                    .create();
 
 

--- a/azure-samples/src/main/java/com/microsoft/azure/management/samples/Utils.java
+++ b/azure-samples/src/main/java/com/microsoft/azure/management/samples/Utils.java
@@ -279,8 +279,8 @@ public final class Utils {
 
         StringBuilder msi = new StringBuilder().append("\n\tMSI: ");
         msi.append("\n\t\t\tMSI enabled:").append(resource.isManagedServiceIdentityEnabled());
-        msi.append("\n\t\t\tLocal MSI Active Directory Service Principal Id:").append(resource.localManagedServiceIdentityPrincipalId());
-        msi.append("\n\t\t\tLocal MSI Active Directory Tenant Id:").append(resource.localManagedServiceIdentityTenantId());
+        msi.append("\n\t\t\tSystem Assigned MSI Active Directory Service Principal Id:").append(resource.systemAssignedManagedServiceIdentityPrincipalId());
+        msi.append("\n\t\t\tSystem Assigned MSI Active Directory Tenant Id:").append(resource.systemAssignedManagedServiceIdentityTenantId());
 
         StringBuilder zones = new StringBuilder().append("\n\tZones: ");
         zones.append(resource.availabilityZones());


### PR DESCRIPTION
Once we integrate new User Assigned Managed Service Identity, it is necessary to distinguish it from existing System Assigned Managed Service Identity. This PR renames existing MSI methods in VM and VMSS to make it clear that those areSystem Assigned MSI. PR adopts the terms [User Assigned, SystemAssigned] agreed with AD team & portal.

<table>
  <tr>
    <th align=left>Area/Model</th>SystemAssigned
    <th align=left>In V1.4</th>
    <th align=left>In V1.5</th>
    <th align=left>Remarks</th>
    <th align=left>Ref</th>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.managedServiceIdentityTenantId()</code></td>
    <td><code>.systemAssignedManagedServiceIdentityTenantId()</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83 </a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.managedServiceIdentityPrincipalId()</code></td>
    <td><code>.systemAssignedManagedServiceIdentityPrincipalId()</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83 </a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.withManagedServiceIdentity()</code></td>
    <td><code>.withSystemAssignedManagedServiceIdentity()</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.withRoleBasedAccessTo(scope, role)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessTo(resourceId, role)</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.withRoleBasedAccessToCurrentResourceGroup(role)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(role)</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.withRoleDefinitionBasedAccessTo(scope, roleDefinitionId)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessTo(resourceId, roleDefinitionId)</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachine</code></td>
    <td><code>.withRoleDefinitionBasedAccessToCurrentResourceGroup(roleDefinitionId)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(roleDefinitionId)</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.managedServiceIdentityTenantId()</code></td>
    <td><code>.SystemAssignedManagedServiceIdentityTenantId()</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83">PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.managedServiceIdentityPrincipalId()</code></td>
    <td><code>.SystemAssignedManagedServiceIdentityPrincipalId()</code></td>
    <td></td>
    <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.withManagedServiceIdentity()</code></td>
    <td><code>.withSystemAssignedManagedServiceIdentity()</code></td>
    <td></td>
       <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.withRoleBasedAccessTo(scope, role)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessTo(resourceId, role)</code></td>
    <td></td>
        <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83 </a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88 </a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.withRoleBasedAccessToCurrentResourceGroup(role)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(role)</code></td>
    <td></td>
       <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.withRoleDefinitionBasedAccessTo(scope, roleDefinitionId)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessTo(resourceId, roleDefinitionId)</code></td>
    <td></td>
        <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83</a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88</a></td>
  </tr>
  <tr>
    <td><code>VirtualMachineScaleSet</code></td>
    <td><code>.withRoleDefinitionBasedAccessToCurrentResourceGroup(roleDefinitionId)</code></td>
    <td><code>.withSystemAssignedIdentityBasedAccessToCurrentResourceGroup(roleDefinitionId)</code></td>
    <td></td>
        <td><a href="https://github.com/Azure/azure-libraries-for-java/pull/83”>PR #83 </a><br/><a href="https://github.com/Azure/azure-libraries-for-java/pull/88">PR #88 </a></td>
  </tr>
</table>
