### PR TITLE
Adding StorageAccountTypes::Standard_ZRS

### DIFF
--- a/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/StorageAccountTypes.java
+++ b/azure-mgmt-compute/src/main/java/com/microsoft/azure/management/compute/StorageAccountTypes.java
@@ -22,7 +22,10 @@ public enum StorageAccountTypes {
     PREMIUM_LRS("Premium_LRS"),
 
     /** Enum value StandardSSD_LRS. */
-    STANDARD_SSD_LRS("StandardSSD_LRS");
+    STANDARD_SSD_LRS("StandardSSD_LRS"),
+
+    /** Enum value Standard_ZRS. */
+    STANDARD_ZRS("Standard_ZRS");
 
     /** The actual serialized value for a StorageAccountTypes instance. */
     private String value;


### PR DESCRIPTION
Related to the issue described in this [PR](https://github.com/Azure/azure-libraries-for-java/pull/145)

While testing with different subscriptions, found that there is one more enum value `Standard_ZRS`, this PR add that value as well. Update the [issue](https://github.com/Azure/azure-rest-api-specs/issues/2343) in the api spec.