### PR TITLE
Add spotbugs plugin, include only and exclude filter list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,23 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>3.1.1</version>
+          <configuration>
+            <includeFilterFile>${project.parent.basedir}/spotbugs-includeFilter.xml</includeFilterFile>
+            <excludeFilterFile>${project.parent.basedir}/spotbugs-excludeFilter.xml</excludeFilterFile>
+          </configuration>
+          <dependencies>
+            <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs</artifactId>
+              <version>3.1.1</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>2.4.3</version>

--- a/spotbugs-excludeFilter.xml
+++ b/spotbugs-excludeFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+  <Match>
+    <Bug pattern="UWF_UNWRITTEN_FIELD"/>
+  </Match>
+</FindBugsFilter>

--- a/spotbugs-includeFilter.xml
+++ b/spotbugs-includeFilter.xml
@@ -1,0 +1,8 @@
+<FindBugsFilter>
+  <Match>
+    <Bug category="CORRECTNESS"/>
+  </Match>
+  <Match>
+    <Bug category="MALICIOUS_CODE"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
Commands to use:
 - mvn spotbugs:spotbugs - generates an XML report under the target of the child project
 - mvn spotbugs:check - fails the build if bugs are found
 - mvn spotbugs:gui - opens an UI app to check the bugs found
Currently only detect and fail if CORRECTNESS issues were found.