### PR TITLE
Use master azure-rest-api-specs branch since current branch no longer exists

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var os = require('os');
 var fs = require('fs');
 
 const mappings = require('./api-specs.json');
-const defaultSpecRoot = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/current";
+const defaultSpecRoot = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master";
 
 gulp.task('default', function() {
     console.log("Usage: gulp codegen " +


### PR DESCRIPTION
"current" branch was recently deleted from azure-rest-api-specs and "master" instead contains the up to date API specs. This changes the URL in gulpfile.js to look up AutoRest config files under the master branch.