### PR TITLE
Use gulpfile-specified output folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,7 +121,7 @@ var codegen = function(project, cb) {
                         ' --azure-arm ' +
                         generator +
                         ` --namespace=${mappings[project].package} ` +
-                        ` --output-folder=${outDir} ` +
+                        ` --java.output-folder=${outDir} ` +
                         ` --license-header=MICROSOFT_MIT_NO_CODEGEN ` +
                         generatorPath +
                         regenManager +


### PR DESCRIPTION
Fixes a breaking config change that was introduced in azure-rest-api-specs.

It seems to me that while AutoRest config which affects the meaning of the generated code, like `input-file` and `title` may belong in azure-rest-api-specs, but stuff like `output-folder` and `clear-output-folder` is project-specific and shouldn't necessarily come from azure-rest-api-specs.

I'm not invested in this working any particular way so feel free to make any changes to the gulpfile in here @daschult as long as the code generation works :)