### PR TITLE
vnext update gulp

### DIFF
--- a/api-specs.json
+++ b/api-specs.json
@@ -21,7 +21,7 @@
     "dir": "azure-mgmt-keyvault",
     "source": "specification/keyvault/resource-manager/readme.md",
     "package": "com.azure.management.keyvault",
-    "args": "--payload-flattening-threshold=1 --tag=package-2018-02 --track2-naming=true"
+    "args": "--payload-flattening-threshold=1 --tag=package-2018-02"
   },
   "authorization": {
     "dir": "azure-mgmt-graph-rbac",
@@ -76,7 +76,7 @@
     "dir": "azure-mgmt-compute",
     "source": "specification/compute/resource-manager/readme.md",
     "package": "com.microsoft.azure.management.compute",
-    "args": "--payload-flattening-threshold=1 --tag=package-2019-03-01"
+    "args": "--track1-naming=true --payload-flattening-threshold=1 --tag=package-2019-03-01"
   },
   "consumption": {
     "dir": "azure-mgmt-consumption",
@@ -163,7 +163,7 @@
   "features": {
     "dir": "azure-mgmt-resources",
     "source": "specification/resources/resource-manager/readme.md",
-    "package": "com.azure.management.resources --tag=package-features-2015-12 --track2-naming=true"
+    "package": "com.azure.management.resources --tag=package-features-2015-12"
   },
   "graphrbac": {
     "dir": "azure-mgmt-graph-rbac",
@@ -212,7 +212,7 @@
     "dir": "azure-mgmt-network",
     "source": "specification/network/resource-manager/readme.md",
     "package": "com.azure.management.network",
-    "args": "--title=NetworkManagementClient --payload-flattening-threshold=1 --tag=package-2019-06 --add-inner=ApplicationGatewayIPConfiguration,ApplicationGatewayPathRule,ApplicationGatewayProbe,ApplicationGatewayRedirectConfiguration,ApplicationGatewayRequestRoutingRule,ApplicationGatewaySslCertificate,ApplicationGatewayUrlPathMap,ApplicationGatewayAuthenticationCertificate,VirtualNetworkGatewayIPConfiguration,ConnectionMonitor,PacketCapture"
+    "args": "--track1-naming=true --payload-flattening-threshold=1 --tag=package-2019-06 --add-inner=ApplicationGatewayIPConfiguration,ApplicationGatewayPathRule,ApplicationGatewayProbe,ApplicationGatewayRedirectConfiguration,ApplicationGatewayRequestRoutingRule,ApplicationGatewaySslCertificate,ApplicationGatewayUrlPathMap,ApplicationGatewayAuthenticationCertificate,VirtualNetworkGatewayIPConfiguration,ConnectionMonitor,PacketCapture"
   },
   "notificationhubs": {
     "dir": "azure-mgmt-notificationhubs",
@@ -265,7 +265,7 @@
     "dir": "azure-mgmt-resources",
     "source": "specification/resources/resource-manager/readme.md",
     "package": "com.azure.management.resources --tag=package-resources-2019-08",
-    "args": "--payload-flattening-threshold=0 --add-inner=Deployment --track2-naming=true"
+    "args": "--payload-flattening-threshold=0 --add-inner=Deployment"
   },
   "scheduler": {
     "dir": "azure-mgmt-scheduler",
@@ -307,7 +307,7 @@
     "dir": "azure-mgmt-storage",
     "source": "specification/storage/resource-manager/readme.md",
     "package": "com.azure.management.storage",
-    "args": "--payload-flattening-threshold=2 --tag=package-2019-06 --track2-naming=true"
+    "args": "--payload-flattening-threshold=2 --tag=package-2019-06"
   },
   "storsimple8000series": {
     "dir": "azure-mgmt-storsimple8000series",
@@ -325,7 +325,7 @@
     "dir": "azure-mgmt-resources",
     "source": "specification/resources/resource-manager/readme.md",
     "package": "com.azure.management.resources --tag=package-subscriptions-2016-06",
-    "args": "--track2-naming=true"
+    "args": ""
   },
   "trafficmanager": {
     "dir": "azure-mgmt-trafficmanager",

--- a/api-specs.json
+++ b/api-specs.json
@@ -76,7 +76,7 @@
     "dir": "azure-mgmt-compute",
     "source": "specification/compute/resource-manager/readme.md",
     "package": "com.microsoft.azure.management.compute",
-    "args": "--track1-naming=true --payload-flattening-threshold=1 --tag=package-2019-03-01"
+    "args": "--payload-flattening-threshold=1 --tag=package-2019-03-01"
   },
   "consumption": {
     "dir": "azure-mgmt-consumption",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,9 +109,9 @@ var codegen = function(project, cb) {
 
     // path.join won't work if specRoot is a URL
     const readmeFile = specRoot + '/' + mappings[project].source;
-    const transcribedReadmeFile = readmeFile + '.temp.md';
-    const tag = findTag(mappings[project].package + ' ' + mappings[project].args);
-    transcribeReadme(readmeFile, transcribedReadmeFile, tag);
+//    const transcribedReadmeFile = readmeFile + '.temp.md';
+//    const tag = findTag(mappings[project].package + ' ' + mappings[project].args);
+//    transcribeReadme(readmeFile, transcribedReadmeFile, tag);
 
     console.log('Generating "' + project + '" from spec file ' + readmeFile);
     var generator = '--fluent=true';
@@ -126,7 +126,7 @@ var codegen = function(project, cb) {
     const regenManager = args['regenerate-manager'] ? ' --regenerate-manager=true ' : '';
 
     const outDir = path.resolve(mappings[project].dir);
-    cmd = autoRestExe + ' ' + transcribedReadmeFile +
+    cmd = autoRestExe + ' ' + readmeFile +
                         ' --java ' +
                         ' --azure-arm=true ' +
                         ' --generate-client-as-impl=true --implementation-subpackage=models --sync-methods=all --required-parameter-client-methods=true ' +


### PR DESCRIPTION
change option to track1-naming (e.g. withName), now default is track2 style (e.g. setName)

also latest autorest support `tag`