### PR TITLE
fix NoSuchElementException in WebApp and FunctionApp

### DIFF
--- a/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/FunctionAppsImpl.java
+++ b/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/FunctionAppsImpl.java
@@ -74,7 +74,7 @@ class FunctionAppsImpl
             @Override
             public Observable<FunctionApp> call(final SiteInner siteInner) {
                 if (siteInner == null) {
-                    return null;
+                    return Observable.just(null);
                 }
                 return Observable.zip(
                         self.inner().getConfigurationAsync(groupName, name),

--- a/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/WebAppsImpl.java
+++ b/azure-mgmt-appservice/src/main/java/com/microsoft/azure/management/appservice/implementation/WebAppsImpl.java
@@ -63,7 +63,7 @@ class WebAppsImpl
             @Override
             public Observable<WebApp> call(final SiteInner siteInner) {
                 if (siteInner == null) {
-                    return null;
+                    return Observable.just(null);
                 }
                 return Observable.zip(
                         self.inner().getConfigurationAsync(groupName, name),


### PR DESCRIPTION
Fix https://github.com/Azure/azure-libraries-for-java/issues/953

`Observable.just(null)` probably is not a good idea. But anyway `null` is what returned from `Inner.getByResourceGroupAsync()`.