### PR TITLE
Support for external child resource independent definition & update and dependencies for external child resource

### DIFF
--- a/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationImpl.java
+++ b/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationImpl.java
@@ -69,7 +69,7 @@ public class ApplicationImpl
     }
 
     @Override
-    public Observable<Application> createAsync() {
+    public Observable<Application> createResourceAsync() {
         final ApplicationImpl self = this;
         ApplicationCreateParametersInner createParameter = new ApplicationCreateParametersInner();
         createParameter.withDisplayName(this.inner().displayName());
@@ -101,7 +101,7 @@ public class ApplicationImpl
     }
 
     @Override
-    public Observable<Application> updateAsync() {
+    public Observable<Application> updateResourceAsync() {
         final ApplicationImpl self = this;
 
         ApplicationUpdateParametersInner updateParameter = new ApplicationUpdateParametersInner();
@@ -128,7 +128,7 @@ public class ApplicationImpl
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.parent().manager().inner().applications().deleteAsync(
                 this.parent().resourceGroupName(),
                 this.parent().name(),

--- a/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationPackageImpl.java
+++ b/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationPackageImpl.java
@@ -51,7 +51,7 @@ public class ApplicationPackageImpl
     }
 
     @Override
-    public Observable<ApplicationPackage> createAsync() {
+    public Observable<ApplicationPackage> createResourceAsync() {
         final ApplicationPackageImpl self = this;
 
         return this.client.createAsync(this.parent().parent().resourceGroupName(), this.parent().parent().name(), this.parent().name(), this.name())
@@ -66,12 +66,12 @@ public class ApplicationPackageImpl
     }
 
     @Override
-    public Observable<ApplicationPackage> updateAsync() {
+    public Observable<ApplicationPackage> updateResourceAsync() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.client.deleteAsync(this.parent().parent().resourceGroupName(), this.parent().parent().name(), this.parent().name(), this.name());
     }
 
@@ -112,7 +112,7 @@ public class ApplicationPackageImpl
 
     @Override
     public void delete() {
-        this.deleteAsync().toBlocking().last();
+        this.deleteResourceAsync().toBlocking().last();
     }
 
     @Override

--- a/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationPackagesImpl.java
+++ b/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationPackagesImpl.java
@@ -36,11 +36,11 @@ class ApplicationPackagesImpl extends
     }
 
     public ApplicationPackageImpl define(String name) {
-        return this.prepareDefine(name);
+        return this.prepareInlineDefine(name);
     }
 
     public void remove(String applicationPackageName) {
-        this.prepareRemove(applicationPackageName);
+        this.prepareInlineRemove(applicationPackageName);
     }
 
     @Override

--- a/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationsImpl.java
+++ b/azure-mgmt-batch/src/main/java/com/microsoft/azure/management/batch/implementation/ApplicationsImpl.java
@@ -44,15 +44,15 @@ class ApplicationsImpl extends
     }
 
     public ApplicationImpl define(String name) {
-        return this.prepareDefine(name);
+        return this.prepareInlineDefine(name);
     }
 
     public ApplicationImpl update(String name) {
-        return this.prepareUpdate(name);
+        return this.prepareInlineUpdate(name);
     }
 
     public void remove(String name) {
-        this.prepareRemove(name);
+        this.prepareInlineRemove(name);
     }
 
     public void addApplication(ApplicationImpl application) {

--- a/azure-mgmt-cdn/src/main/java/com/microsoft/azure/management/cdn/implementation/CdnEndpointImpl.java
+++ b/azure-mgmt-cdn/src/main/java/com/microsoft/azure/management/cdn/implementation/CdnEndpointImpl.java
@@ -79,7 +79,7 @@ class CdnEndpointImpl extends ExternalChildResourceImpl<CdnEndpoint,
     }
 
     @Override
-    public Observable<CdnEndpoint> createAsync() {
+    public Observable<CdnEndpoint> createResourceAsync() {
         final CdnEndpointImpl self = this;
         return this.parent().manager().inner().endpoints().createAsync(this.parent().resourceGroupName(),
                 this.parent().name(),
@@ -108,7 +108,7 @@ class CdnEndpointImpl extends ExternalChildResourceImpl<CdnEndpoint,
     }
 
     @Override
-    public Observable<CdnEndpoint> updateAsync() {
+    public Observable<CdnEndpoint> updateResourceAsync() {
         final CdnEndpointImpl self = this;
         EndpointUpdateParametersInner updateInner = new EndpointUpdateParametersInner();
         updateInner.withIsHttpAllowed(this.inner().isHttpAllowed())
@@ -183,7 +183,7 @@ class CdnEndpointImpl extends ExternalChildResourceImpl<CdnEndpoint,
 
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.parent().manager().inner().endpoints().deleteAsync(this.parent().resourceGroupName(),
                 this.parent().name(),
                 this.name());

--- a/azure-mgmt-cdn/src/main/java/com/microsoft/azure/management/cdn/implementation/CdnEndpointsImpl.java
+++ b/azure-mgmt-cdn/src/main/java/com/microsoft/azure/management/cdn/implementation/CdnEndpointsImpl.java
@@ -56,7 +56,7 @@ class CdnEndpointsImpl extends
      * @param name the name of the endpoint to be removed
      */
     public void remove(String name) {
-        this.prepareRemove(name);
+        this.prepareInlineRemove(name);
     }
 
     /**
@@ -107,7 +107,7 @@ class CdnEndpointsImpl extends
     }
 
     public CdnEndpointImpl defineNewEndpoint(String name) {
-        CdnEndpointImpl endpoint = this.prepareDefine(name);
+        CdnEndpointImpl endpoint = this.prepareInlineDefine(name);
         endpoint.inner().withLocation(endpoint.parent().region().toString());
         endpoint.inner().withOrigins(new ArrayList<DeepCreatedOrigin>());
         return endpoint;
@@ -125,7 +125,7 @@ class CdnEndpointsImpl extends
     }
 
     public CdnEndpointImpl updateEndpoint(String name) {
-        CdnEndpointImpl endpoint = this.prepareUpdate(name);
+        CdnEndpointImpl endpoint = this.prepareInlineUpdate(name);
         return endpoint;
     }
 

--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineExtensionImpl.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineExtensionImpl.java
@@ -228,7 +228,7 @@ class VirtualMachineExtensionImpl
     // Implementation of ExternalChildResourceImpl createAsyncStreaming,  updateAsync and deleteAsync
     //
     @Override
-    public Observable<VirtualMachineExtension> createAsync() {
+    public Observable<VirtualMachineExtension> createResourceAsync() {
         final VirtualMachineExtensionImpl self = this;
         return this.client.createOrUpdateAsync(this.parent().resourceGroupName(),
                 this.parent().name(),
@@ -245,7 +245,7 @@ class VirtualMachineExtensionImpl
     }
 
     @Override
-    public Observable<VirtualMachineExtension> updateAsync() {
+    public Observable<VirtualMachineExtension> updateResourceAsync() {
         this.nullifySettingsIfEmpty();
         if (this.isReference()) {
             String extensionName = ResourceUtils.nameFromResourceId(this.inner().id());
@@ -277,16 +277,16 @@ class VirtualMachineExtensionImpl
                                     }
                                 }
                             }
-                            return createAsync();
+                            return createResourceAsync();
                         }
                     });
         } else {
-            return this.createAsync();
+            return this.createResourceAsync();
         }
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return RXMapper.mapToVoid(this.client.deleteAsync(
                 this.parent().resourceGroupName(),
                 this.parent().name(),

--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineExtensionsImpl.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/implementation/VirtualMachineExtensionsImpl.java
@@ -110,7 +110,7 @@ class VirtualMachineExtensionsImpl extends
      * @return the extension
      */
     public VirtualMachineExtensionImpl define(String name) {
-        VirtualMachineExtensionImpl newExtension = this.prepareDefine(name);
+        VirtualMachineExtensionImpl newExtension = this.prepareInlineDefine(name);
         return newExtension;
     }
 
@@ -121,7 +121,7 @@ class VirtualMachineExtensionsImpl extends
      * @return the extension
      */
     public VirtualMachineExtensionImpl update(String name) {
-        return this.prepareUpdate(name);
+        return this.prepareInlineUpdate(name);
     }
 
     /**
@@ -130,7 +130,7 @@ class VirtualMachineExtensionsImpl extends
      * @param name the reference name of the extension to be removed
      */
     public void remove(String name) {
-        this.prepareRemove(name);
+        this.prepareInlineRemove(name);
     }
 
     /**

--- a/azure-mgmt-containerregistry/src/main/java/com/microsoft/azure/management/containerregistry/implementation/WebhookImpl.java
+++ b/azure-mgmt-containerregistry/src/main/java/com/microsoft/azure/management/containerregistry/implementation/WebhookImpl.java
@@ -243,7 +243,7 @@ public class WebhookImpl
     }
 
     @Override
-    public Observable<Webhook> createAsync() {
+    public Observable<Webhook> createResourceAsync() {
         final WebhookImpl self = this;
         if (webhookCreateParametersInner != null) {
             return this.containerRegistryManager.inner().webhooks()
@@ -295,7 +295,7 @@ public class WebhookImpl
     }
 
     @Override
-    public Observable<Webhook> updateAsync() {
+    public Observable<Webhook> updateResourceAsync() {
         final WebhookImpl self = this;
         if (webhookUpdateParametersInner != null) {
             return this.containerRegistryManager.inner().webhooks()
@@ -327,7 +327,7 @@ public class WebhookImpl
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.containerRegistryManager.inner().webhooks()
             .deleteAsync(this.resourceGroupName,
             this.registryName,
@@ -362,12 +362,12 @@ public class WebhookImpl
 
     @Override
     public Observable<Webhook> applyAsync() {
-        return this.updateAsync();
+        return this.updateResourceAsync();
     }
 
     @Override
     public ServiceFuture<Webhook> applyAsync(ServiceCallback<Webhook> callback) {
-        return ServiceFuture.fromBody(this.updateAsync(), callback);
+        return ServiceFuture.fromBody(this.updateResourceAsync(), callback);
     }
 
     @Override

--- a/azure-mgmt-containerregistry/src/main/java/com/microsoft/azure/management/containerregistry/implementation/WebhooksImpl.java
+++ b/azure-mgmt-containerregistry/src/main/java/com/microsoft/azure/management/containerregistry/implementation/WebhooksImpl.java
@@ -32,14 +32,14 @@ public class WebhooksImpl
     }
 
     WebhookImpl defineWebhook(String name) {
-        return prepareDefine(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(true));
+        return prepareInlineDefine(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(true));
     }
 
     WebhookImpl updateWebhook(String name) {
-        return prepareUpdate(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(false));
+        return prepareInlineUpdate(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(false));
     }
 
     void withoutWebhook(String name) {
-        prepareRemove(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(false));
+        prepareInlineRemove(new WebhookImpl(name, this.parent(), new WebhookInner(), this.parent().manager()).setCreateMode(false));
     }
 }

--- a/azure-mgmt-dns/src/main/java/com/microsoft/azure/management/dns/implementation/DnsRecordSetImpl.java
+++ b/azure-mgmt-dns/src/main/java/com/microsoft/azure/management/dns/implementation/DnsRecordSetImpl.java
@@ -304,12 +304,12 @@ class DnsRecordSetImpl extends ExternalChildResourceImpl<DnsRecordSet,
     //
 
     @Override
-    public Observable<DnsRecordSet> createAsync() {
+    public Observable<DnsRecordSet> createResourceAsync() {
         return createOrUpdateAsync(this.inner());
     }
 
     @Override
-    public Observable<DnsRecordSet> updateAsync() {
+    public Observable<DnsRecordSet> updateResourceAsync() {
         return this.parent().manager().inner().recordSets().getAsync(this.parent().resourceGroupName(),
                 this.parent().name(), this.name(), this.recordType())
                 .map(new Func1<RecordSetInner, RecordSetInner>() {
@@ -325,7 +325,7 @@ class DnsRecordSetImpl extends ExternalChildResourceImpl<DnsRecordSet,
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.parent().manager().inner().recordSets().deleteAsync(this.parent().resourceGroupName(),
                 this.parent().name(), this.name(), this.recordType(), this.eTagState.ifMatchValueOnDelete());
     }

--- a/azure-mgmt-dns/src/main/java/com/microsoft/azure/management/dns/implementation/DnsRecordSetsImpl.java
+++ b/azure-mgmt-dns/src/main/java/com/microsoft/azure/management/dns/implementation/DnsRecordSetsImpl.java
@@ -35,109 +35,109 @@ class DnsRecordSetsImpl extends
     }
 
     DnsRecordSetImpl defineARecordSet(String name) {
-        return setDefaults(prepareDefine(ARecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(ARecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl defineAaaaRecordSet(String name) {
-        return setDefaults(prepareDefine(AaaaRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(AaaaRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     void withCNameRecordSet(String name, String alias) {
         CNameRecordSetImpl recordSet = CNameRecordSetImpl.newRecordSet(name, this.parent());
         recordSet.inner().cnameRecord().withCname(alias);
-        setDefaults(prepareDefine(recordSet.withTimeToLive(defaultTtlInSeconds)));
+        setDefaults(prepareInlineDefine(recordSet.withTimeToLive(defaultTtlInSeconds)));
     }
 
     DnsRecordSetImpl defineCNameRecordSet(String name) {
-        return setDefaults(prepareDefine(CNameRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(CNameRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl defineMXRecordSet(String name) {
-        return setDefaults(prepareDefine(MXRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(MXRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl defineNSRecordSet(String name) {
-        return setDefaults(prepareDefine(NSRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(NSRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl definePtrRecordSet(String name) {
-        return setDefaults(prepareDefine(PtrRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(PtrRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl defineSrvRecordSet(String name) {
-        return setDefaults(prepareDefine(SrvRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(SrvRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl defineTxtRecordSet(String name) {
-        return setDefaults(prepareDefine(TxtRecordSetImpl.newRecordSet(name, this.parent())));
+        return setDefaults(prepareInlineDefine(TxtRecordSetImpl.newRecordSet(name, this.parent())));
     }
 
     DnsRecordSetImpl updateARecordSet(String name) {
-        return prepareUpdate(ARecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(ARecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateAaaaRecordSet(String name) {
-        return prepareUpdate(AaaaRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(AaaaRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateMXRecordSet(String name) {
-        return prepareUpdate(MXRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(MXRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateCNameRecordSet(String name) {
-        return prepareUpdate(CNameRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(CNameRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateNSRecordSet(String name) {
-        return prepareUpdate(NSRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(NSRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updatePtrRecordSet(String name) {
-        return prepareUpdate(PtrRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(PtrRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateSrvRecordSet(String name) {
-        return prepareUpdate(SrvRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(SrvRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateTxtRecordSet(String name) {
-        return prepareUpdate(TxtRecordSetImpl.newRecordSet(name, this.parent()));
+        return prepareInlineUpdate(TxtRecordSetImpl.newRecordSet(name, this.parent()));
     }
 
     DnsRecordSetImpl updateSoaRecordSet() {
-        return prepareUpdate(SoaRecordSetImpl.newRecordSet(this.parent()));
+        return prepareInlineUpdate(SoaRecordSetImpl.newRecordSet(this.parent()));
     }
 
     void withoutARecordSet(String name, String eTagValue) {
-        prepareRemove(ARecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(ARecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutAaaaRecordSet(String name, String eTagValue) {
-        prepareRemove(AaaaRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(AaaaRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutCNameRecordSet(String name, String eTagValue) {
-        prepareRemove(CNameRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(CNameRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutMXRecordSet(String name, String eTagValue) {
-        prepareRemove(MXRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(MXRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutNSRecordSet(String name, String eTagValue) {
-        prepareRemove(NSRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(NSRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutPtrRecordSet(String name, String eTagValue) {
-        prepareRemove(PtrRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(PtrRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutSrvRecordSet(String name, String eTagValue) {
-        prepareRemove(SrvRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(SrvRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     void withoutTxtRecordSet(String name, String eTagValue) {
-        prepareRemove(TxtRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
+        prepareInlineRemove(TxtRecordSetImpl.newRecordSet(name, this.parent()).withETagOnDelete(eTagValue));
     }
 
     private DnsRecordSetImpl setDefaults(DnsRecordSetImpl recordSet) {

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourceCollectionImpl.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourceCollectionImpl.java
@@ -152,7 +152,7 @@ public abstract class ExternalChildResourceCollectionImpl<
                 }).flatMap(new Func1<FluentModelTImpl, Observable<FluentModelTImpl>>() {
                     @Override
                     public Observable<FluentModelTImpl> call(final FluentModelTImpl childResource) {
-                        return childResource.deleteAsync()
+                        return childResource.deleteResourceAsync()
                                 .map(new Func1<Void, FluentModelTImpl>() {
                                     @Override
                                     public FluentModelTImpl call(Void response) {
@@ -184,7 +184,7 @@ public abstract class ExternalChildResourceCollectionImpl<
                 }).flatMap(new Func1<FluentModelTImpl, Observable<FluentModelTImpl>>() {
                     @Override
                     public Observable<FluentModelTImpl> call(final FluentModelTImpl childResource) {
-                        return childResource.createAsync()
+                        return childResource.createResourceAsync()
                                 .map(new Func1<FluentModelT, FluentModelTImpl>() {
                                     @Override
                                     public FluentModelTImpl call(FluentModelT fluentModelT) {
@@ -217,7 +217,7 @@ public abstract class ExternalChildResourceCollectionImpl<
                 }).flatMap(new Func1<FluentModelTImpl, Observable<FluentModelTImpl>>() {
                     @Override
                     public Observable<FluentModelTImpl> call(final FluentModelTImpl childResource) {
-                        return childResource.updateAsync()
+                        return childResource.updateResourceAsync()
                                 .map(new Func1<FluentModelT, FluentModelTImpl>() {
                                     @Override
                                     public FluentModelTImpl call(FluentModelT e) {

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourcesCachedImpl.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourcesCachedImpl.java
@@ -61,23 +61,35 @@ public abstract class ExternalChildResourcesCachedImpl<
     }
 
     /**
-     * Prepare for definition of a new external child resource.
+     * Prepare for independent definition of a new external child resource (without the parent context).
+     *
+     * @param name the name of the new external child resource
+     * @return the external child resource prepared for create
+     */
+    protected final FluentModelTImpl prepareIndependentDefine(String name) {
+        FluentModelTImpl childResource = newChildResource(name);
+        childResource.setPendingOperation(ExternalChildResourceImpl.PendingOperation.ToBeCreated);
+        return childResource;
+    }
+
+    /**
+     * Prepare for inline definition of a new external child resource (along with the definition or update of parent resource).
      *
      * @param name the name for the new external child resource
      * @return the child resource
      */
-    protected FluentModelTImpl prepareDefine(String name) {
-        return prepareDefine(name, name);
+    protected FluentModelTImpl prepareInlineDefine(String name) {
+        return prepareInlineDefine(name, name);
     }
 
     /**
-     * Prepare for definition of a new external child resource.
+     * Prepare for inline definition of a new external child resource (along with the definition or update of parent resource).
      *
      * @param name the name of the new external child resource
      * @param key the key
      * @return the child resource
      */
-    protected final FluentModelTImpl prepareDefine(String name, String key) {
+    protected final FluentModelTImpl prepareInlineDefine(String name, String key) {
         if (find(key) != null) {
             throw new IllegalArgumentException("A child resource ('" + childResourceName + "') with name (key) '" + name + " (" + key + ")' already exists");
         }
@@ -87,23 +99,23 @@ public abstract class ExternalChildResourcesCachedImpl<
     }
 
     /**
-     * Prepare for an external child resource update.
+     * Prepare for inline update of an external child resource (along with the update of parent resource).
      *
      * @param name the name of the external child resource
      * @return the external child resource to be updated
      */
-    protected final FluentModelTImpl prepareUpdate(String name) {
-        return prepareUpdate(name, name);
+    protected final FluentModelTImpl prepareInlineUpdate(String name) {
+        return prepareInlineUpdate(name, name);
     }
 
     /**
-     * Prepare for an external child resource update.
+     * Prepare for inline update of an external child resource (along with the update of parent resource).
      *
      * @param name the name of the external child resource
      * @param key the key
      * @return the external child resource to be updated
      */
-    protected final FluentModelTImpl prepareUpdate(String name, String key) {
+    protected final FluentModelTImpl prepareInlineUpdate(String name, String key) {
         FluentModelTImpl childResource = find(key);
         if (childResource == null
                 || childResource.pendingOperation() == ExternalChildResourceImpl.PendingOperation.ToBeCreated) {
@@ -117,21 +129,21 @@ public abstract class ExternalChildResourcesCachedImpl<
     }
 
     /**
-     * Mark an external child resource with given name as to be removed.
+     * Prepare for inline removal of an external child resource (along with the update of parent resource).
      *
      * @param name the name of the external child resource
      */
-    protected final void prepareRemove(String name) {
-        prepareRemove(name, name);
+    protected final void prepareInlineRemove(String name) {
+        prepareInlineRemove(name, name);
     }
 
     /**
-     * Mark an external child resource with given key as to be removed.
+     * Prepare for inline removal of an external child resource (along with the update of parent resource).
      *
      * @param name the name of the external child resource
      * @param key the key
      */
-    protected final void prepareRemove(String name, String key) {
+    protected final void prepareInlineRemove(String name, String key) {
         FluentModelTImpl childResource = find(key);
         if (childResource == null
                 || childResource.pendingOperation() == ExternalChildResourceImpl.PendingOperation.ToBeCreated) {

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourcesNonCachedImpl.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/arm/collection/implementation/ExternalChildResourcesNonCachedImpl.java
@@ -44,12 +44,23 @@ public abstract class ExternalChildResourcesNonCachedImpl<
     }
 
     /**
-     * Prepare a given model of an external child resource for create.
+     * Prepare the given model of an external child resource for independent definition (without the parent context).
+     *
+     * @param model the model to prepare for independent create definition
+     * @return the external child resource prepared for create
+     */
+    protected final FluentModelTImpl prepareIndependentDefine(FluentModelTImpl model) {
+        model.setPendingOperation(ExternalChildResourceImpl.PendingOperation.ToBeCreated);
+        return model;
+    }
+
+    /**
+     * Prepare the given model of an external child resource for inline create (along with the definition or update of parent resource).
      *
      * @param model the model to track create changes
      * @return the external child resource prepared for create
      */
-    protected final FluentModelTImpl prepareDefine(FluentModelTImpl model) {
+    protected final FluentModelTImpl prepareInlineDefine(FluentModelTImpl model) {
         FluentModelTImpl childResource = find(model.childResourceKey());
         if (childResource != null) {
             throw new IllegalArgumentException(pendingOperationMessage(model.name(), model.childResourceKey()));
@@ -60,12 +71,12 @@ public abstract class ExternalChildResourcesNonCachedImpl<
     }
 
     /**
-     * Prepare a given model of an external child resource for update.
+     * Prepare the given model of an external child resource for inline update (along with the definition or update of parent resource).
      *
      * @param model the model to track update changes
      * @return the external child resource prepared for update
      */
-    protected final FluentModelTImpl prepareUpdate(FluentModelTImpl model) {
+    protected final FluentModelTImpl prepareInlineUpdate(FluentModelTImpl model) {
         FluentModelTImpl childResource = find(model.childResourceKey());
         if (childResource != null) {
             throw new IllegalArgumentException(pendingOperationMessage(model.name(), model.childResourceKey()));
@@ -76,11 +87,11 @@ public abstract class ExternalChildResourcesNonCachedImpl<
     }
 
     /**
-     * Prepare a given model of an external child resource for remove.
+     * Prepare the given model of an external child resource for inline removal (along with the definition or update of parent resource).
      *
      * @param model the model representing child resource to remove
      */
-    protected final void prepareRemove(FluentModelTImpl model) {
+    protected final void prepareInlineRemove(FluentModelTImpl model) {
         FluentModelTImpl childResource = find(model.childResourceKey());
         if (childResource != null) {
             throw new IllegalArgumentException(pendingOperationMessage(model.name(), model.childResourceKey()));

--- a/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/ExternalChildResourceTests.java
+++ b/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/ExternalChildResourceTests.java
@@ -7,12 +7,15 @@
 package com.microsoft.azure.management.resources.childresource;
 
 import com.microsoft.azure.management.resources.fluentcore.arm.models.implementation.ExternalChildResourceImpl;
+import com.microsoft.azure.management.resources.fluentcore.model.Creatable;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
 import org.junit.Assert;
 import org.junit.Test;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
 import rx.exceptions.CompositeException;
+import rx.functions.Action1;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -181,5 +184,84 @@ public class ExternalChildResourceTests {
                     }
                 });
         monitor.await();
+    }
+
+    @Test
+    public void canCrossReferenceChildren() throws Exception {
+        SchoolsImpl schools = new SchoolsImpl();
+
+        Observable<Indexable> items = schools.define("redmondSchool")
+                .withAddress("sc-address")
+                .defineTeacher("maria")
+                    .withSubject("Maths")
+                    .attach()
+                .defineStudent("bob")
+                    .withAge(10)
+                    .withTeacher("maria")   // Refer another creatable external child resource with key 'maria' in the parent
+                    .attach()
+                .createAsync();
+
+        final SchoolsImpl.SchoolImpl foundSchool[] = new SchoolsImpl.SchoolImpl[1];
+        final SchoolsImpl.TeacherImpl foundTeacher[] = new SchoolsImpl.TeacherImpl[1];
+        final SchoolsImpl.StudentImpl foundStudent[] = new SchoolsImpl.StudentImpl[1];
+
+        items.doOnNext(new Action1<Indexable>() {
+            @Override
+            public void call(Indexable indexable) {
+                if (indexable instanceof SchoolsImpl.SchoolImpl) {
+                    foundSchool[0] = (SchoolsImpl.SchoolImpl) indexable;
+                }
+                if (indexable instanceof SchoolsImpl.TeacherImpl) {
+                    foundTeacher[0] = (SchoolsImpl.TeacherImpl) indexable;
+                }
+                if (indexable instanceof SchoolsImpl.StudentImpl) {
+                    foundStudent[0] = (SchoolsImpl.StudentImpl) indexable;
+                }
+            }
+        }).toBlocking().last();
+
+        Assert.assertNotNull(foundSchool[0]);
+        Assert.assertNotNull(foundTeacher[0]);
+        Assert.assertNotNull(foundStudent[0]);
+
+        Assert.assertTrue(foundSchool[0].isInvoked());
+        Assert.assertTrue(foundTeacher[0].isInvoked());
+        Assert.assertTrue(foundStudent[0].isInvoked());
+    }
+
+    @Test
+    public void canCreateChildrenIndependently() throws Exception {
+        SchoolsImpl schools = new SchoolsImpl();
+
+        Creatable<SchoolsImpl.TeacherImpl>  creatableTeacher = schools.independentTeachers()
+                .define("john")
+                .withSubject("physics");
+
+        Creatable<SchoolsImpl.StudentImpl>  creatableStudent = schools.independentStudents()
+                .define("nit")
+                .withAge(15)
+                .withTeacher(creatableTeacher);
+
+        final SchoolsImpl.TeacherImpl foundTeacher[] = new SchoolsImpl.TeacherImpl[1];
+        final SchoolsImpl.StudentImpl foundStudent[] = new SchoolsImpl.StudentImpl[1];
+
+        creatableStudent.createAsync()
+                .doOnNext(new Action1<Indexable>() {
+                    @Override
+                    public void call(Indexable indexable) {
+                        if (indexable instanceof SchoolsImpl.TeacherImpl) {
+                            foundTeacher[0] = (SchoolsImpl.TeacherImpl) indexable;
+                        }
+                        if (indexable instanceof SchoolsImpl.StudentImpl) {
+                            foundStudent[0] = (SchoolsImpl.StudentImpl) indexable;
+                        }
+                    }
+                }).toBlocking().last();
+
+        Assert.assertNotNull(foundTeacher[0]);
+        Assert.assertNotNull(foundStudent[0]);
+
+        Assert.assertTrue(foundTeacher[0].isInvoked());
+        Assert.assertTrue(foundStudent[0].isInvoked());
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/PulletImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/PulletImpl.java
@@ -34,7 +34,7 @@ class PulletImpl extends ExternalChildResourceImpl<Pullet, Object, ChickenImpl, 
     }
 
     @Override
-    public Observable<Pullet> createAsync() {
+    public Observable<Pullet> createResourceAsync() {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException ex) {
@@ -51,7 +51,7 @@ class PulletImpl extends ExternalChildResourceImpl<Pullet, Object, ChickenImpl, 
     }
 
     @Override
-    public Observable<Pullet> updateAsync() {
+    public Observable<Pullet> updateResourceAsync() {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException ex) {
@@ -68,7 +68,7 @@ class PulletImpl extends ExternalChildResourceImpl<Pullet, Object, ChickenImpl, 
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException ex) {

--- a/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/PulletsImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/PulletsImpl.java
@@ -17,15 +17,15 @@ class PulletsImpl extends ExternalChildResourcesCachedImpl<PulletImpl, Pullet, O
     }
 
     public PulletImpl define(String name) {
-        return super.prepareDefine(name);
+        return super.prepareInlineDefine(name);
     }
 
     public PulletImpl update(String name) {
-        return super.prepareUpdate(name);
+        return super.prepareInlineUpdate(name);
     }
 
     public void remove(String name) {
-        super.prepareRemove(name);
+        super.prepareInlineRemove(name);
     }
 
     public void addPullet(PulletImpl pullet) {

--- a/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/SchoolsImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/childresource/SchoolsImpl.java
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.management.resources.childresource;
+
+import com.microsoft.azure.management.resources.fluentcore.arm.collection.implementation.ExternalChildResourcesCachedImpl;
+import com.microsoft.azure.management.resources.fluentcore.arm.models.implementation.ExternalChildResourceImpl;
+import com.microsoft.azure.management.resources.fluentcore.dag.TaskGroup;
+import com.microsoft.azure.management.resources.fluentcore.dag.TaskItem;
+import com.microsoft.azure.management.resources.fluentcore.model.Creatable;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
+import rx.Completable;
+import rx.Observable;
+import rx.functions.Func1;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Type representing top level school collection using which
+ *    1. new schools can be created with associated teachers and students
+ *    2. new teachers and students can be created independently.
+ */
+class SchoolsImpl {
+    private IndependentTeachersImpl independentTeachers;
+    private IndependentStudentsImpl independentStudents;
+
+    public SchoolsImpl() {
+        this.independentTeachers = new IndependentTeachersImpl();
+        this.independentStudents = new IndependentStudentsImpl();
+    }
+
+    public SchoolImpl define(String name) {
+        return new SchoolImpl(name);
+    }
+
+    // Accessor to teachers collection from schools that can be created independently
+    //
+    public IndependentTeachersImpl independentTeachers() {
+        return this.independentTeachers;
+    }
+
+    // Accessor to students collection from schools that can be created independently
+    //
+    public IndependentStudentsImpl independentStudents() {
+        return this.independentStudents;
+    }
+
+    /**
+     * Type representing an instance of School.
+     */
+    class SchoolImpl implements TaskItem, Indexable {
+        private final TaskGroup taskGroup;
+        private final String name;
+        private final String key;
+        private boolean isInvoked;
+        public InlineTeachersImpl inlineTeachers;
+        public IndependentTeachersImpl independentTeachers;
+        public InlineStudentsImpl inlineStudents;
+        public IndependentStudentsImpl independentStudents;
+
+        public SchoolImpl(String name) {
+            this.name = name;
+            this.key = name;
+            this.taskGroup = new TaskGroup(this.key, this);
+            this.inlineTeachers = new InlineTeachersImpl(this, this.taskGroup, "InlineTeacher");
+            this.independentTeachers = new IndependentTeachersImpl();
+
+            this.inlineStudents = new InlineStudentsImpl(this, this.taskGroup, "InlineStudent");
+            this.independentStudents = new IndependentStudentsImpl();
+        }
+
+        public boolean isInvoked() {
+            return this.isInvoked;
+        }
+
+        @Override
+        public String key() {
+            return this.key;
+        }
+
+        public SchoolImpl withAddress(String address) {
+            return this;
+        }
+
+        // Define an inline teacher that can be associated to school by invoking attach()
+        //
+        public TeacherImpl defineTeacher(String name) {
+            return this.inlineTeachers.define(name);
+        }
+
+        // Teachers in the school that can be created and updated independently
+        //
+        public IndependentTeachersImpl independentTeachers() {
+            return this.independentTeachers;
+        }
+
+        // Define an inline student that can be associated to school by invoking attach()
+        //
+        public StudentImpl defineStudent(String name) {
+            return this.inlineStudents.define(name);
+        }
+
+        // Students in the school that can be created and updated independently
+        //
+        public IndependentStudentsImpl independentStudents() {
+            return this.independentStudents;
+        }
+
+        public Observable<Indexable> createAsync() {
+            return taskGroup.invokeAsync(this.taskGroup.newInvocationContext());
+        }
+
+        @Override
+        public Indexable result() {
+            return this;
+        }
+
+        @Override
+        public void beforeGroupInvoke() {
+            // NOP
+        }
+
+        @Override
+        public boolean isHot() {
+            return true;
+        }
+
+        @Override
+        public Observable<Indexable> invokeAsync(TaskGroup.InvocationContext context) {
+            return Observable.<Indexable>just(this)
+                    .map(new Func1<Indexable, Indexable>() {
+                        @Override
+                        public Indexable call(Indexable indexable) {
+                            isInvoked = true;
+                            return indexable;
+                        }
+                    });
+        }
+
+        @Override
+        public Completable invokeAfterPostRunAsync(boolean isGroupFaulted) {
+            return Completable.complete();
+        }
+
+        public SchoolImpl withTeacher(TeacherImpl teacher) {
+            this.inlineTeachers.withTeacher(teacher);
+            return this;
+        }
+
+        public SchoolImpl withStudent(StudentImpl student) {
+            this.inlineStudents.withStudent(student);
+            return this;
+        }
+    }
+
+    /**
+     * Type representing an instance of Teacher.
+     */
+    class TeacherImpl
+            extends ExternalChildResourceImpl<TeacherImpl, Object, SchoolImpl, Object>
+            implements TaskGroup.HasTaskGroup, Creatable<TeacherImpl> {
+
+        private boolean isInvoked;
+
+        protected TeacherImpl(String name, SchoolImpl parent, Object inner) {
+            super(name, name, parent, inner);
+        }
+
+        TeacherImpl withSubject(String subjectName) {
+           return this;
+        }
+
+        @Override
+        public String id() {
+            return name();
+        }
+
+        public boolean isInvoked() {
+            return this.isInvoked;
+        }
+
+        @Override
+        public Observable<TeacherImpl> createResourceAsync() {
+            return Observable.just(this)
+                    .map(new Func1<TeacherImpl, TeacherImpl>() {
+                        @Override
+                        public TeacherImpl call(TeacherImpl teacher) {
+                            isInvoked = true;
+                            return teacher;
+                        }
+                    });
+        }
+
+        @Override
+        public Observable<TeacherImpl> updateResourceAsync() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Observable<Void> deleteResourceAsync() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        protected Observable<Object> getInnerAsync() {
+            throw new NotImplementedException();
+        }
+
+        public SchoolImpl attach() {
+            return this.parent().withTeacher(this);
+        }
+    }
+
+    /**
+     * Type representing Teacher collection where a teacher entries can be created as part of parent School.
+     */
+    class InlineTeachersImpl extends ExternalChildResourcesCachedImpl<TeacherImpl, TeacherImpl, Object, SchoolImpl, Object> {
+
+        protected InlineTeachersImpl(SchoolImpl parent, TaskGroup parentTaskGroup, String childResourceName) {
+            super(parent, parentTaskGroup, childResourceName);
+        }
+
+        public TeacherImpl define(String name) {
+            return super.prepareInlineDefine(name);
+        }
+
+        TeacherImpl findTeacher(String teacherName) {
+            return this.find(teacherName);
+        }
+
+        @Override
+        protected List<TeacherImpl> listChildResources() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        protected TeacherImpl newChildResource(String name) {
+            return new TeacherImpl(name, this.parent(), null);
+        }
+
+        public void withTeacher(TeacherImpl teacher) {
+            this.addChildResource(teacher);
+        }
+    }
+
+    /**
+     * Type representing Teacher collection where a teacher entries can be created independently.
+     */
+    class IndependentTeachersImpl {
+        public TeacherImpl define(String name) {
+            TeacherImpl newTeacher = new TeacherImpl(name, null, null);
+            newTeacher.setPendingOperation(ExternalChildResourceImpl.PendingOperation.ToBeCreated);
+            return newTeacher;
+        }
+    }
+
+    /**
+     * Type representing an instance of Student.
+     */
+    class StudentImpl
+            extends ExternalChildResourceImpl<StudentImpl, Object, SchoolImpl, Object>
+            implements TaskGroup.HasTaskGroup, Creatable<StudentImpl> {
+        private String teacherName;
+        private boolean isInvoked;
+
+        protected StudentImpl(String name, SchoolImpl parent, Object inner) {
+            super(name, name, parent, inner);
+        }
+
+        StudentImpl withAge(int age) {
+            return this;
+        }
+
+        StudentImpl withTeacher(String teacherRefName) {
+            this.teacherName = teacherRefName;
+            TaskGroup.HasTaskGroup teacher = this.parent().inlineTeachers.findTeacher(teacherRefName);
+            if (teacher == null) {
+                throw new IllegalStateException("Expected teacher not found in the inline collection");
+            }
+            this.addDependency(teacher);
+            return this;
+        }
+
+        StudentImpl withTeacher(Creatable<TeacherImpl> newTeacher) {
+            this.teacherName = newTeacher.name();
+            this.addDependency(newTeacher);
+            return this;
+        }
+
+        @Override
+        public String id() {
+            return name();
+        }
+        public boolean isInvoked() {
+            return this.isInvoked;
+        }
+
+        @Override
+        public Observable<StudentImpl> createResourceAsync() {
+            Indexable teacher = this.taskGroup().taskResult(teacherName);
+            if (teacher == null) {
+                throw new IllegalStateException("Expected dependency teacher not found");
+            }
+            TeacherImpl teacherImpl = (TeacherImpl) teacher;
+            if (teacherImpl == null) {
+                throw new IllegalStateException("Casting Indexable to teacherImpl failed");
+            }
+            if (teacherImpl.isInvoked() == false) {
+                throw new IllegalStateException("teacherImpl.isInvoked() should be true");
+            }
+
+            return Observable.just(this).map(new Func1<StudentImpl, StudentImpl>() {
+                @Override
+                public StudentImpl call(StudentImpl student) {
+                    isInvoked = true;
+                    return student;
+                }
+            });
+        }
+
+        @Override
+        public Observable<StudentImpl> updateResourceAsync() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Observable<Void> deleteResourceAsync() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        protected Observable<Object> getInnerAsync() {
+            throw new NotImplementedException();
+        }
+
+        public SchoolImpl attach() {
+            return this.parent().withStudent(this);
+        }
+    }
+
+    /**
+     * Type representing Student collection where a student entries can be created as part of parent School.
+     */
+    class InlineStudentsImpl extends ExternalChildResourcesCachedImpl<StudentImpl, StudentImpl, Object, SchoolImpl, Object> {
+
+        protected InlineStudentsImpl(SchoolImpl parent, TaskGroup parentTaskGroup, String childResourceName) {
+            super(parent, parentTaskGroup, childResourceName);
+        }
+
+        public StudentImpl define(String name) {
+            return super.prepareInlineDefine(name);
+        }
+
+        StudentImpl findStudent(String studentName) {
+            return this.find(studentName);
+        }
+
+        @Override
+        protected List<StudentImpl> listChildResources() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        protected StudentImpl newChildResource(String name) {
+            return new StudentImpl(name, this.parent(), null);
+        }
+
+        public void withStudent(StudentImpl student) {
+            this.addChildResource(student);
+        }
+    }
+
+    /**
+     * Type representing Student collection where a student entries can be created independently.
+     */
+    class IndependentStudentsImpl {
+        public StudentImpl define(String name) {
+            StudentImpl newStudent = new StudentImpl(name, null, null);
+            newStudent.setPendingOperation(ExternalChildResourceImpl.PendingOperation.ToBeCreated);
+            return newStudent;
+        }
+    }
+}

--- a/azure-mgmt-trafficmanager/src/main/java/com/microsoft/azure/management/trafficmanager/implementation/TrafficManagerEndpointImpl.java
+++ b/azure-mgmt-trafficmanager/src/main/java/com/microsoft/azure/management/trafficmanager/implementation/TrafficManagerEndpointImpl.java
@@ -206,7 +206,7 @@ class TrafficManagerEndpointImpl extends ExternalChildResourceImpl<TrafficManage
     }
 
     @Override
-    public Observable<TrafficManagerEndpoint> createAsync() {
+    public Observable<TrafficManagerEndpoint> createResourceAsync() {
         final TrafficManagerEndpointImpl self = this;
         return this.client.createOrUpdateAsync(this.parent().resourceGroupName(),
                 this.parent().name(),
@@ -223,12 +223,12 @@ class TrafficManagerEndpointImpl extends ExternalChildResourceImpl<TrafficManage
     }
 
     @Override
-    public Observable<TrafficManagerEndpoint> updateAsync() {
-        return createAsync();
+    public Observable<TrafficManagerEndpoint> updateResourceAsync() {
+        return createResourceAsync();
     }
 
     @Override
-    public Observable<Void> deleteAsync() {
+    public Observable<Void> deleteResourceAsync() {
         return this.client.deleteAsync(this.parent().resourceGroupName(),
                 this.parent().name(),
                 this.endpointType().localName(),

--- a/azure-mgmt-trafficmanager/src/main/java/com/microsoft/azure/management/trafficmanager/implementation/TrafficManagerEndpointsImpl.java
+++ b/azure-mgmt-trafficmanager/src/main/java/com/microsoft/azure/management/trafficmanager/implementation/TrafficManagerEndpointsImpl.java
@@ -105,7 +105,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl defineAzureTargetEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareDefine(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineDefine(name);
         endpoint.inner().withType(EndpointType.AZURE.toString());
         return endpoint;
     }
@@ -117,7 +117,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl defineExteralTargetEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareDefine(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineDefine(name);
         endpoint.inner().withType(EndpointType.EXTERNAL.toString());
         return endpoint;
     }
@@ -129,7 +129,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl defineNestedProfileTargetEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareDefine(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineDefine(name);
         endpoint.inner().withType(EndpointType.NESTED_PROFILE.toString());
         return endpoint;
     }
@@ -141,7 +141,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl updateAzureEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareUpdate(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineUpdate(name);
         if (endpoint.endpointType() != EndpointType.AZURE) {
             throw new IllegalArgumentException("An azure endpoint with name " + name + " not found in the profile");
         }
@@ -155,7 +155,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl updateExternalEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareUpdate(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineUpdate(name);
         if (endpoint.endpointType() != EndpointType.EXTERNAL) {
             throw new IllegalArgumentException("An external endpoint with name " + name + " not found in the profile");
         }
@@ -169,7 +169,7 @@ class TrafficManagerEndpointsImpl extends
      * @return the endpoint
      */
     public TrafficManagerEndpointImpl updateNestedProfileEndpoint(String name) {
-        TrafficManagerEndpointImpl endpoint = this.prepareUpdate(name);
+        TrafficManagerEndpointImpl endpoint = this.prepareInlineUpdate(name);
         if (endpoint.endpointType() != EndpointType.NESTED_PROFILE) {
             throw new IllegalArgumentException("A nested profile endpoint with name " + name + " not found in the profile");
         }
@@ -181,7 +181,7 @@ class TrafficManagerEndpointsImpl extends
      * @param name the name of the endpoint to be removed
      */
     public void remove(String name) {
-        this.prepareRemove(name);
+        this.prepareInlineRemove(name);
     }
 
     /**


### PR DESCRIPTION
@milismsft this PR should address the new design requirement you wanted to support in SQL.


PR enables following two new ** NEW SUPPORT**:

[1]. Enable external child resources to add dependencies just like any other top-level resources.
[2]. Enable external child resources to be defined independently in addition to currently supported inline definition. 

-- Example --

Let’s say we have a top level resource `School` and it’s collection `Schools`. A `School` instance has two external child resources `Teachers` (with `Teacher` as collection item type) and `Students` (with `Student` as collection item type).

**[CURRENT SUPPORT]** The current external child resource design allows inline definition of external child resource along with parent definition/update:

```java
schools()
	.define(“school_name”)
	.withAddress(“school_address”)
	.defineTeacher(“teacher_name”)
		.withSubject(“subject”)
		.withExperienceInYears(“years”) 
		.attach()
	.defineStudent(“student_name”)
		.withAge(“age”)
		.attach()
	.create();
```

**[NEW SUPPORT]** Now it is often required that we want a `teacher` to be associated with a `student`, with this PR we can enable that association like below:

```java
schools()
	.define(“school_name”)
	.withAddress(“school_address”)
	.defineTeacher(“teacher_name”)
		.withSubject(“subject”)
		.withExperienceInYears(“years”) 
		.attach()
	.defineStudent(“student_name”)
		.withAge(“age”)
		.withTeacher(“teacher_name”)	// Cross-referencing child resource 
		.attach()
	.create();
```
This is achieved by enabl-ing external child resources to add dependencies.

**[NEW SUPPORT]** Sometimes it make sense to be able to define, update an external child resource independently (without starting with parent definition or update), with this PR we can support following pattern.

```java
Creatable<Teacher> creatableTeacher = schools().teachers()
	.define(“teacher_name”)
		.withSubject(“subject”)
		.withExperienceInYears(“years”)
                .withExistingSchool("school_name");

Student student = schools().students()
	.define(“student_name”)
	.withAge(“age”)
	.withNewTeacher(creatableTeacher)  // Creatable reference like top-level resource
        .withExistingSchool("school_name")
	.create();
```