### PR TITLE
Pass publishing profile options when get publishing profile in deployment slot

### DIFF
--- a/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/DeploymentSlotBaseImpl.java
+++ b/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/DeploymentSlotBaseImpl.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.Page;
 import com.microsoft.azure.management.apigeneration.LangDefinition;
 import com.microsoft.azure.management.appservice.AppSetting;
 import com.microsoft.azure.management.appservice.ConnectionString;
+import com.microsoft.azure.management.appservice.CsmPublishingProfileOptions;
 import com.microsoft.azure.management.appservice.CsmSlotEntity;
 import com.microsoft.azure.management.appservice.HostNameBinding;
 import com.microsoft.azure.management.appservice.MSDeploy;
@@ -102,7 +103,7 @@ abstract class DeploymentSlotBaseImpl<
     }
 
     public Observable<PublishingProfile> getPublishingProfileAsync() {
-        return manager().inner().webApps().listPublishingProfileXmlWithSecretsSlotAsync(resourceGroupName(), this.parent().name(), name(), null)
+        return manager().inner().webApps().listPublishingProfileXmlWithSecretsSlotAsync(resourceGroupName(), this.parent().name(), name(), new CsmPublishingProfileOptions())
                 .map(new Func1<InputStream, PublishingProfile>() {
                     @Override
                     public PublishingProfile call(InputStream stream) {


### PR DESCRIPTION
Pass publishing profile options when get publishing profile in deployment slot, for issue #955 

Refers [AppServiceBaseImpl](https://github.com/Azure/azure-libraries-for-java/blob/master/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/AppServiceBaseImpl.java#L190)
