### PR TITLE
add delegate in base to handle get404 as null

### DIFF
--- a/azure-mgmt-resources/src/main/java/com/azure/management/AzureServiceClient.java
+++ b/azure-mgmt-resources/src/main/java/com/azure/management/AzureServiceClient.java
@@ -3,6 +3,7 @@
 
 package com.azure.management;
 
+import com.azure.core.exception.HttpResponseException;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.management.AzureEnvironment;
@@ -25,7 +26,6 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.azure.core.util.FluxUtil.withContext;
@@ -97,6 +97,14 @@ public abstract class AzureServiceClient {
         MAC_ADDRESS_HASH = macAddress;
         String version = System.getProperty("java.version");
         JAVA_VERSION = version != null ? version : "Unknown";
+    }
+
+    public <T> Mono<T> delegateForGetAsync(Mono<T> responseMono) {
+        return responseMono
+                .onErrorResume(
+                        t -> t instanceof HttpResponseException && ((HttpResponseException) t).getResponse().getStatusCode() == 404,
+                        t -> Mono.empty()
+                );
     }
 
     private SerializerAdapter serializerAdapter = new AzureJacksonAdapter();

--- a/azure-mgmt-resources/src/main/java/com/azure/management/resources/models/ResourceGroupsInner.java
+++ b/azure-mgmt-resources/src/main/java/com/azure/management/resources/models/ResourceGroupsInner.java
@@ -11,7 +11,6 @@ import com.azure.core.annotation.Delete;
 import com.azure.core.annotation.ExpectedResponses;
 import com.azure.core.annotation.Get;
 import com.azure.core.annotation.Head;
-import com.azure.core.annotation.HeaderParam;
 import com.azure.core.annotation.Host;
 import com.azure.core.annotation.HostParam;
 import com.azure.core.annotation.Patch;
@@ -277,14 +276,15 @@ public final class ResourceGroupsInner {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<ResourceGroupInner> getAsync(String resourceGroupName) {
-        return getWithResponseAsync(resourceGroupName)
+        return client.delegateForGetAsync(getWithResponseAsync(resourceGroupName)
             .flatMap((SimpleResponse<ResourceGroupInner> res) -> {
                 if (res.getValue() != null) {
                     return Mono.just(res.getValue());
                 } else {
                     return Mono.empty();
                 }
-            });
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
In v1, GET method with 404 response is treated as null

Whether we need to do this in v2? Currently, 404 is exception.