### PR TITLE
Fix use of ampersand characters in JavaDoc by replacing with &amp;

### DIFF
--- a/azure-samples/src/main/java/com/microsoft/azure/management/batchai/samples/ManageBatchAI.java
+++ b/azure-samples/src/main/java/com/microsoft/azure/management/batchai/samples/ManageBatchAI.java
@@ -32,7 +32,7 @@ import java.io.File;
  *  - Wait for job to complete
  *  - Get output files
  *
- * Please note: in order to run this sample, please download and unzip sample package from here: https://batchaisamples.blob.core.windows.net/samples/BatchAIQuickStart.zip?st=2017-09-29T18%3A29%3A00Z&se=2099-12-31T08%3A00%3A00Z&sp=rl&sv=2016-05-31&sr=b&sig=hrAZfbZC%2BQ%2FKccFQZ7OC4b%2FXSzCF5Myi4Cj%2BW3sVZDo%3D
+ * Please note: in order to run this sample, please download and unzip sample package from here: https://batchaisamples.blob.core.windows.net/samples/BatchAIQuickStart.zip?st=2017-09-29T18%3A29%3A00Z&amp;se=2099-12-31T08%3A00%3A00Z&amp;sp=rl&amp;sv=2016-05-31&amp;sr=b&amp;sig=hrAZfbZC%2BQ%2FKccFQZ7OC4b%2FXSzCF5Myi4Cj%2BW3sVZDo%3D
  * Export path to the content to $SAMPLE_DATA_PATH.
  */
 public final class ManageBatchAI {


### PR DESCRIPTION
Fixes issue as discussed in https://github.com/Azure/azure-libraries-for-java/issues/171#issuecomment-367133811