### PR TITLE
Adding missing StandardSSD_LRS enum-value to StorageAccountTypes

### DIFF
--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/StorageAccountTypes.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/StorageAccountTypes.java
@@ -19,7 +19,10 @@ public enum StorageAccountTypes {
     STANDARD_LRS("Standard_LRS"),
 
     /** Enum value Premium_LRS. */
-    PREMIUM_LRS("Premium_LRS");
+    PREMIUM_LRS("Premium_LRS"),
+
+    /** Enum value StandardSSD_LRS. */
+    STANDARD_SSD_LRS("StandardSSD_LRS");
 
     /** The actual serialized value for a StorageAccountTypes instance. */
     private String value;


### PR DESCRIPTION
Adding `StandardSSD_LRS` enum value to `StorageAccountTypes` in this [commit](https://github.com/Azure/azure-libraries-for-java/pull/145/commits/98a74a80371fd3ea65614c410865ea3132dbde7e). Opened an [issue](https://github.com/Azure/azure-rest-api-specs/issues/2343)  in rest api spec. For now this need to be manually patched otherwise deserialization of the values *will fail* and clients will start seeing exceptions. 