### PR TITLE
fix: authorization-auxiliary use "," to separate instead of ";"

### DIFF
--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/AuxiliaryCredentialsInterceptor.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/AuxiliaryCredentialsInterceptor.java
@@ -52,7 +52,7 @@ public final class AuxiliaryCredentialsInterceptor implements Interceptor {
                     buff.append(" ");
                     buff.append(tokenCredentials[i].getToken(chain.request().url().scheme() + "://" + chain.request().url().host()));
                     if (i < tokenCredentials.length - 1) {
-                        buff.append(";");
+                        buff.append(",");
                     }
                 }
                 Request request = chain.request().newBuilder()


### PR DESCRIPTION
by https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant