### PR TITLE
Upgrade junit4 to junit5

### DIFF
--- a/azure-mgmt-graph-rbac/pom.xml
+++ b/azure-mgmt-graph-rbac/pom.xml
@@ -70,8 +70,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ApplicationsTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ApplicationsTests.java
@@ -7,8 +7,8 @@
 package com.azure.management.graphrbac;
 
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -32,20 +32,20 @@ public class ApplicationsTests extends GraphRbacManagementTest {
                         .attach()
                     .create();
             System.out.println(application.id() + " - " + application.applicationId());
-            Assert.assertNotNull(application.id());
-            Assert.assertNotNull(application.applicationId());
-            Assert.assertEquals(name, application.name());
-            Assert.assertEquals(1, application.certificateCredentials().size());
-            Assert.assertEquals(1, application.passwordCredentials().size());
-            Assert.assertEquals(1, application.replyUrls().size());
-            Assert.assertEquals(1, application.identifierUris().size());
-            Assert.assertEquals("http://easycreate.azure.com/" + name, application.signOnUrl().toString());
+            Assertions.assertNotNull(application.id());
+            Assertions.assertNotNull(application.applicationId());
+            Assertions.assertEquals(name, application.name());
+            Assertions.assertEquals(1, application.certificateCredentials().size());
+            Assertions.assertEquals(1, application.passwordCredentials().size());
+            Assertions.assertEquals(1, application.replyUrls().size());
+            Assertions.assertEquals(1, application.identifierUris().size());
+            Assertions.assertEquals("http://easycreate.azure.com/" + name, application.signOnUrl().toString());
 
             application.update()
                     .withoutCredential("passwd")
                     .apply();
             System.out.println(application.id() + " - " + application.applicationId());
-            Assert.assertEquals(0, application.passwordCredentials().size());
+            Assertions.assertEquals(0, application.passwordCredentials().size());
         } finally {
             if (application != null) {
                 graphRbacManager.applications().deleteById(application.id());

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/GroupsTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/GroupsTests.java
@@ -7,8 +7,8 @@
 package com.azure.management.graphrbac;
 
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -44,14 +44,14 @@ public class GroupsTests extends GraphRbacManagementTest {
                     .withMember(group1.id())
                     .create();
 
-            Assert.assertNotNull(group2);
-            Assert.assertNotNull(group2.id());
+            Assertions.assertNotNull(group2);
+            Assertions.assertNotNull(group2.id());
             Set<ActiveDirectoryObject> members = group2.listMembers();
-            Assert.assertEquals(3, members.size());
+            Assertions.assertEquals(3, members.size());
             Iterator<ActiveDirectoryObject> iterator = members.iterator();
-            Assert.assertNotNull(iterator.next().id());
-            Assert.assertNotNull(iterator.next().id());
-            Assert.assertNotNull(iterator.next().id());
+            Assertions.assertNotNull(iterator.next().id());
+            Assertions.assertNotNull(iterator.next().id());
+            Assertions.assertNotNull(iterator.next().id());
         } finally {
             if (servicePrincipal != null) {
                 graphRbacManager.servicePrincipals().deleteById(servicePrincipal.id());

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleAssignmentTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleAssignmentTests.java
@@ -7,10 +7,7 @@
 package com.azure.management.graphrbac;
 
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.AfterClass;
 import org.junit.jupiter.api.Assertions;
-import org.junit.BeforeClass;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class RoleAssignmentTests extends GraphRbacManagementTest {

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleAssignmentTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleAssignmentTests.java
@@ -8,10 +8,10 @@ package com.azure.management.graphrbac;
 
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import org.junit.AfterClass;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class RoleAssignmentTests extends GraphRbacManagementTest {
     @Test
@@ -32,7 +32,7 @@ public class RoleAssignmentTests extends GraphRbacManagementTest {
                 .withSubscriptionScope(resourceManager.getSubscriptionId())
                 .create();
 
-        Assert.assertNotNull(roleAssignment);
+        Assertions.assertNotNull(roleAssignment);
     }
 
 }

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleDefinitionTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/RoleDefinitionTests.java
@@ -6,17 +6,17 @@
 
 package com.azure.management.graphrbac;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class RoleDefinitionTests extends GraphRbacManagementTest {
     @Test
     public void canGetRoleByRoleName() throws Exception {
         RoleDefinition roleDefinition = graphRbacManager.roleDefinitions()
                 .getByScopeAndRoleName("subscriptions/" + resourceManager.getSubscriptionId(), "Contributor");
-        Assert.assertNotNull(roleDefinition);
-        Assert.assertEquals("Contributor", roleDefinition.roleName());
+        Assertions.assertNotNull(roleDefinition);
+        Assertions.assertEquals("Contributor", roleDefinition.roleName());
     }
 
 }

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ServicePrincipalsTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ServicePrincipalsTests.java
@@ -21,8 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
 
-import static org.junit.Assertions.fail;
-
 public class ServicePrincipalsTests extends GraphRbacManagementTest {
 
     @Test
@@ -122,7 +120,7 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
             try {
                 resourceManager.resourceGroups().define(rgName + "2")
                         .withRegion(Region.US_WEST).create();
-                fail();
+                Assertions.fail();
             } catch (Exception e) {
                 // expected
             }

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ServicePrincipalsTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/ServicePrincipalsTests.java
@@ -11,9 +11,9 @@ import com.azure.management.resources.ResourceGroup;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.azure.management.resources.implementation.ResourceManager;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assertions.fail;
 
 public class ServicePrincipalsTests extends GraphRbacManagementTest {
 
@@ -38,19 +38,19 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
                         .attach()
                     .create();
             System.out.println(servicePrincipal.id() + " - " + String.join(",", servicePrincipal.servicePrincipalNames()));
-            Assert.assertNotNull(servicePrincipal.id());
-            Assert.assertNotNull(servicePrincipal.applicationId());
-            Assert.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
-            Assert.assertEquals(1, servicePrincipal.passwordCredentials().size());
-            Assert.assertEquals(0, servicePrincipal.certificateCredentials().size());
+            Assertions.assertNotNull(servicePrincipal.id());
+            Assertions.assertNotNull(servicePrincipal.applicationId());
+            Assertions.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
+            Assertions.assertEquals(1, servicePrincipal.passwordCredentials().size());
+            Assertions.assertEquals(0, servicePrincipal.certificateCredentials().size());
 
             // Get
             servicePrincipal = graphRbacManager.servicePrincipals().getByName(name);
-            Assert.assertNotNull(servicePrincipal);
-            Assert.assertNotNull(servicePrincipal.applicationId());
-            Assert.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
-            Assert.assertEquals(1, servicePrincipal.passwordCredentials().size());
-            Assert.assertEquals(0, servicePrincipal.certificateCredentials().size());
+            Assertions.assertNotNull(servicePrincipal);
+            Assertions.assertNotNull(servicePrincipal.applicationId());
+            Assertions.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
+            Assertions.assertEquals(1, servicePrincipal.passwordCredentials().size());
+            Assertions.assertEquals(0, servicePrincipal.certificateCredentials().size());
 
             // Update
             servicePrincipal.update()
@@ -61,11 +61,11 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
                         .withDuration(Duration.ofDays(1))
                         .attach()
                     .apply();
-            Assert.assertNotNull(servicePrincipal);
-            Assert.assertNotNull(servicePrincipal.applicationId());
-            Assert.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
-            Assert.assertEquals(0, servicePrincipal.passwordCredentials().size());
-            Assert.assertEquals(1, servicePrincipal.certificateCredentials().size());
+            Assertions.assertNotNull(servicePrincipal);
+            Assertions.assertNotNull(servicePrincipal.applicationId());
+            Assertions.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
+            Assertions.assertEquals(0, servicePrincipal.passwordCredentials().size());
+            Assertions.assertEquals(1, servicePrincipal.certificateCredentials().size());
         } finally {
             if (servicePrincipal != null) {
                 graphRbacManager.servicePrincipals().deleteById(servicePrincipal.id());
@@ -75,7 +75,7 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
     }
 
     @Test
-    @Ignore("Do not record - recorded JSON may contain auth info")
+    @Disabled("Do not record - recorded JSON may contain auth info")
     public void canCRUDServicePrincipalWithRole() throws Exception {
         String name = SdkContext.randomResourceName("ssp", 21);
         String rgName = SdkContext.randomResourceName("rg", 22);
@@ -100,9 +100,9 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
                     .withNewRoleInSubscription(BuiltInRole.CONTRIBUTOR, subscription)
                     .create();
             System.out.println(servicePrincipal.id() + " - " + String.join(",",servicePrincipal.servicePrincipalNames()));
-            Assert.assertNotNull(servicePrincipal.id());
-            Assert.assertNotNull(servicePrincipal.applicationId());
-            Assert.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
+            Assertions.assertNotNull(servicePrincipal.id());
+            Assertions.assertNotNull(servicePrincipal.applicationId());
+            Assertions.assertEquals(2, servicePrincipal.servicePrincipalNames().size());
 
             SdkContext.sleep(10000);
             ResourceManager resourceManager = ResourceManager.authenticate(
@@ -118,7 +118,7 @@ public class ServicePrincipalsTests extends GraphRbacManagementTest {
                     .apply();
 
             SdkContext.sleep(120000);
-            Assert.assertNotNull(resourceManager.resourceGroups().getByName(group.name()));
+            Assertions.assertNotNull(resourceManager.resourceGroups().getByName(group.name()));
             try {
                 resourceManager.resourceGroups().define(rgName + "2")
                         .withRegion(Region.US_WEST).create();

--- a/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/UsersTests.java
+++ b/azure-mgmt-graph-rbac/src/test/java/com/azure/management/graphrbac/UsersTests.java
@@ -8,30 +8,30 @@ package com.azure.management.graphrbac;
 
 import com.azure.management.resources.fluentcore.arm.CountryIsoCode;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class UsersTests extends GraphRbacManagementTest {
     @Test
-    @Ignore("Need a specific domain")
+    @Disabled("Need a specific domain")
     public void canGetUserByEmail() throws Exception {
         ActiveDirectoryUser user = graphRbacManager.users().getByName("admin@azuresdkteam.onmicrosoft.com");
-        Assert.assertEquals("Admin", user.name());
+        Assertions.assertEquals("Admin", user.name());
     }
 
     @Test
-    @Ignore("Need a specific domain")
+    @Disabled("Need a specific domain")
     public void canGetUserByForeignEmail() throws Exception {
         ActiveDirectoryUser user = graphRbacManager.users().getByName("jianghlu@microsoft.com");
-        Assert.assertEquals("Jianghao Lu", user.name());
+        Assertions.assertEquals("Jianghao Lu", user.name());
     }
 
     @Test
-    @Ignore("Need a specific domain")
+    @Disabled("Need a specific domain")
     public void canGetUserByDisplayName() throws Exception {
         ActiveDirectoryUser user = graphRbacManager.users().getByName("Reader zero");
-        Assert.assertEquals("Reader zero", user.name());
+        Assertions.assertEquals("Reader zero", user.name());
     }
 
     @Test
@@ -43,8 +43,8 @@ public class UsersTests extends GraphRbacManagementTest {
                 .withPromptToChangePasswordOnLogin(true)
                 .create();
 
-        Assert.assertNotNull(user);
-        Assert.assertNotNull(user.id());
+        Assertions.assertNotNull(user);
+        Assertions.assertNotNull(user.id());
     }
 
     @Test
@@ -59,6 +59,6 @@ public class UsersTests extends GraphRbacManagementTest {
                 .withUsageLocation(CountryIsoCode.AUSTRALIA)
                 .apply();
 
-        Assert.assertEquals(CountryIsoCode.AUSTRALIA, user.usageLocation());
+        Assertions.assertEquals(CountryIsoCode.AUSTRALIA, user.usageLocation());
     }
 }

--- a/azure-mgmt-graph-rbac/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-graph-rbac/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-mgmt-keyvault/pom.xml
+++ b/azure-mgmt-keyvault/pom.xml
@@ -69,8 +69,8 @@
       <artifactId>azure-security-keyvault-secrets</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/KeyTests.java
+++ b/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/KeyTests.java
@@ -18,8 +18,8 @@ import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
 import com.azure.security.keyvault.keys.models.JsonWebKey;
 import com.azure.security.keyvault.keys.models.KeyOperation;
 import com.azure.security.keyvault.keys.models.KeyType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -48,21 +48,21 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withKeyOperations(KeyOperation.SIGN, KeyOperation.VERIFY)
                 .create();
 
-        Assert.assertNotNull(key);
-        Assert.assertNotNull(key.id());
-        Assert.assertEquals(2, key.getJsonWebKey().getKeyOps().size());
+        Assertions.assertNotNull(key);
+        Assertions.assertNotNull(key.id());
+        Assertions.assertEquals(2, key.getJsonWebKey().getKeyOps().size());
 
         // Get
         Key key1 = vault.keys().getById(key.id());
-        Assert.assertNotNull(key1);
-        Assert.assertEquals(key.id(), key1.id());
+        Assertions.assertNotNull(key1);
+        Assertions.assertEquals(key.id(), key1.id());
 
         // Update
         key = key.update()
                 .withKeyOperations(KeyOperation.ENCRYPT)
                 .apply();
 
-        Assert.assertEquals(1, key.getJsonWebKey().getKeyOps().size());
+        Assertions.assertEquals(1, key.getJsonWebKey().getKeyOps().size());
 
         // New version
         key = key.update()
@@ -70,11 +70,11 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withKeyOperations(KeyOperation.ENCRYPT, KeyOperation.DECRYPT, KeyOperation.SIGN)
                 .apply();
 
-        Assert.assertEquals(3, key.getJsonWebKey().getKeyOps().size());
+        Assertions.assertEquals(3, key.getJsonWebKey().getKeyOps().size());
 
         // List versions
         Iterable<Key> keys = key.listVersions();
-        Assert.assertEquals(2, TestUtilities.getPagedIterableSize(keys));
+        Assertions.assertEquals(2, TestUtilities.getPagedIterableSize(keys));
     }
 
     @Test
@@ -86,8 +86,8 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withLocalKeyToImport(JsonWebKey.fromRsa(KeyPairGenerator.getInstance("RSA").generateKeyPair()))
                 .create();
 
-        Assert.assertNotNull(key);
-        Assert.assertNotNull(key.id());
+        Assertions.assertNotNull(key);
+        Assertions.assertNotNull(key.id());
     }
 
     @Test
@@ -99,18 +99,18 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withLocalKeyToImport(JsonWebKey.fromRsa(KeyPairGenerator.getInstance("RSA").generateKeyPair()))
                 .create();
 
-        Assert.assertNotNull(key);
+        Assertions.assertNotNull(key);
 
         byte[] backup = key.backup();
 
         vault.keys().deleteById(key.id());
-        Assert.assertEquals(0, TestUtilities.getPagedIterableSize(vault.keys().list()));
+        Assertions.assertEquals(0, TestUtilities.getPagedIterableSize(vault.keys().list()));
 
         vault.keys().restore(backup);
         PagedIterable<Key> keys = vault.keys().list();
-        Assert.assertEquals(1, TestUtilities.getPagedIterableSize(keys));
+        Assertions.assertEquals(1, TestUtilities.getPagedIterableSize(keys));
 
-        Assert.assertEquals(key.getJsonWebKey(), keys.iterator().next().getJsonWebKey());
+        Assertions.assertEquals(key.getJsonWebKey(), keys.iterator().next().getJsonWebKey());
     }
 
     @Test
@@ -124,17 +124,17 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withLocalKeyToImport(JsonWebKey.fromRsa(keyPair))
                 .create();
 
-        Assert.assertNotNull(key);
+        Assertions.assertNotNull(key);
 
         String s = "the quick brown fox jumps over the lazy dog";
         byte[] data = s.getBytes();
 
         // Remote encryption
         byte[] encrypted = key.encrypt(EncryptionAlgorithm.RSA1_5, data);
-        Assert.assertNotNull(encrypted);
+        Assertions.assertNotNull(encrypted);
 
         byte[] decrypted = key.decrypt(EncryptionAlgorithm.RSA1_5, encrypted);
-        Assert.assertEquals(s, new String(decrypted));
+        Assertions.assertEquals(s, new String(decrypted));
 
         // Local encryption
         Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
@@ -142,7 +142,7 @@ public class KeyTests extends KeyVaultManagementTest {
         encrypted = cipher.doFinal(data);
 
         decrypted = key.decrypt(EncryptionAlgorithm.RSA_OAEP, encrypted);
-        Assert.assertEquals(s, new String(decrypted));
+        Assertions.assertEquals(s, new String(decrypted));
     }
 
     @Test
@@ -156,22 +156,22 @@ public class KeyTests extends KeyVaultManagementTest {
                 .withLocalKeyToImport(JsonWebKey.fromRsa(keyPair))
                 .create();
 
-        Assert.assertNotNull(key);
+        Assertions.assertNotNull(key);
 
         String s = "the quick brown fox jumps over the lazy dog";
         byte[] data = s.getBytes();
         byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
         byte[] signature = key.sign(SignatureAlgorithm.RS256, digest);
-        Assert.assertNotNull(signature);
+        Assertions.assertNotNull(signature);
 
         // Local verification
         Signature sign = Signature.getInstance("SHA256withRSA");
         sign.initVerify(keyPair.getPublic());
         sign.update(data);
-        Assert.assertTrue(sign.verify(signature));
+        Assertions.assertTrue(sign.verify(signature));
 
         // Remote verification
-        Assert.assertTrue(key.verify(SignatureAlgorithm.RS256, digest, signature));
+        Assertions.assertTrue(key.verify(SignatureAlgorithm.RS256, digest, signature));
     }
 
     @Test
@@ -186,11 +186,11 @@ public class KeyTests extends KeyVaultManagementTest {
         SecretKey secretKey = KeyGenerator.getInstance("AES").generateKey();
 
         byte[] wrapped = key.wrapKey(KeyWrapAlgorithm.RSA1_5, secretKey.getEncoded());
-        Assert.assertNotNull(wrapped);
+        Assertions.assertNotNull(wrapped);
 
         byte[] unwrapped = key.unwrapKey(KeyWrapAlgorithm.RSA1_5, wrapped);
-        Assert.assertNotNull(unwrapped);
-        Assert.assertEquals(secretKey, new SecretKeySpec(unwrapped, "AES"));
+        Assertions.assertNotNull(unwrapped);
+        Assertions.assertEquals(secretKey, new SecretKeySpec(unwrapped, "AES"));
     }
 
     private Vault createVault() throws Exception {
@@ -207,7 +207,7 @@ public class KeyTests extends KeyVaultManagementTest {
                     .attach()
                 .create();
 
-        Assert.assertNotNull(vault);
+        Assertions.assertNotNull(vault);
 
         SdkContext.sleep(10000);
 

--- a/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/SecretTests.java
+++ b/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/SecretTests.java
@@ -10,8 +10,8 @@ import com.azure.management.ApplicationTokenCredential;
 import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -37,7 +37,7 @@ public class SecretTests extends KeyVaultManagementTest {
                     .attach()
                 .create();
 
-        Assert.assertNotNull(vault);
+        Assertions.assertNotNull(vault);
 
         SdkContext.sleep(10000);
 
@@ -45,15 +45,15 @@ public class SecretTests extends KeyVaultManagementTest {
                 .withValue("Some secret value")
                 .create();
 
-        Assert.assertNotNull(secret);
-        Assert.assertNotNull(secret.id());
-        Assert.assertEquals("Some secret value", secret.value());
+        Assertions.assertNotNull(secret);
+        Assertions.assertNotNull(secret.id());
+        Assertions.assertEquals("Some secret value", secret.value());
 
         secret = secret.update()
                 .withValue("Some updated value")
                 .apply();
 
-        Assert.assertEquals("Some updated value", secret.value());
+        Assertions.assertEquals("Some updated value", secret.value());
 
         Iterable<Secret> versions = secret.listVersions();
 
@@ -66,7 +66,7 @@ public class SecretTests extends KeyVaultManagementTest {
                 count --;
             }
         }
-        Assert.assertEquals(0, count);
+        Assertions.assertEquals(0, count);
 
     }
 }

--- a/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/VaultTests.java
+++ b/azure-mgmt-keyvault/src/test/java/com/azure/management/keyvault/VaultTests.java
@@ -12,8 +12,8 @@ import com.azure.management.graphrbac.ActiveDirectoryUser;
 import com.azure.management.graphrbac.ServicePrincipal;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class VaultTests extends KeyVaultManagementTest {
     @Test
@@ -53,23 +53,23 @@ public class VaultTests extends KeyVaultManagementTest {
                     .withAccessFromAzureServices()
                     .withAccessFromIpAddress("0.0.0.0/0")
                     .create();
-            Assert.assertNotNull(vault);
-            Assert.assertFalse(vault.softDeleteEnabled());
-            Assert.assertEquals(vault.networkRuleSet().getBypass(), NetworkRuleBypassOptions.AZURE_SERVICES);
+            Assertions.assertNotNull(vault);
+            Assertions.assertFalse(vault.softDeleteEnabled());
+            Assertions.assertEquals(vault.networkRuleSet().getBypass(), NetworkRuleBypassOptions.AZURE_SERVICES);
             
             // GET
             vault = keyVaultManager.vaults().getByResourceGroup(RG_NAME, VAULT_NAME);
-            Assert.assertNotNull(vault);
+            Assertions.assertNotNull(vault);
             for (AccessPolicy policy : vault.accessPolicies()) {
                 if (policy.objectId().equals(servicePrincipal.id())) {
-                    Assert.assertArrayEquals(new KeyPermissions[] { KeyPermissions.LIST }, policy.permissions().getKeys().toArray());
-                    Assert.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
-                    Assert.assertArrayEquals(new CertificatePermissions[] { CertificatePermissions.GET }, policy.permissions().getCertificates().toArray());
+                    Assertions.assertArrayEquals(new KeyPermissions[] { KeyPermissions.LIST }, policy.permissions().getKeys().toArray());
+                    Assertions.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
+                    Assertions.assertArrayEquals(new CertificatePermissions[] { CertificatePermissions.GET }, policy.permissions().getCertificates().toArray());
                 }
                 if (policy.objectId().equals(user.id())) {
-                    Assert.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
-                    Assert.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
-                    Assert.assertEquals(3, policy.permissions().getCertificates().size());
+                    Assertions.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
+                    Assertions.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
+                    Assertions.assertEquals(3, policy.permissions().getCertificates().size());
                 }
             }
             // LIST
@@ -80,7 +80,7 @@ public class VaultTests extends KeyVaultManagementTest {
                     break;
                 }
             }
-            Assert.assertNotNull(vault);
+            Assertions.assertNotNull(vault);
             // UPDATE
             vault.update()
                     .updateAccessPolicy(servicePrincipal.id())
@@ -92,9 +92,9 @@ public class VaultTests extends KeyVaultManagementTest {
                     .apply();
             for (AccessPolicy policy : vault.accessPolicies()) {
                 if (policy.objectId().equals(servicePrincipal.id())) {
-                    Assert.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
-                    Assert.assertEquals(0, policy.permissions().getSecrets().size());
-                    Assert.assertEquals(CertificatePermissions.values().size(), policy.permissions().getCertificates().size());
+                    Assertions.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
+                    Assertions.assertEquals(0, policy.permissions().getSecrets().size());
+                    Assertions.assertEquals(CertificatePermissions.values().size(), policy.permissions().getCertificates().size());
                 }
             }
             
@@ -142,21 +142,21 @@ public class VaultTests extends KeyVaultManagementTest {
                         .allowCertificatePermissions(CertificatePermissions.GET, CertificatePermissions.LIST, CertificatePermissions.CREATE)
                         .attach()
                     .create();
-            Assert.assertNotNull(vault);
-            Assert.assertFalse(vault.softDeleteEnabled());
+            Assertions.assertNotNull(vault);
+            Assertions.assertFalse(vault.softDeleteEnabled());
             // GET
             vault = keyVaultManager.vaults().getByResourceGroupAsync(RG_NAME, VAULT_NAME).block();
-            Assert.assertNotNull(vault);
+            Assertions.assertNotNull(vault);
             for (AccessPolicy policy : vault.accessPolicies()) {
                 if (policy.objectId().equals(servicePrincipal.id())) {
-                    Assert.assertArrayEquals(new KeyPermissions[] { KeyPermissions.LIST }, policy.permissions().getKeys().toArray());
-                    Assert.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
-                    Assert.assertArrayEquals(new CertificatePermissions[] { CertificatePermissions.GET }, policy.permissions().getCertificates().toArray());
+                    Assertions.assertArrayEquals(new KeyPermissions[] { KeyPermissions.LIST }, policy.permissions().getKeys().toArray());
+                    Assertions.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
+                    Assertions.assertArrayEquals(new CertificatePermissions[] { CertificatePermissions.GET }, policy.permissions().getCertificates().toArray());
                 }
                 if (policy.objectId().equals(user.id())) {
-                    Assert.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
-                    Assert.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
-                    Assert.assertEquals(3, policy.permissions().getCertificates().size());
+                    Assertions.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
+                    Assertions.assertEquals(SecretPermissions.values().size(), policy.permissions().getSecrets().size());
+                    Assertions.assertEquals(3, policy.permissions().getCertificates().size());
                 }
             }
             // LIST
@@ -167,7 +167,7 @@ public class VaultTests extends KeyVaultManagementTest {
                     break;
                 }
             }
-            Assert.assertNotNull(vault);
+            Assertions.assertNotNull(vault);
             // UPDATE
             vault.update()
                     .updateAccessPolicy(servicePrincipal.id())
@@ -179,9 +179,9 @@ public class VaultTests extends KeyVaultManagementTest {
                     .apply();
             for (AccessPolicy policy : vault.accessPolicies()) {
                 if (policy.objectId().equals(servicePrincipal.id())) {
-                    Assert.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
-                    Assert.assertEquals(0, policy.permissions().getSecrets().size());
-                    Assert.assertEquals(CertificatePermissions.values().size(), policy.permissions().getCertificates().size());
+                    Assertions.assertEquals(KeyPermissions.values().size(), policy.permissions().getKeys().size());
+                    Assertions.assertEquals(0, policy.permissions().getSecrets().size());
+                    Assertions.assertEquals(CertificatePermissions.values().size(), policy.permissions().getCertificates().size());
                 }
             }
             
@@ -230,12 +230,12 @@ public class VaultTests extends KeyVaultManagementTest {
                         .attach()
                     .withSoftDeleteEnabled()
                     .create();
-            Assert.assertTrue(vault.softDeleteEnabled());
+            Assertions.assertTrue(vault.softDeleteEnabled());
 
             keyVaultManager.vaults().deleteByResourceGroup(RG_NAME, otherVaultName);;
             SdkContext.sleep(20000);
             //Can still see deleted vault.
-            Assert.assertNotNull(keyVaultManager.vaults().getDeleted(otherVaultName, Region.US_WEST.toString()));
+            Assertions.assertNotNull(keyVaultManager.vaults().getDeleted(otherVaultName, Region.US_WEST.toString()));
 
             keyVaultManager.vaults().purgeDeleted(otherVaultName,  Region.US_WEST.toString());
             SdkContext.sleep(20000);
@@ -256,6 +256,6 @@ public class VaultTests extends KeyVaultManagementTest {
                 deleted = true;
             }
         }
-        Assert.assertTrue(deleted);
+        Assertions.assertTrue(deleted);
     }
 }

--- a/azure-mgmt-keyvault/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-keyvault/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-mgmt-msi/pom.xml
+++ b/azure-mgmt-msi/pom.xml
@@ -65,8 +65,8 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-mgmt-msi/src/test/java/com/azure/management/msi/MSIIdentityManagementTests.java
+++ b/azure-mgmt-msi/src/test/java/com/azure/management/msi/MSIIdentityManagementTests.java
@@ -18,8 +18,8 @@ import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.Indexable;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.azure.management.resources.implementation.ResourceManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,40 +58,40 @@ public class MSIIdentityManagementTests extends TestBase {
                 .withNewResourceGroup(creatableRG)
                 .create();
 
-        Assert.assertNotNull(identity);
-        Assert.assertNotNull(identity.inner());
-        Assert.assertTrue(String.format("%s == %s", identityName, identity.name()), identityName.equalsIgnoreCase(identity.name()));
-        Assert.assertTrue(String.format("%s == %s", RG_NAME, identity.resourceGroupName()), RG_NAME.equalsIgnoreCase(identity.resourceGroupName()));
+        Assertions.assertNotNull(identity);
+        Assertions.assertNotNull(identity.inner());
+        Assertions.assertTrue(String.format("%s == %s", identityName, identity.name()), identityName.equalsIgnoreCase(identity.name()));
+        Assertions.assertTrue(String.format("%s == %s", RG_NAME, identity.resourceGroupName()), RG_NAME.equalsIgnoreCase(identity.resourceGroupName()));
 
-        Assert.assertNotNull(identity.clientId());
-        Assert.assertNotNull(identity.principalId());
-        Assert.assertNotNull(identity.tenantId());
-        //Assert.assertNotNull(identity.clientSecretUrl());
+        Assertions.assertNotNull(identity.clientId());
+        Assertions.assertNotNull(identity.principalId());
+        Assertions.assertNotNull(identity.tenantId());
+        //Assertions.assertNotNull(identity.clientSecretUrl());
 
         identity = msiManager.identities().getById(identity.id());
 
-        Assert.assertNotNull(identity);
-        Assert.assertNotNull(identity.inner());
+        Assertions.assertNotNull(identity);
+        Assertions.assertNotNull(identity.inner());
 
         PagedIterable<Identity> identities = msiManager.identities()
                 .listByResourceGroup(RG_NAME);
 
-        Assert.assertNotNull(identities);
+        Assertions.assertNotNull(identities);
 
         boolean found = false;
         for (Identity id : identities) {
-            Assert.assertNotNull(id);
-            Assert.assertNotNull(id.inner());
+            Assertions.assertNotNull(id);
+            Assertions.assertNotNull(id.inner());
             if (id.name().equalsIgnoreCase(identityName)) {
                 found = true;
             }
-            Assert.assertNotNull(identity.clientId());
-            Assert.assertNotNull(identity.principalId());
-            Assert.assertNotNull(identity.tenantId());
-            //Assert.assertNotNull(identity.clientSecretUrl());
+            Assertions.assertNotNull(identity.clientId());
+            Assertions.assertNotNull(identity.principalId());
+            Assertions.assertNotNull(identity.tenantId());
+            //Assertions.assertNotNull(identity.clientSecretUrl());
         }
 
-        Assert.assertTrue(found);
+        Assertions.assertTrue(found);
 
         msiManager.identities()
                 .deleteById(identity.id());
@@ -124,7 +124,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assert.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
+        Assertions.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
 
         identity.update()
                 .withoutAccessTo(resourceGroup.id(), BuiltInRole.READER)
@@ -142,7 +142,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assert.assertTrue("Role assignment to access resource group is not removed", notFound);
+        Assertions.assertTrue("Role assignment to access resource group is not removed", notFound);
 
         msiManager.identities()
                 .deleteById(identity.id());
@@ -193,10 +193,10 @@ public class MSIIdentityManagementTests extends TestBase {
             }
         }
 
-        Assert.assertEquals(1, resourceGroupResourcesCount);
-        Assert.assertEquals(2, roleAssignmentResourcesCount);
-        Assert.assertEquals(2, identityResourcesCount); // Identity resource will be emitted twice - before & after post-run, will be fixed in graph
-        Assert.assertNotNull(identity);
+        Assertions.assertEquals(1, resourceGroupResourcesCount);
+        Assertions.assertEquals(2, roleAssignmentResourcesCount);
+        Assertions.assertEquals(2, identityResourcesCount); // Identity resource will be emitted twice - before & after post-run, will be fixed in graph
+        Assertions.assertNotNull(identity);
 
         // Ensure roles are assigned
         //
@@ -209,7 +209,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assert.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
+        Assertions.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
 
         roleAssignments = this.msiManager.graphRbacManager().roleAssignments().listByScope(anotherResourceGroup.id());
         found = false;
@@ -219,15 +219,15 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assert.assertTrue("Expected role assignment not found for the resource group resource", found);
+        Assertions.assertTrue("Expected role assignment not found for the resource group resource", found);
 
         identity = identity
                 .update()
                 .withTag("a", "bb")
                 .apply();
 
-        Assert.assertNotNull(identity.tags());
-        Assert.assertTrue(identity.tags().containsKey("a"));
+        Assertions.assertNotNull(identity.tags());
+        Assertions.assertTrue(identity.tags().containsKey("a"));
 
         resourceManager.resourceGroups().deleteByName(anotherRgName);
     }

--- a/azure-mgmt-msi/src/test/java/com/azure/management/msi/MSIIdentityManagementTests.java
+++ b/azure-mgmt-msi/src/test/java/com/azure/management/msi/MSIIdentityManagementTests.java
@@ -60,8 +60,8 @@ public class MSIIdentityManagementTests extends TestBase {
 
         Assertions.assertNotNull(identity);
         Assertions.assertNotNull(identity.inner());
-        Assertions.assertTrue(String.format("%s == %s", identityName, identity.name()), identityName.equalsIgnoreCase(identity.name()));
-        Assertions.assertTrue(String.format("%s == %s", RG_NAME, identity.resourceGroupName()), RG_NAME.equalsIgnoreCase(identity.resourceGroupName()));
+        Assertions.assertTrue(identityName.equalsIgnoreCase(identity.name()), String.format("%s == %s", identityName, identity.name()));
+        Assertions.assertTrue(RG_NAME.equalsIgnoreCase(identity.resourceGroupName()), String.format("%s == %s", RG_NAME, identity.resourceGroupName()));
 
         Assertions.assertNotNull(identity.clientId());
         Assertions.assertNotNull(identity.principalId());
@@ -124,7 +124,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assertions.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
+        Assertions.assertTrue(found, "Expected role assignment not found for the resource group that identity belongs to");
 
         identity.update()
                 .withoutAccessTo(resourceGroup.id(), BuiltInRole.READER)
@@ -142,7 +142,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assertions.assertTrue("Role assignment to access resource group is not removed", notFound);
+        Assertions.assertTrue(notFound, "Role assignment to access resource group is not removed");
 
         msiManager.identities()
                 .deleteById(identity.id());
@@ -209,7 +209,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assertions.assertTrue("Expected role assignment not found for the resource group that identity belongs to", found);
+        Assertions.assertTrue(found, "Expected role assignment not found for the resource group that identity belongs to");
 
         roleAssignments = this.msiManager.graphRbacManager().roleAssignments().listByScope(anotherResourceGroup.id());
         found = false;
@@ -219,7 +219,7 @@ public class MSIIdentityManagementTests extends TestBase {
                 break;
             }
         }
-        Assertions.assertTrue("Expected role assignment not found for the resource group resource", found);
+        Assertions.assertTrue(found, "Expected role assignment not found for the resource group resource");
 
         identity = identity
                 .update()

--- a/azure-mgmt-msi/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-msi/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-mgmt-network/pom.xml
+++ b/azure-mgmt-network/pom.xml
@@ -64,8 +64,8 @@
       <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/ApplicationGatewayTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/ApplicationGatewayTests.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.Files;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -64,11 +64,11 @@ public class ApplicationGatewayTests extends NetworkManagementTest {
                 .withWebApplicationFirewall(true, ApplicationGatewayFirewallMode.PREVENTION)
                 .create();
 
-        Assert.assertTrue(appGateway != null);
-        Assert.assertTrue(ApplicationGatewayTier.WAF_V2.equals(appGateway.tier()));
-        Assert.assertTrue(ApplicationGatewaySkuName.WAF_V2.equals(appGateway.size()));
-        Assert.assertTrue(appGateway.autoscaleConfiguration().minCapacity() == 2);
-        Assert.assertTrue(appGateway.autoscaleConfiguration().maxCapacity() == 5);
+        Assertions.assertTrue(appGateway != null);
+        Assertions.assertTrue(ApplicationGatewayTier.WAF_V2.equals(appGateway.tier()));
+        Assertions.assertTrue(ApplicationGatewaySkuName.WAF_V2.equals(appGateway.size()));
+        Assertions.assertTrue(appGateway.autoscaleConfiguration().minCapacity() == 2);
+        Assertions.assertTrue(appGateway.autoscaleConfiguration().maxCapacity() == 5);
 
         ApplicationGatewayWebApplicationFirewallConfiguration config = appGateway.webApplicationFirewallConfiguration();
         config.withFileUploadLimitInMb(200);
@@ -89,23 +89,23 @@ public class ApplicationGatewayTests extends NetworkManagementTest {
         appGateway.refresh();
 
         // Verify WAF
-        Assert.assertTrue(appGateway.webApplicationFirewallConfiguration().fileUploadLimitInMb() == 200);
-        Assert.assertTrue(appGateway.webApplicationFirewallConfiguration().requestBodyCheck());
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().maxRequestBodySizeInKb(), (Integer) 64);
+        Assertions.assertTrue(appGateway.webApplicationFirewallConfiguration().fileUploadLimitInMb() == 200);
+        Assertions.assertTrue(appGateway.webApplicationFirewallConfiguration().requestBodyCheck());
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().maxRequestBodySizeInKb(), (Integer) 64);
 
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().size(), 1);
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().size(), 1);
 
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).matchVariable(), "RequestHeaderNames");
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).selectorMatchOperator(), "StartsWith");
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).selector(), "User-Agent");
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).matchVariable(), "RequestHeaderNames");
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).selectorMatchOperator(), "StartsWith");
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().exclusions().get(0).selector(), "User-Agent");
 
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().disabledRuleGroups().size(), 1);
-        Assert.assertEquals(appGateway.webApplicationFirewallConfiguration().disabledRuleGroups().get(0).ruleGroupName(),
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().disabledRuleGroups().size(), 1);
+        Assertions.assertEquals(appGateway.webApplicationFirewallConfiguration().disabledRuleGroups().get(0).ruleGroupName(),
                 "REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION");
     }
 
     @Test
-    @Ignore("Need client id for key vault usage")
+    @Disabled("Need client id for key vault usage")
     public void canCreateApplicationGatewayWithSecret() throws Exception {
         String appGatewayName = SdkContext.randomResourceName("agwaf", 15);
         String appPublicIp = SdkContext.randomResourceName("pip", 15);
@@ -128,8 +128,8 @@ public class ApplicationGatewayTests extends NetworkManagementTest {
                 .withExistingResourceGroup(RG_NAME)
                 .create();
 
-        Assert.assertNotNull(identity.name());
-        Assert.assertNotNull(identity.principalId());
+        Assertions.assertNotNull(identity.name());
+        Assertions.assertNotNull(identity.principalId());
 
         Secret secret1 = createKeyVaultSecret(credentials.getClientId(), identity.principalId());
         Secret secret2 = createKeyVaultSecret(credentials.getClientId(), identity.principalId());
@@ -159,8 +159,8 @@ public class ApplicationGatewayTests extends NetworkManagementTest {
                 .withWebApplicationFirewall(true, ApplicationGatewayFirewallMode.PREVENTION)
                 .create();
 
-        Assert.assertEquals(secret1.id(), appGateway.sslCertificates().get("ssl1").keyVaultSecretId());
-        Assert.assertEquals(secret1.id(), appGateway.requestRoutingRules().get("rule1").sslCertificate().keyVaultSecretId());
+        Assertions.assertEquals(secret1.id(), appGateway.sslCertificates().get("ssl1").keyVaultSecretId());
+        Assertions.assertEquals(secret1.id(), appGateway.requestRoutingRules().get("rule1").sslCertificate().keyVaultSecretId());
 
         appGateway = appGateway.update()
                 .defineSslCertificate("ssl2")
@@ -168,7 +168,7 @@ public class ApplicationGatewayTests extends NetworkManagementTest {
                 .attach()
                 .apply();
 
-        Assert.assertEquals(secret2.id(), appGateway.sslCertificates().get("ssl2").keyVaultSecretId());
+        Assertions.assertEquals(secret2.id(), appGateway.sslCertificates().get("ssl2").keyVaultSecretId());
     }
 
     private Secret createKeyVaultSecret(String servicePrincipal, String identityPrincipal) throws Exception {

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/ApplicationSecurityGroupTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/ApplicationSecurityGroupTests.java
@@ -10,8 +10,8 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ApplicationSecurityGroupTests extends NetworkManagementTest {
 
@@ -24,16 +24,16 @@ public class ApplicationSecurityGroupTests extends NetworkManagementTest {
                 .withNewResourceGroup(RG_NAME)
                 .withTag("tag1", "value1")
                 .create();
-        Assert.assertEquals("value1", applicationSecurityGroup.tags().get("tag1"));
+        Assertions.assertEquals("value1", applicationSecurityGroup.tags().get("tag1"));
 
         PagedIterable<ApplicationSecurityGroup> asgList = networkManager.applicationSecurityGroups().list();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(asgList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(asgList) > 0);
 
         asgList = networkManager.applicationSecurityGroups().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(asgList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(asgList) > 0);
 
         networkManager.applicationSecurityGroups().deleteById(applicationSecurityGroup.id());
         asgList = networkManager.applicationSecurityGroups().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.isEmpty(asgList));
+        Assertions.assertTrue(TestUtilities.isEmpty(asgList));
     }
 }

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/DdosProtectionPlanTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/DdosProtectionPlanTests.java
@@ -9,8 +9,8 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DdosProtectionPlanTests extends NetworkManagementTest {
 
@@ -23,16 +23,16 @@ public class DdosProtectionPlanTests extends NetworkManagementTest {
                 .withNewResourceGroup(RG_NAME)
                 .withTag("tag1", "value1")
                 .create();
-        Assert.assertEquals("value1", pPlan.tags().get("tag1"));
+        Assertions.assertEquals("value1", pPlan.tags().get("tag1"));
 
         PagedIterable<DdosProtectionPlan> ppList = networkManager.ddosProtectionPlans().list();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(ppList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(ppList) > 0);
 
         ppList = networkManager.ddosProtectionPlans().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(ppList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(ppList) > 0);
 
         networkManager.ddosProtectionPlans().deleteById(pPlan.id());
         ppList = networkManager.ddosProtectionPlans().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.isEmpty(ppList));
+        Assertions.assertTrue(TestUtilities.isEmpty(ppList));
     }
 }

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/LoadBalancerTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/LoadBalancerTests.java
@@ -9,8 +9,8 @@ import com.azure.management.network.implementation.NetworkManager;
 import com.azure.management.resources.ResourceGroup;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LoadBalancerTests extends NetworkManagementTest {
 
@@ -34,19 +34,19 @@ public class LoadBalancerTests extends NetworkManagementTest {
 
         // verify created probes
         loadBalancer.refresh();
-        Assert.assertEquals(2, loadBalancer.loadBalancingRules().size());
-        Assert.assertEquals(0, loadBalancer.tcpProbes().size());
-        Assert.assertEquals(1, loadBalancer.httpProbes().size());
-        Assert.assertEquals(1, loadBalancer.httpsProbes().size());
+        Assertions.assertEquals(2, loadBalancer.loadBalancingRules().size());
+        Assertions.assertEquals(0, loadBalancer.tcpProbes().size());
+        Assertions.assertEquals(1, loadBalancer.httpProbes().size());
+        Assertions.assertEquals(1, loadBalancer.httpsProbes().size());
         LoadBalancerHttpProbe httpProbe = loadBalancer.httpProbes().get(probeName1);
-        Assert.assertNotNull(httpProbe);
-        Assert.assertEquals(1, httpProbe.loadBalancingRules().size());
+        Assertions.assertNotNull(httpProbe);
+        Assertions.assertEquals(1, httpProbe.loadBalancingRules().size());
         LoadBalancerHttpProbe httpsProbe = loadBalancer.httpsProbes().get(probeName2);
-        Assert.assertEquals(1, httpsProbe.loadBalancingRules().size());
+        Assertions.assertEquals(1, httpsProbe.loadBalancingRules().size());
         // verify https probe
-        Assert.assertEquals(ProbeProtocol.HTTPS, httpsProbe.protocol());
-        Assert.assertEquals(443, httpsProbe.port());
-        Assert.assertEquals("/", httpsProbe.requestPath());
+        Assertions.assertEquals(ProbeProtocol.HTTPS, httpsProbe.protocol());
+        Assertions.assertEquals(443, httpsProbe.port());
+        Assertions.assertEquals("/", httpsProbe.requestPath());
 
         // update probe
         loadBalancer.update()
@@ -57,15 +57,15 @@ public class LoadBalancerTests extends NetworkManagementTest {
 
         // verify probe updated
         loadBalancer.refresh();
-        Assert.assertEquals(1, loadBalancer.httpProbes().size());
-        Assert.assertEquals(1, loadBalancer.httpsProbes().size());
-        Assert.assertEquals(1, httpProbe.loadBalancingRules().size());
+        Assertions.assertEquals(1, loadBalancer.httpProbes().size());
+        Assertions.assertEquals(1, loadBalancer.httpsProbes().size());
+        Assertions.assertEquals(1, httpProbe.loadBalancingRules().size());
         httpsProbe = loadBalancer.httpsProbes().get(probeName2);
-        Assert.assertEquals(1, httpsProbe.loadBalancingRules().size());
-        Assert.assertEquals(ProbeProtocol.HTTPS, httpsProbe.protocol());
-        Assert.assertEquals(443, httpsProbe.port());
-        Assert.assertEquals(60, httpsProbe.intervalInSeconds());
-        Assert.assertEquals("/health", httpsProbe.requestPath());
+        Assertions.assertEquals(1, httpsProbe.loadBalancingRules().size());
+        Assertions.assertEquals(ProbeProtocol.HTTPS, httpsProbe.protocol());
+        Assertions.assertEquals(443, httpsProbe.port());
+        Assertions.assertEquals(60, httpsProbe.intervalInSeconds());
+        Assertions.assertEquals("/health", httpsProbe.requestPath());
 
         // delete probe
         loadBalancer.update()
@@ -74,9 +74,9 @@ public class LoadBalancerTests extends NetworkManagementTest {
 
         // verify probe deleted (and deref from rule)
         loadBalancer.refresh();
-        Assert.assertEquals(1, loadBalancer.httpProbes().size());
-        Assert.assertEquals(0, loadBalancer.httpsProbes().size());
-        Assert.assertNull(loadBalancer.loadBalancingRules().get(ruleName2).probe());
+        Assertions.assertEquals(1, loadBalancer.httpProbes().size());
+        Assertions.assertEquals(0, loadBalancer.httpsProbes().size());
+        Assertions.assertNull(loadBalancer.loadBalancingRules().get(ruleName2).probe());
 
         // add probe
         loadBalancer.update()
@@ -87,10 +87,10 @@ public class LoadBalancerTests extends NetworkManagementTest {
 
         // verify probe added
         loadBalancer.refresh();
-        Assert.assertEquals(1, loadBalancer.httpProbes().size());
-        Assert.assertEquals(1, loadBalancer.httpsProbes().size());
+        Assertions.assertEquals(1, loadBalancer.httpProbes().size());
+        Assertions.assertEquals(1, loadBalancer.httpsProbes().size());
         httpsProbe = loadBalancer.httpsProbes().get(probeName2);
-        Assert.assertEquals(0, httpsProbe.loadBalancingRules().size());
+        Assertions.assertEquals(0, httpsProbe.loadBalancingRules().size());
     }
 
     static final String subnetName = "subnet1";

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkInterfaceOperationsTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkInterfaceOperationsTests.java
@@ -206,7 +206,7 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
                 Assertions.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
                 Assertions.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
             } else {
-                Assertions.assertTrue("Unrecognized NIC ID", false);
+                Assertions.assertTrue(false, "Unrecognized NIC ID");
             }
         }
     }

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkInterfaceOperationsTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkInterfaceOperationsTests.java
@@ -12,8 +12,8 @@ import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.CreatedResources;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -92,41 +92,41 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
 
         // Verify NIC0
         nic = nics[0];
-        Assert.assertNotNull(nic);
+        Assertions.assertNotNull(nic);
         primaryIPConfig = nic.primaryIPConfiguration();
-        Assert.assertNotNull(primaryIPConfig);
-        Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-        Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+        Assertions.assertNotNull(primaryIPConfig);
+        Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+        Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
         // Verify NIC1
         nic = nics[1];
-        Assert.assertNotNull(nic);
-        Assert.assertEquals(2, nic.ipConfigurations().size());
+        Assertions.assertNotNull(nic);
+        Assertions.assertEquals(2, nic.ipConfigurations().size());
 
         primaryIPConfig = nic.primaryIPConfiguration();
-        Assert.assertNotNull(primaryIPConfig);
-        Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-        Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+        Assertions.assertNotNull(primaryIPConfig);
+        Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+        Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
         secondaryIPConfig = nic.ipConfigurations().get("nicip2");
-        Assert.assertNotNull(secondaryIPConfig);
-        Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-        Assert.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
+        Assertions.assertNotNull(secondaryIPConfig);
+        Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+        Assertions.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
 
         // Verify NIC2
         nic = nics[2];
-        Assert.assertNotNull(nic);
-        Assert.assertEquals(2, nic.ipConfigurations().size());
+        Assertions.assertNotNull(nic);
+        Assertions.assertEquals(2, nic.ipConfigurations().size());
 
         primaryIPConfig = nic.primaryIPConfiguration();
-        Assert.assertNotNull(primaryIPConfig);
-        Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-        Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+        Assertions.assertNotNull(primaryIPConfig);
+        Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+        Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
         secondaryIPConfig = nic.ipConfigurations().get("nicip2");
-        Assert.assertNotNull(secondaryIPConfig);
-        Assert.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
-        Assert.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
+        Assertions.assertNotNull(secondaryIPConfig);
+        Assertions.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
+        Assertions.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
 
         nic = null;
 
@@ -166,47 +166,47 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
 
         // Verify updated NICs
         for (NetworkInterface n : updatedNics) {
-            Assert.assertNotNull(n);
+            Assertions.assertNotNull(n);
             if (n.id().equalsIgnoreCase(nics[0].id())) {
                 // Verify NIC0
-                Assert.assertEquals(2, n.ipConfigurations().size());
+                Assertions.assertEquals(2, n.ipConfigurations().size());
 
                 primaryIPConfig = n.primaryIPConfiguration();
-                Assert.assertNotNull(primaryIPConfig);
-                Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-                Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+                Assertions.assertNotNull(primaryIPConfig);
+                Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+                Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
                 secondaryIPConfig = n.ipConfigurations().get("nicip2");
-                Assert.assertNotNull(secondaryIPConfig);
-                Assert.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
-                Assert.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
+                Assertions.assertNotNull(secondaryIPConfig);
+                Assertions.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
+                Assertions.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
 
             } else if (n.id().equals(nics[1].id())) {
                 // Verify NIC1
-                Assert.assertEquals(1, n.ipConfigurations().size());
+                Assertions.assertEquals(1, n.ipConfigurations().size());
                 primaryIPConfig = n.primaryIPConfiguration();
-                Assert.assertNotNull(primaryIPConfig);
-                Assert.assertNotEquals("nicip2", primaryIPConfig.name());
-                Assert.assertTrue("subnet2".equalsIgnoreCase(primaryIPConfig.subnetName()));
-                Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+                Assertions.assertNotNull(primaryIPConfig);
+                Assertions.assertNotEquals("nicip2", primaryIPConfig.name());
+                Assertions.assertTrue("subnet2".equalsIgnoreCase(primaryIPConfig.subnetName()));
+                Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
             } else if (n.id().equals(nics[2].id())) {
                 // Verify NIC
-                Assert.assertEquals(2, n.ipConfigurations().size());
+                Assertions.assertEquals(2, n.ipConfigurations().size());
 
                 primaryIPConfig = n.primaryIPConfiguration();
-                Assert.assertNotNull(primaryIPConfig);
-                Assert.assertNotEquals("nicip2", primaryIPConfig.name());
-                Assert.assertNotEquals("nicip3", primaryIPConfig.name());
-                Assert.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
-                Assert.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
+                Assertions.assertNotNull(primaryIPConfig);
+                Assertions.assertNotEquals("nicip2", primaryIPConfig.name());
+                Assertions.assertNotEquals("nicip3", primaryIPConfig.name());
+                Assertions.assertTrue("subnet1".equalsIgnoreCase(primaryIPConfig.subnetName()));
+                Assertions.assertTrue(network.id().equalsIgnoreCase(primaryIPConfig.networkId()));
 
                 secondaryIPConfig = n.ipConfigurations().get("nicip3");
-                Assert.assertNotNull(secondaryIPConfig);
-                Assert.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
-                Assert.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
+                Assertions.assertNotNull(secondaryIPConfig);
+                Assertions.assertTrue("subnet1".equalsIgnoreCase(secondaryIPConfig.subnetName()));
+                Assertions.assertTrue(network.id().equalsIgnoreCase(secondaryIPConfig.networkId()));
             } else {
-                Assert.assertTrue("Unrecognized NIC ID", false);
+                Assertions.assertTrue("Unrecognized NIC ID", false);
             }
         }
     }
@@ -268,7 +268,7 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
                 networkInterface3Creatable,
                 networkInterface4Creatable).values();
 
-        Assert.assertTrue(batchNics.size() == 4);
+        Assertions.assertTrue(batchNics.size() == 4);
         HashMap<String, Boolean> found = new LinkedHashMap<>();
         for (NetworkInterface nic : batchNics) {
             if (nic.name().equalsIgnoreCase(nic1Name)) {
@@ -284,7 +284,7 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
                 found.put(nic4Name, true);
             }
         }
-        Assert.assertTrue(found.size() == 4);
+        Assertions.assertTrue(found.size() == 4);
     }
 
     @Test
@@ -316,7 +316,7 @@ public class NetworkInterfaceOperationsTests extends NetworkManagementTest {
         } catch (InterruptedException exception) {
             throw new RuntimeException(exception);
         }
-        Assert.assertEquals(counter.intValue(), 1);
+        Assertions.assertEquals(counter.intValue(), 1);
     }
 
 }

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkUsageOperationsTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkUsageOperationsTests.java
@@ -9,8 +9,8 @@ package com.azure.management.network;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -18,7 +18,7 @@ public class NetworkUsageOperationsTests extends NetworkManagementTest {
     @Test
     public void canListNetworkUsages() throws Exception {
         PagedIterable<NetworkUsage> usages = networkManager.usages().listByRegion(Region.US_EAST);
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(usages) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(usages) > 0);
     }
 
     @Override

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkWatcherTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/NetworkWatcherTests.java
@@ -8,9 +8,9 @@ package com.azure.management.network;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.List;
 public class NetworkWatcherTests extends NetworkManagementTest {
 
     @Test
-    @Ignore("https://github.com/Azure/azure-rest-api-specs/issues/7579")
+    @Disabled("https://github.com/Azure/azure-rest-api-specs/issues/7579")
     public void canListProvidersAndGetReachabilityReport() throws Exception {
         String nwName = SdkContext.randomResourceName("nw", 8);
         Region region = Region.US_WEST;
@@ -36,17 +36,17 @@ public class NetworkWatcherTests extends NetworkManagementTest {
                 .create();
         AvailableProviders providers = nw.availableProviders()
                 .execute();
-        Assert.assertTrue(providers.providersByCountry().size() > 1);
-        Assert.assertNotNull(providers.providersByCountry().get("United States"));
+        Assertions.assertTrue(providers.providersByCountry().size() > 1);
+        Assertions.assertNotNull(providers.providersByCountry().get("United States"));
 
         providers = nw.availableProviders()
                 .withAzureLocation("West US")
                 .withCountry("United States")
                 .withState("washington")
                 .execute();
-        Assert.assertEquals(1, providers.providersByCountry().size());
-        Assert.assertEquals("washington", providers.providersByCountry().get("United States").states().get(0).stateName());
-        Assert.assertTrue(providers.providersByCountry().get("United States").states().get(0).providers().size() > 0);
+        Assertions.assertEquals(1, providers.providersByCountry().size());
+        Assertions.assertEquals("washington", providers.providersByCountry().get("United States").states().get(0).stateName());
+        Assertions.assertTrue(providers.providersByCountry().get("United States").states().get(0).providers().size() > 0);
 
         String localProvider = providers.providersByCountry().get("United States").states().get(0).providers().get(0);
         AzureReachabilityReport report = nw.azureReachabilityReport()
@@ -56,7 +56,7 @@ public class NetworkWatcherTests extends NetworkManagementTest {
                 .withProviders(localProvider)
                 .withAzureLocations("West US")
                 .execute();
-        Assert.assertEquals("State", report.aggregationLevel());
-        Assert.assertTrue(report.reachabilityReport().size() > 0);
+        Assertions.assertEquals("State", report.aggregationLevel());
+        Assertions.assertTrue(report.reachabilityReport().size() > 0);
     }
 }

--- a/azure-mgmt-network/src/test/java/com/azure/management/network/RouteFilterTests.java
+++ b/azure-mgmt-network/src/test/java/com/azure/management/network/RouteFilterTests.java
@@ -10,8 +10,8 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -26,17 +26,17 @@ public class RouteFilterTests extends NetworkManagementTest {
                 .withNewResourceGroup(RG_NAME)
                 .withTag("tag1", "value1")
                 .create();
-        Assert.assertEquals("value1", routeFilter.tags().get("tag1"));
+        Assertions.assertEquals("value1", routeFilter.tags().get("tag1"));
 
         PagedIterable<RouteFilter> rfList = networkManager.routeFilters().list();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(rfList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(rfList) > 0);
 
         rfList = networkManager.routeFilters().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(rfList) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(rfList) > 0);
 
         networkManager.routeFilters().deleteById(routeFilter.id());
         rfList = networkManager.routeFilters().listByResourceGroup(RG_NAME);
-        Assert.assertTrue(TestUtilities.isEmpty(rfList));
+        Assertions.assertTrue(TestUtilities.isEmpty(rfList));
     }
 
     @Test
@@ -53,9 +53,9 @@ public class RouteFilterTests extends NetworkManagementTest {
                 .withBgpCommunity("12076:51004")
                 .attach()
                 .apply();
-        Assert.assertEquals(1, routeFilter.rules().size());
-        Assert.assertEquals(1, routeFilter.rules().get(ruleName).communities().size());
-        Assert.assertEquals("12076:51004", routeFilter.rules().get(ruleName).communities().get(0));
+        Assertions.assertEquals(1, routeFilter.rules().size());
+        Assertions.assertEquals(1, routeFilter.rules().get(ruleName).communities().size());
+        Assertions.assertEquals("12076:51004", routeFilter.rules().get(ruleName).communities().get(0));
 
         routeFilter.update()
                 .updateRule(ruleName)
@@ -63,7 +63,7 @@ public class RouteFilterTests extends NetworkManagementTest {
                 .denyAccess()
                 .parent()
                 .apply();
-        Assert.assertEquals(2, routeFilter.rules().get(ruleName).communities().size());
-        Assert.assertEquals(Access.DENY, routeFilter.rules().get(ruleName).access());
+        Assertions.assertEquals(2, routeFilter.rules().get(ruleName).communities().size());
+        Assertions.assertEquals(Access.DENY, routeFilter.rules().get(ruleName).access());
     }
 }

--- a/azure-mgmt-network/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-network/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-mgmt-resources/pom.xml
+++ b/azure-mgmt-resources/pom.xml
@@ -66,8 +66,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/DeploymentsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/DeploymentsTests.java
@@ -11,9 +11,9 @@ import com.azure.management.RestClient;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DeploymentsTests extends ResourceManagerTestBase {
     private static ResourceGroups resourceGroups;
@@ -64,25 +64,25 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 found = true;
             }
         }
-        Assert.assertTrue(found);
+        Assertions.assertTrue(found);
         // Check existence
-        Assert.assertTrue(resourceClient.deployments().checkExistence(rgName, dpName));
+        Assertions.assertTrue(resourceClient.deployments().checkExistence(rgName, dpName));
 
         // Get
         Deployment deployment = resourceClient.deployments().getByResourceGroup(rgName, dpName);
-        Assert.assertNotNull(deployment);
-        Assert.assertEquals("Succeeded", deployment.provisioningState());
+        Assertions.assertNotNull(deployment);
+        Assertions.assertEquals("Succeeded", deployment.provisioningState());
         GenericResource generic = resourceClient.genericResources().get(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15");
-        Assert.assertNotNull(generic);
+        Assertions.assertNotNull(generic);
         // Export
-        Assert.assertNotNull(deployment.exportTemplate().templateAsJson());
+        Assertions.assertNotNull(deployment.exportTemplate().templateAsJson());
         // Export from resource group
-        Assert.assertNotNull(resourceGroup.exportTemplate(ResourceGroupExportTemplateOptions.INCLUDE_BOTH));
+        Assertions.assertNotNull(resourceGroup.exportTemplate(ResourceGroupExportTemplateOptions.INCLUDE_BOTH));
         // Deployment operations
         PagedIterable<DeploymentOperation> operations = deployment.deploymentOperations().list();
-        Assert.assertEquals(4, TestUtilities.getPagedIterableSize(operations));
+        Assertions.assertEquals(4, TestUtilities.getPagedIterableSize(operations));
         DeploymentOperation op = deployment.deploymentOperations().getById(operations.iterator().next().operationId());
-        Assert.assertNotNull(op);
+        Assertions.assertNotNull(op);
         resourceClient.genericResources().delete(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15");
     }
 
@@ -106,12 +106,12 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 found = true;
             }
         }
-        Assert.assertTrue(found);
+        Assertions.assertTrue(found);
 
         // Get
         Deployment deployment = resourceClient.deployments().getByResourceGroup(rgName, dpName);
-        Assert.assertNotNull(deployment);
-        Assert.assertEquals("Succeeded", deployment.provisioningState());
+        Assertions.assertNotNull(deployment);
+        Assertions.assertEquals("Succeeded", deployment.provisioningState());
 
         //What if
         WhatIfOperationResult result = deployment.prepareWhatIf()
@@ -119,9 +119,9 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 .withWhatIfTemplateLink(templateUri, contentVersion)
                 .whatIf();
 
-        Assert.assertEquals("Succeeded", result.status());
+        Assertions.assertEquals("Succeeded", result.status());
         // FIXME: regression?
-        // Assert.assertEquals(3, result.changes().size());
+        // Assertions.assertEquals(3, result.changes().size());
 
         resourceClient.genericResources().delete(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15");
     }
@@ -146,12 +146,12 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 found = true;
             }
         }
-        Assert.assertTrue(found);
+        Assertions.assertTrue(found);
 
         // Get
         Deployment deployment = resourceClient.deployments().getByResourceGroup(rgName, dpName);
-        Assert.assertNotNull(deployment);
-        Assert.assertEquals("Succeeded", deployment.provisioningState());
+        Assertions.assertNotNull(deployment);
+        Assertions.assertEquals("Succeeded", deployment.provisioningState());
 
         //What if
         WhatIfOperationResult result = deployment.prepareWhatIf()
@@ -160,15 +160,15 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 .withWhatIfTemplateLink(blankTemplateUri, contentVersion)
                 .whatIfAtSubscriptionScope();
 
-        Assert.assertEquals("Succeeded", result.status());
+        Assertions.assertEquals("Succeeded", result.status());
         // FIXME: Regression?
-        // Assert.assertEquals(0, result.changes().size());
+        // Assertions.assertEquals(0, result.changes().size());
 
         resourceClient.genericResources().delete(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15");
     }
 
     @Test
-    @Ignore("deployment.cancel() doesn't throw but provisining state says Running not Cancelled...")
+    @Disabled("deployment.cancel() doesn't throw but provisining state says Running not Cancelled...")
     public void canCancelVirtualNetworkDeployment() throws Exception {
         final String dp = "dpB" + testId;
 
@@ -181,12 +181,12 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 .withMode(DeploymentMode.COMPLETE)
                 .beginCreate();
         Deployment deployment = resourceClient.deployments().getByResourceGroup(rgName, dp);
-        Assert.assertEquals(dp, deployment.name());
+        Assertions.assertEquals(dp, deployment.name());
         // Cancel
         deployment.cancel();
         deployment = resourceClient.deployments().getByResourceGroup(rgName, dp);
-        Assert.assertEquals("Canceled", deployment.provisioningState());
-        Assert.assertFalse(resourceClient.genericResources().checkExistence(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15"));
+        Assertions.assertEquals("Canceled", deployment.provisioningState());
+        Assertions.assertFalse(resourceClient.genericResources().checkExistence(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet1", "2015-06-15"));
     }
 
     @Test
@@ -202,12 +202,12 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 .withMode(DeploymentMode.COMPLETE)
                 .beginCreate();
         Deployment deployment = resourceClient.deployments().getByResourceGroup(rgName, dp);
-        Assert.assertEquals(createdDeployment.correlationId(), deployment.correlationId());
-        Assert.assertEquals(dp, deployment.name());
+        Assertions.assertEquals(createdDeployment.correlationId(), deployment.correlationId());
+        Assertions.assertEquals(dp, deployment.name());
         // Cancel
         deployment.cancel();
         deployment = resourceClient.deployments().getByResourceGroup(rgName, dp);
-        Assert.assertEquals("Canceled", deployment.provisioningState());
+        Assertions.assertEquals("Canceled", deployment.provisioningState());
         // Update
         deployment.update()
                 .withTemplate(updateTemplate)
@@ -215,10 +215,10 @@ public class DeploymentsTests extends ResourceManagerTestBase {
                 .withMode(DeploymentMode.INCREMENTAL)
                 .apply();
         deployment = resourceClient.deployments().getByResourceGroup(rgName, dp);
-        Assert.assertEquals(DeploymentMode.INCREMENTAL, deployment.mode());
-        Assert.assertEquals("Succeeded", deployment.provisioningState());
+        Assertions.assertEquals(DeploymentMode.INCREMENTAL, deployment.mode());
+        Assertions.assertEquals("Succeeded", deployment.provisioningState());
         GenericResource genericVnet = resourceClient.genericResources().get(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet2", "2015-06-15");
-        Assert.assertNotNull(genericVnet);
+        Assertions.assertNotNull(genericVnet);
         resourceClient.genericResources().delete(rgName, "Microsoft.Network", "", "virtualnetworks", "VNet2", "2015-06-15");
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/GenericResourcesTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/GenericResourcesTests.java
@@ -14,8 +14,8 @@ import com.azure.management.resources.fluentcore.utils.SdkContext;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GenericResourcesTests extends ResourceManagerTestBase {
     private static ResourceGroups resourceGroups;
@@ -70,21 +70,21 @@ public class GenericResourcesTests extends ResourceManagerTestBase {
                 break;
             }
         }
-        Assert.assertTrue(found);
+        Assertions.assertTrue(found);
         // Get
-        Assert.assertNotNull(genericResources.get(rgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
+        Assertions.assertNotNull(genericResources.get(rgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
         // Move
         genericResources.moveResources(rgName, resourceGroups.getByName(newRgName), Arrays.asList(resource.id()));
-        Assert.assertFalse(genericResources.checkExistence(rgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
+        Assertions.assertFalse(genericResources.checkExistence(rgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
         resource = genericResources.get(newRgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion());
-        Assert.assertNotNull(resource);
+        Assertions.assertNotNull(resource);
         // Update
         resource.update()
                 .withProperties(new ObjectMapper().readTree("{\"SiteMode\":\"Limited\",\"ComputeMode\":\"Dynamic\"}"))
                 .apply();
         // Delete
         genericResources.deleteById(resource.id());
-        Assert.assertFalse(genericResources.checkExistence(newRgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
-        Assert.assertFalse(genericResources.checkExistenceById(resource.id()));
+        Assertions.assertFalse(genericResources.checkExistence(newRgName, resource.resourceProviderNamespace(), resource.parentResourcePath(), resource.resourceType(), resource.name(), resource.apiVersion()));
+        Assertions.assertFalse(genericResources.checkExistenceById(resource.id()));
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/GroupPagedListTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/GroupPagedListTests.java
@@ -14,8 +14,8 @@
 //import com.azure.management.resources.implementation.ResourceGroupInner;
 //import com.microsoft.rest.ServiceCallback;
 //import com.microsoft.rest.ServiceFuture;
-//import org.junit.Assert;
-//import org.junit.Test;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
 //import rx.Observable;
 //
 //import java.util.ArrayList;
@@ -92,7 +92,7 @@
 //        PagedList<ResourceGroup> pagedResourceList = new PagedList<ResourceGroup>(pages.get(0)) {
 //            @Override
 //            public Page<ResourceGroup> nextPage(String nextLink) {
-//                Assert.assertSame(itr.next(), nextLink);
+//                Assertions.assertSame(itr.next(), nextLink);
 //                int index = Integer.parseInt(nextLink);
 //                return pages.get(index);
 //            }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/PolicyTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/PolicyTests.java
@@ -12,13 +12,13 @@
 //import com.azure.management.resources.fluentcore.arm.Region;
 //import com.azure.management.resources.implementation.ResourceManager;
 //import com.microsoft.rest.RestClient;
-//import org.junit.Assert;
-//import org.junit.Ignore;
-//import org.junit.Test;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.Test;
 //
 //import java.util.List;
 //
-//import static org.junit.Assert.fail;
+//import static org.junit.Assertions.fail;
 //
 //public class PolicyTests extends TestBase {
 //    protected static ResourceManager resourceManager;
@@ -37,7 +37,7 @@
 //    }
 //
 //    @Test
-//    @Ignore("Not authorized for scope - 'Microsoft.Authorization/policydefinitions/write'")
+//    @Disabled("Not authorized for scope - 'Microsoft.Authorization/policydefinitions/write'")
 //    public void canCRUDPolicyDefinition() throws Exception {
 //        // Create
 //        PolicyDefinition definition = resourceManager.policyDefinitions().define("policy1")
@@ -46,10 +46,10 @@
 //                .withDisplayName("My Policy")
 //                .withDescription("This is my policy")
 //                .create();
-//        Assert.assertEquals("policy1", definition.name());
-//        Assert.assertEquals(PolicyType.CUSTOM, definition.policyType());
-//        Assert.assertEquals("My Policy", definition.displayName());
-//        Assert.assertEquals("This is my policy", definition.description());
+//        Assertions.assertEquals("policy1", definition.name());
+//        Assertions.assertEquals(PolicyType.CUSTOM, definition.policyType());
+//        Assertions.assertEquals("My Policy", definition.displayName());
+//        Assertions.assertEquals("This is my policy", definition.description());
 //        // List
 //        List<PolicyDefinition> definitions = resourceManager.policyDefinitions().list();
 //        boolean found = false;
@@ -58,17 +58,17 @@
 //                found = true;
 //            }
 //        }
-//        Assert.assertTrue(found);
+//        Assertions.assertTrue(found);
 //        // Get
 //        definition = resourceManager.policyDefinitions().getByName("policy1");
-//        Assert.assertNotNull(definition);
-//        Assert.assertEquals("My Policy", definition.displayName());
+//        Assertions.assertNotNull(definition);
+//        Assertions.assertEquals("My Policy", definition.displayName());
 //        // Delete
 //        resourceManager.policyDefinitions().deleteById(definition.id());
 //    }
 //
 //    @Test
-//    @Ignore("Not authorized for scope - 'Microsoft.Authorization/policydefinitions/write'")
+//    @Disabled("Not authorized for scope - 'Microsoft.Authorization/policydefinitions/write'")
 //    public void canCRUDPolicyAssignment() throws Exception {
 //        // Create definition
 //        PolicyDefinition definition = resourceManager.policyDefinitions().define("policy1")
@@ -101,7 +101,7 @@
 //            fail();
 //        } catch (CloudException ce) {
 //            // expected
-//            Assert.assertTrue(ce.getMessage().contains("disallowed"));
+//            Assertions.assertTrue(ce.getMessage().contains("disallowed"));
 //        }
 //        // Delete
 //        resourceManager.resourceGroups().define(group.name());

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/ProvidersTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/ProvidersTests.java
@@ -12,8 +12,8 @@ import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.azure.management.resources.implementation.ResourceManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -35,7 +35,7 @@ public class ProvidersTests extends TestBase {
     public void canUnregisterAndRegisterProvider() throws Exception {
         PagedIterable<Provider> providers = resourceManager.providers().list();
         int size = TestUtilities.getPagedIterableSize(providers);
-        Assert.assertTrue(size > 0);
+        Assertions.assertTrue(size > 0);
         Provider provider = providers.iterator().next();
         resourceManager.providers().unregister(provider.namespace());
         provider = resourceManager.providers().getByName(provider.namespace());
@@ -49,8 +49,8 @@ public class ProvidersTests extends TestBase {
             SdkContext.sleep(5 * 1000);
             provider = resourceManager.providers().getByName(provider.namespace());
         }
-        Assert.assertEquals("Registered", provider.registrationState());
+        Assertions.assertEquals("Registered", provider.registrationState());
         List<ProviderResourceType> resourceTypes = provider.resourceTypes();
-        Assert.assertTrue(resourceTypes.size() > 0);
+        Assertions.assertTrue(resourceTypes.size() > 0);
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceGroupsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceGroupsTests.java
@@ -9,8 +9,8 @@ package com.azure.management.resources;
 import com.azure.management.RestClient;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ResourceGroupsTests extends ResourceManagerTestBase {
     private static ResourceGroups resourceGroups;
@@ -39,26 +39,26 @@ public class ResourceGroupsTests extends ResourceManagerTestBase {
                 break;
             }
         }
-        Assert.assertNotNull(groupResult);
-        Assert.assertEquals("finance", groupResult.tags().get("department"));
-        Assert.assertEquals("tagvalue", groupResult.tags().get("tagname"));
-        Assert.assertTrue(region.name().equalsIgnoreCase(groupResult.regionName()));
+        Assertions.assertNotNull(groupResult);
+        Assertions.assertEquals("finance", groupResult.tags().get("department"));
+        Assertions.assertEquals("tagvalue", groupResult.tags().get("tagname"));
+        Assertions.assertTrue(region.name().equalsIgnoreCase(groupResult.regionName()));
 
         // Check existence
-        Assert.assertTrue(resourceGroups.contain(rgName));
+        Assertions.assertTrue(resourceGroups.contain(rgName));
 
         // Get
         ResourceGroup getGroup = resourceGroups.getByName(rgName);
-        Assert.assertNotNull(getGroup);
-        Assert.assertEquals(rgName, getGroup.name());
+        Assertions.assertNotNull(getGroup);
+        Assertions.assertEquals(rgName, getGroup.name());
         // Update
         ResourceGroup updatedGroup = getGroup.update()
                 .withTag("tag1", "value1")
                 .apply();
-        Assert.assertEquals("value1", updatedGroup.tags().get("tag1"));
-        Assert.assertTrue(region.name().equalsIgnoreCase(getGroup.regionName()));
+        Assertions.assertEquals("value1", updatedGroup.tags().get("tag1"));
+        Assertions.assertTrue(region.name().equalsIgnoreCase(getGroup.regionName()));
         // Delete
         resourceGroups.deleteByName(rgName);
-        // Assert.assertFalse(resourceGroups.checkExistence(rgName));
+        // Assertions.assertFalse(resourceGroups.checkExistence(rgName));
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceIdTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceIdTests.java
@@ -7,8 +7,8 @@
 package com.azure.management.resources;
 
 import com.azure.management.resources.fluentcore.arm.ResourceId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class to test ResourceId class.
@@ -20,59 +20,59 @@ public class ResourceIdTests {
     public void resourceIdForTopLevelResourceWorksFine() {
         ResourceId resourceId = ResourceId.fromString("/subscriptions/9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef/resourceGroups/resourceGroupName/providers/Microsoft.Network/applicationGateways/something");
 
-        Assert.assertEquals(resourceId.name(), "something");
-        Assert.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.resourceType(), "applicationGateways");
-        Assert.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways");
-        Assert.assertNull(resourceId.parent());
+        Assertions.assertEquals(resourceId.name(), "something");
+        Assertions.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.resourceType(), "applicationGateways");
+        Assertions.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways");
+        Assertions.assertNull(resourceId.parent());
     }
 
     @Test
     public void resourceIdForChildLevelResourceWorksFine() {
         ResourceId resourceId = ResourceId.fromString("/subscriptions/9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef/resourceGroups/resourceGroupName/providers/Microsoft.Network/applicationGateways/something/someChildType/childName");
         
-        Assert.assertEquals(resourceId.name(), "childName");
-        Assert.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.resourceType(), "someChildType");
-        Assert.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways/someChildType");
-        Assert.assertNotNull(resourceId.parent());
-        Assert.assertEquals(resourceId.parent().name(), "something");
-        Assert.assertEquals(resourceId.parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.parent().resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.parent().name(), "something");
-        Assert.assertEquals(resourceId.parent().providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.parent().resourceType(), "applicationGateways");
-        Assert.assertEquals(resourceId.parent().fullResourceType(), "Microsoft.Network/applicationGateways");
+        Assertions.assertEquals(resourceId.name(), "childName");
+        Assertions.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.resourceType(), "someChildType");
+        Assertions.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways/someChildType");
+        Assertions.assertNotNull(resourceId.parent());
+        Assertions.assertEquals(resourceId.parent().name(), "something");
+        Assertions.assertEquals(resourceId.parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.parent().resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.parent().name(), "something");
+        Assertions.assertEquals(resourceId.parent().providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.parent().resourceType(), "applicationGateways");
+        Assertions.assertEquals(resourceId.parent().fullResourceType(), "Microsoft.Network/applicationGateways");
     }
 
     @Test
     public void resourceIdForGrandChildLevelResourceWorksFine() {
         ResourceId resourceId = ResourceId.fromString("/subscriptions/9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef/resourceGroups/resourceGroupName/providers/Microsoft.Network/applicationGateways/something/someChildType/childName/grandChildType/grandChild");
 
-        Assert.assertEquals(resourceId.name(), "grandChild");
-        Assert.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.resourceType(), "grandChildType");
-        Assert.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways/someChildType/grandChildType");
-        Assert.assertNotNull(resourceId.parent());
-        Assert.assertEquals(resourceId.parent().name(), "childName");
-        Assert.assertEquals(resourceId.parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.parent().resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.parent().providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.parent().resourceType(), "someChildType");
-        Assert.assertEquals(resourceId.parent().fullResourceType(), "Microsoft.Network/applicationGateways/someChildType");
-        Assert.assertNotNull(resourceId.parent().parent());
-        Assert.assertEquals(resourceId.parent().parent().name(), "something");
-        Assert.assertEquals(resourceId.parent().parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
-        Assert.assertEquals(resourceId.parent().parent().resourceGroupName(), "resourceGroupName");
-        Assert.assertEquals(resourceId.parent().parent().name(), "something");
-        Assert.assertEquals(resourceId.parent().parent().providerNamespace(), "Microsoft.Network");
-        Assert.assertEquals(resourceId.parent().parent().resourceType(), "applicationGateways");
-        Assert.assertEquals(resourceId.parent().parent().fullResourceType(), "Microsoft.Network/applicationGateways");
+        Assertions.assertEquals(resourceId.name(), "grandChild");
+        Assertions.assertEquals(resourceId.subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.resourceType(), "grandChildType");
+        Assertions.assertEquals(resourceId.fullResourceType(), "Microsoft.Network/applicationGateways/someChildType/grandChildType");
+        Assertions.assertNotNull(resourceId.parent());
+        Assertions.assertEquals(resourceId.parent().name(), "childName");
+        Assertions.assertEquals(resourceId.parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.parent().resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.parent().providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.parent().resourceType(), "someChildType");
+        Assertions.assertEquals(resourceId.parent().fullResourceType(), "Microsoft.Network/applicationGateways/someChildType");
+        Assertions.assertNotNull(resourceId.parent().parent());
+        Assertions.assertEquals(resourceId.parent().parent().name(), "something");
+        Assertions.assertEquals(resourceId.parent().parent().subscriptionId(), "9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef");
+        Assertions.assertEquals(resourceId.parent().parent().resourceGroupName(), "resourceGroupName");
+        Assertions.assertEquals(resourceId.parent().parent().name(), "something");
+        Assertions.assertEquals(resourceId.parent().parent().providerNamespace(), "Microsoft.Network");
+        Assertions.assertEquals(resourceId.parent().parent().resourceType(), "applicationGateways");
+        Assertions.assertEquals(resourceId.parent().parent().fullResourceType(), "Microsoft.Network/applicationGateways");
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceUtilsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceUtilsTests.java
@@ -49,7 +49,7 @@ public class ResourceUtilsTests {
     }
 
     @Test
-    public void canGetDefaultScopeFromHost() throws Exception {
+    public void canGetDefaultScopeFromUrl() throws Exception {
         Assertions.assertEquals("https://graph.windows.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://graph.windows.net/random", AzureEnvironment.AZURE));
         Assertions.assertEquals("https://vault.azure.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://random.vault.azure.net/random", AzureEnvironment.AZURE));
         Assertions.assertEquals("https://api.applicationinsights.io/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://api.applicationinsights.io/random", AzureEnvironment.AZURE));

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceUtilsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/ResourceUtilsTests.java
@@ -8,35 +8,35 @@ package com.azure.management.resources;
 
 import com.azure.core.management.AzureEnvironment;
 import com.azure.management.resources.fluentcore.arm.ResourceUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ResourceUtilsTests {
     @Test
     public void canExtractGroupFromId() throws Exception {
-        Assert.assertEquals("foo", ResourceUtils.groupFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
-        Assert.assertEquals("foo", ResourceUtils.groupFromResourceId("subscriptions/123/resourcegroups/foo/providers/Microsoft.Bar/bars/bar1"));
-        Assert.assertNull(ResourceUtils.groupFromResourceId(null));
+        Assertions.assertEquals("foo", ResourceUtils.groupFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertEquals("foo", ResourceUtils.groupFromResourceId("subscriptions/123/resourcegroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertNull(ResourceUtils.groupFromResourceId(null));
     }
 
     @Test
     public void canExtractResourceProviderFromResourceId() {
-        Assert.assertEquals("Microsoft.Bar", ResourceUtils.resourceProviderFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
-        Assert.assertNull(ResourceUtils.resourceProviderFromResourceId(null));
+        Assertions.assertEquals("Microsoft.Bar", ResourceUtils.resourceProviderFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertNull(ResourceUtils.resourceProviderFromResourceId(null));
     }
 
     @Test
     public void canExtractParentPathFromId() throws Exception {
-        Assert.assertEquals("/subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1", ResourceUtils.parentResourceIdFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1/bazs/baz1"));
-        Assert.assertNull(ResourceUtils.parentResourceIdFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertEquals("/subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1", ResourceUtils.parentResourceIdFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1/bazs/baz1"));
+        Assertions.assertNull(ResourceUtils.parentResourceIdFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
     }
 
     @Test
     public void canExtractRelativePathFromId() throws Exception {
-        Assert.assertEquals("bars/bar1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
-        Assert.assertEquals("", ResourceUtils.parentRelativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
-        Assert.assertEquals("bars/bar1/providers/provider1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1/providers/provider1"));
-        Assert.assertEquals("providers/provider1/bars/bar1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/providers/provider1/bars/bar1"));
+        Assertions.assertEquals("bars/bar1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertEquals("", ResourceUtils.parentRelativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1"));
+        Assertions.assertEquals("bars/bar1/providers/provider1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/bars/bar1/providers/provider1"));
+        Assertions.assertEquals("providers/provider1/bars/bar1", ResourceUtils.relativePathFromResourceId("subscriptions/123/resourceGroups/foo/providers/Microsoft.Bar/providers/provider1/bars/bar1"));
     }
 
     @Test
@@ -45,14 +45,14 @@ public class ResourceUtilsTests {
 //        RestProxy retrofit = new RestProxyBuilder().baseUrl("http://microsoft.com").addCallAdapterFactory(RxJavaCallAdapterFactory.create()).build();
 //        byte[] content = Utils.downloadFileAsync("http://google.com/humans.txt", retrofit).toBlocking().single();
 //        String contentString = new String(content);
-//        Assert.assertNotNull(contentString);
+//        Assertions.assertNotNull(contentString);
     }
 
     @Test
     public void canGetDefaultScopeFromHost() throws Exception {
-        Assert.assertEquals("https://graph.windows.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://graph.windows.net/random", AzureEnvironment.AZURE));
-        Assert.assertEquals("https://vault.azure.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://random.vault.azure.net/random", AzureEnvironment.AZURE));
-        Assert.assertEquals("https://api.applicationinsights.io/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://api.applicationinsights.io/random", AzureEnvironment.AZURE));
-        Assert.assertEquals("https://api.loganalytics.io/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://api.loganalytics.io/random", AzureEnvironment.AZURE));
+        Assertions.assertEquals("https://graph.windows.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://graph.windows.net/random", AzureEnvironment.AZURE));
+        Assertions.assertEquals("https://vault.azure.net/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://random.vault.azure.net/random", AzureEnvironment.AZURE));
+        Assertions.assertEquals("https://api.applicationinsights.io/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://api.applicationinsights.io/random", AzureEnvironment.AZURE));
+        Assertions.assertEquals("https://api.loganalytics.io/.default", com.azure.management.Utils.getDefaultScopeFromUrl("https://api.loganalytics.io/random", AzureEnvironment.AZURE));
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/SubscriptionsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/SubscriptionsTests.java
@@ -8,8 +8,8 @@ import com.azure.management.RestClient;
 import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.implementation.ResourceManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionsTests extends TestBase {
     protected static ResourceManager.Authenticated resourceManager;
@@ -28,12 +28,12 @@ public class SubscriptionsTests extends TestBase {
     @Test
     public void canListSubscriptions() throws Exception {
         PagedIterable<Subscription> subscriptions = resourceManager.subscriptions().list();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(subscriptions) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(subscriptions) > 0);
     }
 
     @Test
     public void canListLocations() throws Exception {
         PagedIterable<Location> locations = resourceManager.subscriptions().list().iterator().next().listLocations();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(locations) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(locations) > 0);
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/TenantsTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/TenantsTests.java
@@ -12,8 +12,8 @@ import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.resources.implementation.ResourceManager;
 import com.azure.management.resources.models.TenantIdDescriptionInner;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TenantsTests extends TestBase {
     protected static ResourceManager.Authenticated resourceManager;
@@ -32,6 +32,6 @@ public class TenantsTests extends TestBase {
     @Test
     public void canListTenants() throws Exception {
         PagedIterable<TenantIdDescriptionInner> tenants = resourceManager.tenants().list();
-        Assert.assertTrue(TestUtilities.getPagedIterableSize(tenants) > 0);
+        Assertions.assertTrue(TestUtilities.getPagedIterableSize(tenants) > 0);
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/TooManyRequestsRetryInterceptorTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/TooManyRequestsRetryInterceptorTests.java
@@ -8,8 +8,8 @@
 //import com.azure.management.resources.fluentcore.arm.Region;
 //import com.azure.management.resources.fluentcore.utils.SdkContext;
 //import com.microsoft.rest.RestClient;
-//import org.junit.Ignore;
-//import org.junit.Test;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.Test;
 //import rx.Observable;
 //import rx.Subscriber;
 //import rx.functions.Func1;
@@ -40,7 +40,7 @@
 //        resourceGroups.beginDeleteByName(rgName);
 //    }
 //
-//    @Ignore("Not for every testing")
+//    @Disabled("Not for every testing")
 //    public void canGenerate429() throws Exception {
 //        Observable.range(1, 1250).flatMap(new Func1<Integer, Observable<Void>>() {
 //            @Override

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/childresource/ExternalChildResourceTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/childresource/ExternalChildResourceTests.java
@@ -35,11 +35,11 @@ public class ExternalChildResourceTests {
         //
         pullets.commitAsync()
                 .subscribe(
-                        pullet -> Assertions.assertTrue("nothing to commit onNext should not be invoked", false),
+                        pullet -> Assertions.assertTrue(false, "nothing to commit onNext should not be invoked"),
 
                         throwable -> {
                             monitor.countDown();
-                            Assertions.assertTrue("nothing to commit onError should not be invoked", false);
+                            Assertions.assertTrue(false, "nothing to commit onError should not be invoked");
                         },
                         () -> monitor.countDown()
                 );
@@ -66,7 +66,7 @@ public class ExternalChildResourceTests {
                 pullet -> changedPuppets.add(pullet),
                 throwable -> {
                     monitor.countDown();
-                    Assertions.assertTrue("onError should not be invoked", false);
+                    Assertions.assertTrue(false, "onError should not be invoked");
                 },
                 () -> monitor.countDown()
         );
@@ -115,7 +115,7 @@ public class ExternalChildResourceTests {
                         },
                         () -> {
                             monitor.countDown();
-                            Assertions.assertTrue("onCompleted should not be invoked", false);
+                            Assertions.assertTrue(false, "onCompleted should not be invoked");
                         }
                 );
 
@@ -143,7 +143,7 @@ public class ExternalChildResourceTests {
                         throwable ->
                         {
                             monitor.countDown();
-                            Assertions.assertTrue("onError should not be invoked", false);
+                            Assertions.assertTrue(false, "onError should not be invoked");
                         },
                         () -> monitor.countDown()
                 );

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/childresource/ExternalChildResourceTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/childresource/ExternalChildResourceTests.java
@@ -9,8 +9,8 @@ package com.azure.management.resources.childresource;
 import com.azure.management.resources.fluentcore.arm.models.implementation.ExternalChildResourceImpl;
 import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.Indexable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -35,11 +35,11 @@ public class ExternalChildResourceTests {
         //
         pullets.commitAsync()
                 .subscribe(
-                        pullet -> Assert.assertTrue("nothing to commit onNext should not be invoked", false),
+                        pullet -> Assertions.assertTrue("nothing to commit onNext should not be invoked", false),
 
                         throwable -> {
                             monitor.countDown();
-                            Assert.assertTrue("nothing to commit onError should not be invoked", false);
+                            Assertions.assertTrue("nothing to commit onError should not be invoked", false);
                         },
                         () -> monitor.countDown()
                 );
@@ -66,15 +66,15 @@ public class ExternalChildResourceTests {
                 pullet -> changedPuppets.add(pullet),
                 throwable -> {
                     monitor.countDown();
-                    Assert.assertTrue("onError should not be invoked", false);
+                    Assertions.assertTrue("onError should not be invoked", false);
                 },
                 () -> monitor.countDown()
         );
 
         monitor.await();
-        Assert.assertTrue(changedPuppets.size() == 3);
+        Assertions.assertTrue(changedPuppets.size() == 3);
         for (PulletImpl pullet : changedPuppets) {
-            Assert.assertTrue(pullet.pendingOperation() == ExternalChildResourceImpl.PendingOperation.None);
+            Assertions.assertTrue(pullet.pendingOperation() == ExternalChildResourceImpl.PendingOperation.None);
         }
     }
 
@@ -105,7 +105,7 @@ public class ExternalChildResourceTests {
                         throwable -> {
                             try {
                                 Throwable[] exception = throwable.getSuppressed();
-                                Assert.assertNotNull(exception);
+                                Assertions.assertNotNull(exception);
                                 for (Throwable innerThrowable : exception) {
                                     throwables.add(innerThrowable);
                                 }
@@ -115,13 +115,13 @@ public class ExternalChildResourceTests {
                         },
                         () -> {
                             monitor.countDown();
-                            Assert.assertTrue("onCompleted should not be invoked", false);
+                            Assertions.assertTrue("onCompleted should not be invoked", false);
                         }
                 );
 
         monitor.await();
-        Assert.assertTrue(throwables.size() == 2);
-        Assert.assertTrue(changedPuppets.size() == 2);
+        Assertions.assertTrue(throwables.size() == 2);
+        Assertions.assertTrue(changedPuppets.size() == 2);
     }
 
     @Test
@@ -139,11 +139,11 @@ public class ExternalChildResourceTests {
         PulletsImpl pullets = chicken.pullets();
         final CountDownLatch monitor = new CountDownLatch(1);
         pullets.commitAndGetAllAsync()
-                .subscribe(lets -> Assert.assertTrue(lets.size() == 3),
+                .subscribe(lets -> Assertions.assertTrue(lets.size() == 3),
                         throwable ->
                         {
                             monitor.countDown();
-                            Assert.assertTrue("onError should not be invoked", false);
+                            Assertions.assertTrue("onError should not be invoked", false);
                         },
                         () -> monitor.countDown()
                 );
@@ -183,13 +183,13 @@ public class ExternalChildResourceTests {
             }
         }).blockLast();
 
-        Assert.assertNotNull(foundSchool[0]);
-        Assert.assertNotNull(foundTeacher[0]);
-        Assert.assertNotNull(foundStudent[0]);
+        Assertions.assertNotNull(foundSchool[0]);
+        Assertions.assertNotNull(foundTeacher[0]);
+        Assertions.assertNotNull(foundStudent[0]);
 
-        Assert.assertTrue(foundSchool[0].isInvoked());
-        Assert.assertTrue(foundTeacher[0].isInvoked());
-        Assert.assertTrue(foundStudent[0].isInvoked());
+        Assertions.assertTrue(foundSchool[0].isInvoked());
+        Assertions.assertTrue(foundTeacher[0].isInvoked());
+        Assertions.assertTrue(foundStudent[0].isInvoked());
     }
 
     @Test
@@ -218,10 +218,10 @@ public class ExternalChildResourceTests {
                     }
                 }).blockLast();
 
-        Assert.assertNotNull(foundTeacher[0]);
-        Assert.assertNotNull(foundStudent[0]);
+        Assertions.assertNotNull(foundTeacher[0]);
+        Assertions.assertNotNull(foundStudent[0]);
 
-        Assert.assertTrue(foundTeacher[0].isInvoked());
-        Assert.assertTrue(foundStudent[0].isInvoked());
+        Assertions.assertTrue(foundTeacher[0].isInvoked());
+        Assertions.assertTrue(foundStudent[0].isInvoked());
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestBase.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestBase.java
@@ -18,12 +18,11 @@ import com.azure.management.ApplicationTokenCredential;
 import com.azure.management.RestClient;
 import com.azure.management.RestClientBuilder;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.File;
 import java.io.IOException;
@@ -129,9 +128,6 @@ public abstract class TestBase {
         return !isPlaybackMode();
     }
 
-    @Rule
-    public TestName testName = new TestName();
-
     protected InterceptorManager interceptorManager = null;
 
     private static void printThreadInfo(String what) {
@@ -140,20 +136,20 @@ public abstract class TestBase {
         System.out.println(String.format("\n***\n*** [%s:%s] - %s\n***\n", name, id, what));
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws IOException {
         printThreadInfo("beforeClass");
         initTestMode();
         initPlaybackUri();
     }
 
-    @Before
-    public void beforeTest() throws IOException {
-        printThreadInfo(String.format("%s: %s", "beforeTest", testName.getMethodName()));
+    @BeforeEach
+    public void beforeTest(TestInfo testInfo) throws IOException {
+        printThreadInfo(String.format("%s: %s", "beforeTest", testInfo.getDisplayName()));
         final String skipMessage = shouldCancelTest(isPlaybackMode());
-        Assume.assumeTrue(skipMessage, skipMessage == null);
+        Assumptions.assumeTrue(skipMessage == null, skipMessage);
 
-        interceptorManager = InterceptorManager.create(testName.getMethodName(), testMode);
+        interceptorManager = InterceptorManager.create(testInfo.getDisplayName(), testMode);
 
         ApplicationTokenCredential credentials;
         RestClient restClient;
@@ -216,7 +212,7 @@ public abstract class TestBase {
         initializeClients(restClient, defaultSubscription, credentials.getDomain());
     }
 
-    @After
+    @AfterEach
     public void afterTest() throws IOException {
         if (shouldCancelTest(isPlaybackMode()) != null) {
             return;

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestBase.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestBase.java
@@ -145,11 +145,12 @@ public abstract class TestBase {
 
     @BeforeEach
     public void beforeTest(TestInfo testInfo) throws IOException {
-        printThreadInfo(String.format("%s: %s", "beforeTest", testInfo.getDisplayName()));
+        String testMothodName = testInfo.getTestMethod().get().getName();
+        printThreadInfo(String.format("%s: %s", "beforeTest", testMothodName));
         final String skipMessage = shouldCancelTest(isPlaybackMode());
         Assumptions.assumeTrue(skipMessage == null, skipMessage);
 
-        interceptorManager = InterceptorManager.create(testInfo.getDisplayName(), testMode);
+        interceptorManager = InterceptorManager.create(testMothodName, testMode);
 
         ApplicationTokenCredential credentials;
         RestClient restClient;

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestResourceProviderRegistration.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/core/TestResourceProviderRegistration.java
@@ -6,8 +6,8 @@
 
 package com.azure.management.resources.core;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,7 +18,7 @@ public class TestResourceProviderRegistration {
         String error = "{\"error\":{\"code\":\"MissingSubscriptionRegistration\",\"message\":\"The subscription is not registered to use namespace 'Microsoft.Devices'. See https://aka.ms/rps-not-found for how to register subscriptions.\"}}";
         Matcher matcher = Pattern.compile(".*'(.*)'").matcher(error);
         matcher.find();
-        Assert.assertEquals("Microsoft.Devices", matcher.group(1));
+        Assertions.assertEquals("Microsoft.Devices", matcher.group(1));
     }
 
     @Test
@@ -26,6 +26,6 @@ public class TestResourceProviderRegistration {
         String error = "{\"error\":{\"code\":\"MissingSubscriptionRegistration\",\"message\":\"The subscription registration is in 'Unregistered' state. The subscription must be registered to use namespace 'Microsoft.Devices'. See https://aka.ms/rps-not-found for how to register subscriptions.\"}}";
         Matcher matcher = Pattern.compile(".*'(.*)'").matcher(error);
         matcher.find();
-        Assert.assertEquals("Microsoft.Devices", matcher.group(1));
+        Assertions.assertEquals("Microsoft.Devices", matcher.group(1));
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGErrorTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGErrorTests.java
@@ -7,8 +7,8 @@
 package com.azure.management.resources.fluentcore.dag;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
@@ -121,11 +121,11 @@ public class DAGErrorTests {
                     return Mono.empty();
                 }).blockLast();
 
-        Assert.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
-        Assert.assertEquals(exceptions.size(), 1);
-        Assert.assertTrue(exceptions.get(0) instanceof RuntimeException);
+        Assertions.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
+        Assertions.assertEquals(exceptions.size(), 1);
+        Assertions.assertTrue(exceptions.get(0) instanceof RuntimeException);
         RuntimeException runtimeException = (RuntimeException) exceptions.get(0);
-        Assert.assertTrue(runtimeException.getMessage().equalsIgnoreCase("B"));
+        Assertions.assertTrue(runtimeException.getMessage().equalsIgnoreCase("B"));
     }
 
     @Test
@@ -240,11 +240,11 @@ public class DAGErrorTests {
                     return Mono.empty();
                 }).blockLast();
 
-        Assert.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
-        Assert.assertEquals(exceptions.size(), 1);
-        Assert.assertTrue(exceptions.get(0) instanceof RuntimeException);
+        Assertions.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
+        Assertions.assertEquals(exceptions.size(), 1);
+        Assertions.assertTrue(exceptions.get(0) instanceof RuntimeException);
         RuntimeException runtimeException = (RuntimeException) exceptions.get(0);
-        Assert.assertTrue(runtimeException.getMessage().equalsIgnoreCase("B"));
+        Assertions.assertTrue(runtimeException.getMessage().equalsIgnoreCase("B"));
     }
 
     @Test
@@ -355,14 +355,14 @@ public class DAGErrorTests {
             return Mono.empty();
         }).blockLast();
 
-        Assert.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
-        Assert.assertEquals(exceptions.size(), 1);
-        Assert.assertTrue(exceptions.get(0) instanceof RuntimeException);
+        Assertions.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
+        Assertions.assertEquals(exceptions.size(), 1);
+        Assertions.assertTrue(exceptions.get(0) instanceof RuntimeException);
         RuntimeException compositeException = (RuntimeException) exceptions.get(0);
-        Assert.assertEquals(compositeException.getSuppressed().length, 2);
+        Assertions.assertEquals(compositeException.getSuppressed().length, 2);
         for (Throwable throwable : compositeException.getSuppressed()) {
             String message = throwable.getMessage();
-            Assert.assertTrue(message.equalsIgnoreCase("B") || message.equalsIgnoreCase("G"));
+            Assertions.assertTrue(message.equalsIgnoreCase("B") || message.equalsIgnoreCase("G"));
         }
     }
 
@@ -471,10 +471,10 @@ public class DAGErrorTests {
             return Mono.empty();
         }).blockLast();
 
-        Assert.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
-        Assert.assertEquals(exceptions.size(), 1);
-        Assert.assertTrue(exceptions.get(0) instanceof RuntimeException);
+        Assertions.assertTrue(Sets.difference(expectedToSee, seen).isEmpty());
+        Assertions.assertEquals(exceptions.size(), 1);
+        Assertions.assertTrue(exceptions.get(0) instanceof RuntimeException);
         RuntimeException runtimeException = (RuntimeException) exceptions.get(0);
-        Assert.assertTrue(runtimeException.getMessage().equalsIgnoreCase("F"));
+        Assertions.assertTrue(runtimeException.getMessage().equalsIgnoreCase("F"));
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGFinalizeTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGFinalizeTests.java
@@ -6,8 +6,8 @@
 
 package com.azure.management.resources.fluentcore.dag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * The tests for prepare stage of the graph (i.e. adding sub-graph in prepare stage).
@@ -55,7 +55,7 @@ public class DAGFinalizeTests {
 
         // Run create to set up the underlying graph nodes with dependent details
         IPizza rootPizza = pizzaF.create();
-        Assert.assertNotNull(rootPizza);
+        Assertions.assertNotNull(rootPizza);
 
         // Check dependencies and dependents
         //
@@ -64,23 +64,23 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 0 - "A"
-        Assert.assertEquals(pizzaA.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaA.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeA = pizzaA.taskGroup().getNode(pizzaA.key());
-        Assert.assertNotNull(nodeA);
-        Assert.assertEquals(nodeA.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeA.dependentKeys().size(), 2);
+        Assertions.assertNotNull(nodeA);
+        Assertions.assertEquals(nodeA.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeA.dependentKeys().size(), 2);
         for (String dependentKey : nodeA.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
                     || dependentKey.equalsIgnoreCase(pizzaC.key()));
         }
         // Level 0 - "I"
-        Assert.assertEquals(pizzaI.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaI.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeI = pizzaI.taskGroup().getNode(pizzaI.key());
-        Assert.assertNotNull(nodeI);
-        Assert.assertEquals(nodeI.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeI.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeI);
+        Assertions.assertEquals(nodeI.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeI.dependentKeys().size(), 1);
         for (String dependentKey : nodeI.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaH.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaH.key()));
         }
 
         // ----------------------------------------------------------------------------------
@@ -88,44 +88,44 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 1 - "B"
-        Assert.assertEquals(pizzaB.taskGroup().getNodes().size(), 2);
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertEquals(pizzaB.taskGroup().getNodes().size(), 2);
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaA.key()));
         TaskGroupEntry<TaskItem> nodeB = pizzaB.taskGroup().getNode(pizzaB.key());
-        Assert.assertNotNull(nodeB);
-        Assert.assertEquals(nodeB.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeB);
+        Assertions.assertEquals(nodeB.dependencyKeys().size(), 1);
         for (String dependentKey : nodeB.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
         }
-        Assert.assertEquals(nodeB.dependentKeys().size(), 2);
+        Assertions.assertEquals(nodeB.dependentKeys().size(), 2);
         for (String dependentKey : nodeB.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
                     || dependentKey.equalsIgnoreCase(pizzaE.key()));
         }
         // Level 1 - "C"
-        Assert.assertEquals(pizzaC.taskGroup().getNodes().size(), 2);
-        Assert.assertNotNull(pizzaC.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertEquals(pizzaC.taskGroup().getNodes().size(), 2);
+        Assertions.assertNotNull(pizzaC.taskGroup().getNode(pizzaA.key()));
         TaskGroupEntry<TaskItem> nodeC = pizzaC.taskGroup().getNode(pizzaC.key());
-        Assert.assertNotNull(nodeC);
-        Assert.assertEquals(nodeC.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeC);
+        Assertions.assertEquals(nodeC.dependencyKeys().size(), 1);
         for (String dependentKey : nodeC.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
         }
-        Assert.assertEquals(nodeC.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeC.dependentKeys().size(), 1);
         for (String dependentKey : nodeC.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaG.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaG.key()));
         }
         // Level 1 - "H"
-        Assert.assertEquals(pizzaH.taskGroup().getNodes().size(), 2);
-        Assert.assertNotNull(pizzaH.taskGroup().getNode(pizzaI.key()));
+        Assertions.assertEquals(pizzaH.taskGroup().getNodes().size(), 2);
+        Assertions.assertNotNull(pizzaH.taskGroup().getNode(pizzaI.key()));
         TaskGroupEntry<TaskItem> nodeH = pizzaH.taskGroup().getNode(pizzaH.key());
-        Assert.assertNotNull(nodeH);
-        Assert.assertEquals(nodeH.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeH);
+        Assertions.assertEquals(nodeH.dependencyKeys().size(), 1);
         for (String dependentKey : nodeH.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaI.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaI.key()));
         }
-        Assert.assertEquals(nodeH.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeH.dependentKeys().size(), 1);
         for (String dependentKey : nodeH.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
 
         // ----------------------------------------------------------------------------------
@@ -133,32 +133,32 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 2 - "D"
-        Assert.assertEquals(pizzaD.taskGroup().getNodes().size(), 3);
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertEquals(pizzaD.taskGroup().getNodes().size(), 3);
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaB.key()));
         TaskGroupEntry<TaskItem> nodeD = pizzaD.taskGroup().getNode(pizzaD.key());
-        Assert.assertNotNull(nodeD);
-        Assert.assertEquals(nodeD.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeD);
+        Assertions.assertEquals(nodeD.dependencyKeys().size(), 1);
         for (String dependentKey : nodeD.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key()));
         }
-        Assert.assertEquals(nodeD.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeD.dependentKeys().size(), 1);
         for (String dependentKey : nodeD.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
         // Level 2 - "G"
-        Assert.assertEquals(pizzaG.taskGroup().getNodes().size(), 3);
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertEquals(pizzaG.taskGroup().getNodes().size(), 3);
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaC.key()));
         TaskGroupEntry<TaskItem> nodeG = pizzaG.taskGroup().getNode(pizzaG.key());
-        Assert.assertNotNull(nodeG);
-        Assert.assertEquals(nodeG.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeG);
+        Assertions.assertEquals(nodeG.dependencyKeys().size(), 1);
         for (String dependentKey : nodeG.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaC.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaC.key()));
         }
-        Assert.assertEquals(nodeG.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeG.dependentKeys().size(), 1);
         for (String dependentKey : nodeG.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaE.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaE.key()));
         }
 
         // ----------------------------------------------------------------------------------
@@ -166,21 +166,21 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 3 - "E"
-        Assert.assertEquals(pizzaE.taskGroup().getNodes().size(), 5);
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaB.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaC.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaG.key()));
+        Assertions.assertEquals(pizzaE.taskGroup().getNodes().size(), 5);
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaG.key()));
         TaskGroupEntry<TaskItem> nodeE = pizzaE.taskGroup().getNode(pizzaE.key());
-        Assert.assertNotNull(nodeE);
-        Assert.assertEquals(nodeE.dependencyKeys().size(), 2);
+        Assertions.assertNotNull(nodeE);
+        Assertions.assertEquals(nodeE.dependencyKeys().size(), 2);
         for (String dependentKey : nodeE.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
                     || dependentKey.equalsIgnoreCase(pizzaG.key()));
         }
-        Assert.assertEquals(nodeE.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeE.dependentKeys().size(), 1);
         for (String dependentKey : nodeE.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
 
         // ----------------------------------------------------------------------------------
@@ -188,24 +188,24 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 4 - "F"
-        Assert.assertEquals(pizzaF.taskGroup().getNodes().size(), 9);
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaB.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaC.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaG.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaI.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaH.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaE.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaD.key()));
+        Assertions.assertEquals(pizzaF.taskGroup().getNodes().size(), 9);
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaG.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaI.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaH.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaE.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaD.key()));
         TaskGroupEntry<TaskItem> nodeF = pizzaF.taskGroup().getNode(pizzaF.key());
-        Assert.assertNotNull(nodeF);
-        Assert.assertEquals(nodeF.dependencyKeys().size(), 3);
+        Assertions.assertNotNull(nodeF);
+        Assertions.assertEquals(nodeF.dependencyKeys().size(), 3);
         for (String dependentKey : nodeF.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
                     || dependentKey.equalsIgnoreCase(pizzaE.key())
                     || dependentKey.equalsIgnoreCase(pizzaH.key()));
         }
-        Assert.assertEquals(nodeF.dependentKeys().size(), 0);
+        Assertions.assertEquals(nodeF.dependentKeys().size(), 0);
     }
 
     @Test
@@ -288,7 +288,7 @@ public class DAGFinalizeTests {
 
         // Run create to set up the underlying graph nodes with dependent details
         IPizza rootPizza = pizzaF.create();
-        Assert.assertNotNull(rootPizza);
+        Assertions.assertNotNull(rootPizza);
         // Check dependencies and dependents
         //
         // ----------------------------------------------------------------------------------
@@ -296,49 +296,49 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 0 - "M"
-        Assert.assertEquals(pizzaM.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaM.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeM = pizzaM.taskGroup().getNode(pizzaM.key());
-        Assert.assertNotNull(nodeM);
-        Assert.assertEquals(nodeM.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeM.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeM);
+        Assertions.assertEquals(nodeM.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeM.dependentKeys().size(), 1);
         for (String dependentKey : nodeM.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key()));
         }
         // Level 0 - "N"
-        Assert.assertEquals(pizzaN.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaN.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeN = pizzaN.taskGroup().getNode(pizzaN.key());
-        Assert.assertNotNull(nodeN);
-        Assert.assertEquals(nodeN.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeN.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeN);
+        Assertions.assertEquals(nodeN.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeN.dependentKeys().size(), 1);
         for (String dependentKey : nodeN.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key()));
         }
         // Level 0 - "K"
-        Assert.assertEquals(pizzaK.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaK.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeK = pizzaK.taskGroup().getNode(pizzaK.key());
-        Assert.assertNotNull(nodeK);
-        Assert.assertEquals(nodeK.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeK.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeK);
+        Assertions.assertEquals(nodeK.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeK.dependentKeys().size(), 1);
         for (String dependentKey : nodeK.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
         }
         // Level 0 - "I"
-        Assert.assertEquals(pizzaI.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaI.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeI = pizzaI.taskGroup().getNode(pizzaI.key());
-        Assert.assertNotNull(nodeI);
-        Assert.assertEquals(nodeI.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeI.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeI);
+        Assertions.assertEquals(nodeI.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeI.dependentKeys().size(), 1);
         for (String dependentKey : nodeI.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaH.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaH.key()));
         }
         // Level 0 - "Q"
-        Assert.assertEquals(pizzaQ.taskGroup().getNodes().size(), 1);
+        Assertions.assertEquals(pizzaQ.taskGroup().getNodes().size(), 1);
         TaskGroupEntry<TaskItem> nodeQ = pizzaQ.taskGroup().getNode(pizzaQ.key());
-        Assert.assertNotNull(nodeQ);
-        Assert.assertEquals(nodeQ.dependencyKeys().size(), 0);
-        Assert.assertEquals(nodeQ.dependentKeys().size(), 1);
+        Assertions.assertNotNull(nodeQ);
+        Assertions.assertEquals(nodeQ.dependencyKeys().size(), 0);
+        Assertions.assertEquals(nodeQ.dependentKeys().size(), 1);
         for (String dependentKey : nodeQ.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaP.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaP.key()));
         }
         //
         // ----------------------------------------------------------------------------------
@@ -346,80 +346,80 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 1 - "H"
-        Assert.assertEquals(pizzaH.taskGroup().getNodes().size(), 2);
-        Assert.assertNotNull(pizzaH.taskGroup().getNode(pizzaI.key()));
+        Assertions.assertEquals(pizzaH.taskGroup().getNodes().size(), 2);
+        Assertions.assertNotNull(pizzaH.taskGroup().getNode(pizzaI.key()));
         TaskGroupEntry<TaskItem> nodeH = pizzaH.taskGroup().getNode(pizzaH.key());
-        Assert.assertNotNull(nodeH);
-        Assert.assertEquals(nodeH.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeH);
+        Assertions.assertEquals(nodeH.dependencyKeys().size(), 1);
         for (String dependentKey : nodeH.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaI.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaI.key()));
         }
-        Assert.assertEquals(nodeH.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeH.dependentKeys().size(), 1);
         for (String dependentKey : nodeH.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
         // Level 1 - "J"
-        Assert.assertEquals(pizzaJ.taskGroup().getNodes().size(), 3);
-        Assert.assertNotNull(pizzaJ.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaJ.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertEquals(pizzaJ.taskGroup().getNodes().size(), 3);
+        Assertions.assertNotNull(pizzaJ.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaJ.taskGroup().getNode(pizzaN.key()));
         TaskGroupEntry<TaskItem> nodeJ = pizzaJ.taskGroup().getNode(pizzaJ.key());
-        Assert.assertNotNull(nodeJ);
-        Assert.assertEquals(nodeJ.dependencyKeys().size(), 2);
+        Assertions.assertNotNull(nodeJ);
+        Assertions.assertEquals(nodeJ.dependencyKeys().size(), 2);
         for (String dependentKey : nodeJ.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaM.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaM.key())
                     || dependentKey.equalsIgnoreCase(pizzaN.key()));
         }
-        Assert.assertEquals(nodeJ.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeJ.dependentKeys().size(), 1);
         for (String dependentKey : nodeJ.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
         }
         // Level 1 - "P"
-        Assert.assertEquals(pizzaP.taskGroup().getNodes().size(), 2);
-        Assert.assertNotNull(pizzaP.taskGroup().getNode(pizzaQ.key()));
+        Assertions.assertEquals(pizzaP.taskGroup().getNodes().size(), 2);
+        Assertions.assertNotNull(pizzaP.taskGroup().getNode(pizzaQ.key()));
         TaskGroupEntry<TaskItem> nodeP = pizzaP.taskGroup().getNode(pizzaP.key());
-        Assert.assertNotNull(nodeP);
-        Assert.assertEquals(nodeP.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeP);
+        Assertions.assertEquals(nodeP.dependencyKeys().size(), 1);
         for (String dependentKey : nodeP.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaQ.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaQ.key()));
         }
-        Assert.assertEquals(nodeP.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeP.dependentKeys().size(), 1);
         for (String dependentKey : nodeP.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaL.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaL.key()));
         }
         // ----------------------------------------------------------------------------------
         // LEVEL - 2
         // ----------------------------------------------------------------------------------
         //
         // Level 1 - "L"
-        Assert.assertEquals(pizzaL.taskGroup().getNodes().size(), 3);
-        Assert.assertNotNull(pizzaL.taskGroup().getNode(pizzaQ.key()));
-        Assert.assertNotNull(pizzaL.taskGroup().getNode(pizzaP.key()));
+        Assertions.assertEquals(pizzaL.taskGroup().getNodes().size(), 3);
+        Assertions.assertNotNull(pizzaL.taskGroup().getNode(pizzaQ.key()));
+        Assertions.assertNotNull(pizzaL.taskGroup().getNode(pizzaP.key()));
         TaskGroupEntry<TaskItem> nodeL = pizzaL.taskGroup().getNode(pizzaL.key());
-        Assert.assertNotNull(nodeL);
-        Assert.assertEquals(nodeL.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeL);
+        Assertions.assertEquals(nodeL.dependencyKeys().size(), 1);
         for (String dependentKey : nodeL.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaP.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaP.key()));
         }
-        Assert.assertEquals(nodeL.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeL.dependentKeys().size(), 1);
         for (String dependentKey : nodeL.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaG.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaG.key()));
         }
         // Level 2 - "A"
-        Assert.assertEquals(pizzaA.taskGroup().getNodes().size(), 5);
-        Assert.assertNotNull(pizzaA.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaA.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaA.taskGroup().getNode(pizzaJ.key()));
-        Assert.assertNotNull(pizzaA.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertEquals(pizzaA.taskGroup().getNodes().size(), 5);
+        Assertions.assertNotNull(pizzaA.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaA.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaA.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertNotNull(pizzaA.taskGroup().getNode(pizzaK.key()));
         TaskGroupEntry<TaskItem> nodeA = pizzaA.taskGroup().getNode(pizzaA.key());
-        Assert.assertNotNull(nodeA);
-        Assert.assertEquals(nodeA.dependencyKeys().size(), 2);
+        Assertions.assertNotNull(nodeA);
+        Assertions.assertEquals(nodeA.dependencyKeys().size(), 2);
         for (String dependentKey : nodeA.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaJ.key())
                     || dependentKey.equalsIgnoreCase(pizzaK.key()));
         }
-        Assert.assertEquals(nodeA.dependentKeys().size(), 2);
+        Assertions.assertEquals(nodeA.dependentKeys().size(), 2);
         for (String dependentKey : nodeA.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
                     || dependentKey.equalsIgnoreCase(pizzaC.key()));
         }
         // ----------------------------------------------------------------------------------
@@ -427,21 +427,21 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 3 - "B"
-        Assert.assertEquals(pizzaB.taskGroup().getNodes().size(), 6);
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaK.key()));
-        Assert.assertNotNull(pizzaB.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertEquals(pizzaB.taskGroup().getNodes().size(), 6);
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertNotNull(pizzaB.taskGroup().getNode(pizzaJ.key()));
         TaskGroupEntry<TaskItem> nodeB = pizzaB.taskGroup().getNode(pizzaB.key());
-        Assert.assertNotNull(nodeB);
-        Assert.assertEquals(nodeB.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeB);
+        Assertions.assertEquals(nodeB.dependencyKeys().size(), 1);
         for (String dependentKey : nodeB.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaA.key()));
         }
-        Assert.assertEquals(nodeB.dependentKeys().size(), 2);
+        Assertions.assertEquals(nodeB.dependentKeys().size(), 2);
         for (String dependentKey : nodeB.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
                     || dependentKey.equalsIgnoreCase(pizzaE.key()));
         }
         // ----------------------------------------------------------------------------------
@@ -449,103 +449,103 @@ public class DAGFinalizeTests {
         // ----------------------------------------------------------------------------------
         //
         // Level 4 - "D"
-        Assert.assertEquals(pizzaD.taskGroup().getNodes().size(), 7);
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaB.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaJ.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaD.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertEquals(pizzaD.taskGroup().getNodes().size(), 7);
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaD.taskGroup().getNode(pizzaK.key()));
         TaskGroupEntry<TaskItem> nodeD = pizzaD.taskGroup().getNode(pizzaD.key());
-        Assert.assertNotNull(nodeD);
-        Assert.assertEquals(nodeD.dependencyKeys().size(), 1);
+        Assertions.assertNotNull(nodeD);
+        Assertions.assertEquals(nodeD.dependencyKeys().size(), 1);
         for (String dependentKey : nodeD.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key()));
         }
-        Assert.assertEquals(nodeD.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeD.dependentKeys().size(), 1);
         for (String dependentKey : nodeD.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
 
         // Level 4 - "G"
-        Assert.assertEquals(pizzaG.taskGroup().getNodes().size(), 10);
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaC.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaQ.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaL.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaP.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaJ.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaG.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertEquals(pizzaG.taskGroup().getNodes().size(), 10);
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaQ.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaL.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaP.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaG.taskGroup().getNode(pizzaK.key()));
         TaskGroupEntry<TaskItem> nodeG = pizzaG.taskGroup().getNode(pizzaG.key());
-        Assert.assertNotNull(nodeG);
-        Assert.assertEquals(nodeG.dependencyKeys().size(), 2);
+        Assertions.assertNotNull(nodeG);
+        Assertions.assertEquals(nodeG.dependencyKeys().size(), 2);
         for (String dependentKey : nodeG.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaC.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaC.key())
                     || dependentKey.equalsIgnoreCase(pizzaL.key()));
         }
-        Assert.assertEquals(nodeG.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeG.dependentKeys().size(), 1);
         for (String dependentKey : nodeG.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaE.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaE.key()));
         }
         // ----------------------------------------------------------------------------------
         // LEVEL - 5
         // ----------------------------------------------------------------------------------
         //
         // Level 5 - "E"
-        Assert.assertEquals(pizzaE.taskGroup().getNodes().size(), 12);
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaG.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaQ.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaB.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaC.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaJ.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaL.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaK.key()));
-        Assert.assertNotNull(pizzaE.taskGroup().getNode(pizzaP.key()));
+        Assertions.assertEquals(pizzaE.taskGroup().getNodes().size(), 12);
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaG.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaQ.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaL.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertNotNull(pizzaE.taskGroup().getNode(pizzaP.key()));
         TaskGroupEntry<TaskItem> nodeE = pizzaE.taskGroup().getNode(pizzaE.key());
-        Assert.assertNotNull(nodeE);
-        Assert.assertEquals(nodeE.dependencyKeys().size(), 2);
+        Assertions.assertNotNull(nodeE);
+        Assertions.assertEquals(nodeE.dependencyKeys().size(), 2);
         for (String dependentKey : nodeE.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaB.key())
                     || dependentKey.equalsIgnoreCase(pizzaG.key()));
         }
-        Assert.assertEquals(nodeE.dependentKeys().size(), 1);
+        Assertions.assertEquals(nodeE.dependentKeys().size(), 1);
         for (String dependentKey : nodeE.dependentKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaF.key()));
         }
         // ----------------------------------------------------------------------------------
         // LEVEL - 6
         // ----------------------------------------------------------------------------------
         //
         // Level 6 - "F"
-        Assert.assertEquals(pizzaF.taskGroup().getNodes().size(), 16);
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaA.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaB.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaC.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaD.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaE.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaG.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaH.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaI.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaJ.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaK.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaL.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaM.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaN.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaP.key()));
-        Assert.assertNotNull(pizzaF.taskGroup().getNode(pizzaQ.key()));
+        Assertions.assertEquals(pizzaF.taskGroup().getNodes().size(), 16);
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaA.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaB.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaC.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaD.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaE.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaG.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaH.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaI.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaJ.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaK.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaL.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaM.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaN.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaP.key()));
+        Assertions.assertNotNull(pizzaF.taskGroup().getNode(pizzaQ.key()));
         TaskGroupEntry<TaskItem> nodeF = pizzaF.taskGroup().getNode(pizzaF.key());
-        Assert.assertNotNull(nodeF);
-        Assert.assertEquals(nodeF.dependencyKeys().size(), 3);
+        Assertions.assertNotNull(nodeF);
+        Assertions.assertEquals(nodeF.dependencyKeys().size(), 3);
         for (String dependentKey : nodeF.dependencyKeys()) {
-            Assert.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
+            Assertions.assertTrue(dependentKey.equalsIgnoreCase(pizzaD.key())
                     || dependentKey.equalsIgnoreCase(pizzaE.key())
                     || dependentKey.equalsIgnoreCase(pizzaH.key()));
         }
-        Assert.assertEquals(nodeF.dependentKeys().size(), 0);
+        Assertions.assertEquals(nodeF.dependentKeys().size(), 0);
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTest.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTest.java
@@ -6,8 +6,8 @@
 
 package com.azure.management.resources.fluentcore.dag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +74,7 @@ public class DAGraphTest {
         ItemHolder nextNode = dag.getNext();
         int i = 0;
         while (nextNode != null) {
-            Assert.assertEquals(nextNode.key(), expectedOrder.get(i));
+            Assertions.assertEquals(nextNode.key(), expectedOrder.get(i));
             dag.reportCompletion(nextNode);
             nextNode = dag.getNext();
             i++;
@@ -135,7 +135,7 @@ public class DAGraphTest {
         ItemHolder nextNode = dag.getNext();
         int i = 0;
         while (nextNode != null) {
-            Assert.assertEquals(expectedOrder.get(i), nextNode.key());
+            Assertions.assertEquals(expectedOrder.get(i), nextNode.key());
             // Process the node
             dag.reportCompletion(nextNode);
             nextNode = dag.getNext();

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTests.java
@@ -161,7 +161,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("X -> ") && exception.getMessage().contains(" -> X");
         }
-        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue(dlDetected, "Expected exception is not thrown");
 
         // ----------------------------------------------------
         /**
@@ -184,7 +184,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("B -> ") && exception.getMessage().contains(" -> B");
         }
-        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue(dlDetected, "Expected exception is not thrown");
 
         // ----------------------------------------------------
         /**
@@ -206,7 +206,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("3 -> ") && exception.getMessage().contains(" -> 3");
         }
-        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue(dlDetected, "Expected exception is not thrown");
     }
 
     @Test
@@ -475,7 +475,7 @@ public class DAGraphTests {
 
         s.removeAll(Arrays.asList(values));
         if (s.size() != 0) {
-            Assertions.assertTrue("Content of set " + set + " does not match with provided array " + Arrays.asList(values), false);
+            Assertions.assertTrue(false, "Content of set " + set + " does not match with provided array " + Arrays.asList(values));
         }
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/DAGraphTests.java
@@ -6,8 +6,8 @@
 
 package com.azure.management.resources.fluentcore.dag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ public class DAGraphTests {
         ItemHolder nextNode = dag.getNext();
         int i = 0;
         while (nextNode != null) {
-            Assert.assertEquals(nextNode.key(), expectedOrder.get(i));
+            Assertions.assertEquals(nextNode.key(), expectedOrder.get(i));
             dag.reportCompletion(nextNode);
             nextNode = dag.getNext();
             i++;
@@ -138,7 +138,7 @@ public class DAGraphTests {
         ItemHolder nextNode = dag.getNext();
         int i = 0;
         while (nextNode != null) {
-            Assert.assertEquals(expectedOrder.get(i), nextNode.key());
+            Assertions.assertEquals(expectedOrder.get(i), nextNode.key());
             // Process the node
             dag.reportCompletion(nextNode);
             nextNode = dag.getNext();
@@ -161,7 +161,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("X -> ") && exception.getMessage().contains(" -> X");
         }
-        Assert.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
 
         // ----------------------------------------------------
         /**
@@ -184,7 +184,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("B -> ") && exception.getMessage().contains(" -> B");
         }
-        Assert.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
 
         // ----------------------------------------------------
         /**
@@ -206,7 +206,7 @@ public class DAGraphTests {
         } catch (IllegalStateException exception) {
             dlDetected = exception.getMessage().contains("3 -> ") && exception.getMessage().contains(" -> 3");
         }
-        Assert.assertTrue("Expected exception is not thrown",  dlDetected);
+        Assertions.assertTrue("Expected exception is not thrown",  dlDetected);
     }
 
     @Test
@@ -302,73 +302,73 @@ public class DAGraphTests {
         // Validate nodeTables (graph1Root)
 
         ItemHolder nodeA_G1 = graph1Root.getNode("A");
-        Assert.assertEquals(1, nodeA_G1.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeA_G1.owner().nodeTable.size());
         assertExactMatch(nodeA_G1.owner().nodeTable.keySet(), new String[] {"A"});
 
         ItemHolder nodeB_G1 = graph1Root.getNode("B");
-        Assert.assertEquals(2, nodeB_G1.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeB_G1.owner().nodeTable.size());
         assertExactMatch(nodeB_G1.owner().nodeTable.keySet(), new String[] {"A", "B"});
 
         ItemHolder nodeC_G1 = graph1Root.getNode("C");
-        Assert.assertEquals(3, nodeC_G1.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeC_G1.owner().nodeTable.size());
         assertExactMatch(nodeC_G1.owner().nodeTable.keySet(), new String[] {"A", "B", "C"});
 
         //======================================================
         // Validate nodeTables (graph4Root1)
 
         ItemHolder nodeA_G41 = graph4Root1.getNode("A");
-        Assert.assertEquals(1, nodeA_G41.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeA_G41.owner().nodeTable.size());
         assertExactMatch(nodeA_G41.owner().nodeTable.keySet(), new String[] {"A"});
 
         ItemHolder nodeB_G41 = graph4Root1.getNode("B");
-        Assert.assertEquals(2, nodeB_G41.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeB_G41.owner().nodeTable.size());
         assertExactMatch(nodeB_G41.owner().nodeTable.keySet(), new String[] {"A", "B"});
 
         ItemHolder nodeC_G41 = graph4Root1.getNode("C");
-        Assert.assertEquals(3, nodeC_G41.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeC_G41.owner().nodeTable.size());
         assertExactMatch(nodeC_G41.owner().nodeTable.keySet(), new String[] {"A", "B", "C"});
 
         ItemHolder nodeG_G41 = graph4Root1.getNode("G");
-        Assert.assertEquals(1, nodeG_G41.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeG_G41.owner().nodeTable.size());
         assertExactMatch(nodeG_G41.owner().nodeTable.keySet(), new String[] {"G"});
 
         ItemHolder nodeD_G41 = graph4Root1.getNode("D");
-        Assert.assertEquals(2, nodeD_G41.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeD_G41.owner().nodeTable.size());
         assertExactMatch(nodeD_G41.owner().nodeTable.keySet(), new String[] {"D", "G"});
 
         ItemHolder nodeE_G41 = graph4Root1.getNode("E");
-        Assert.assertEquals(3, nodeE_G41.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeE_G41.owner().nodeTable.size());
         assertExactMatch(nodeE_G41.owner().nodeTable.keySet(), new String[] {"E", "D", "G"});
 
         ItemHolder nodeF_G41 = graph4Root1.getNode("F");
-        Assert.assertEquals(7, nodeF_G41.owner().nodeTable.size());
+        Assertions.assertEquals(7, nodeF_G41.owner().nodeTable.size());
         assertExactMatch(nodeF_G41.owner().nodeTable.keySet(), new String[] {"E", "F", "D", "G", "A", "B", "C"});
 
         //======================================================
         // Validate nodeTables (graph4Root2)
 
         ItemHolder nodeA_G42 = graph4Root2.getNode("A");
-        Assert.assertEquals(1, nodeA_G42.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeA_G42.owner().nodeTable.size());
         assertExactMatch(nodeA_G42.owner().nodeTable.keySet(), new String[] {"A"});
 
         ItemHolder nodeB_G42 = graph4Root2.getNode("B");
-        Assert.assertEquals(2, nodeB_G42.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeB_G42.owner().nodeTable.size());
         assertExactMatch(nodeB_G42.owner().nodeTable.keySet(), new String[] {"A", "B"});
 
         ItemHolder nodeC_G42 = graph4Root2.getNode("C");
-        Assert.assertEquals(3, nodeC_G42.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeC_G42.owner().nodeTable.size());
         assertExactMatch(nodeC_G42.owner().nodeTable.keySet(), new String[] {"A", "B", "C"});
 
         ItemHolder nodeI_G42 = graph4Root2.getNode("I");
-        Assert.assertEquals(1, nodeI_G42.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeI_G42.owner().nodeTable.size());
         assertExactMatch(nodeI_G42.owner().nodeTable.keySet(), new String[] {"I"});
 
         ItemHolder nodeH_G42 = graph4Root2.getNode("H");
-        Assert.assertEquals(2, nodeH_G42.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeH_G42.owner().nodeTable.size());
         assertExactMatch(nodeH_G42.owner().nodeTable.keySet(), new String[] {"I", "H"});
 
         ItemHolder nodeJ_G42 = graph4Root2.getNode("J");
-        Assert.assertEquals(6, nodeJ_G42.owner().nodeTable.size());
+        Assertions.assertEquals(6, nodeJ_G42.owner().nodeTable.size());
         assertExactMatch(nodeJ_G42.owner().nodeTable.keySet(), new String[] {"I", "H", "J", "A", "B", "C"});
 
         // System.out.println(combinedGraphRoot.nodeTable.keySet());
@@ -427,39 +427,39 @@ public class DAGraphTests {
         // Validate nodeTables (graph4Root1)
 
         ItemHolder nodeK_G41 = graph4Root1.getNode("K");
-        Assert.assertEquals(1, nodeK_G41.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeK_G41.owner().nodeTable.size());
         assertExactMatch(nodeK_G41.owner().nodeTable.keySet(), new String[] {"K"});
 
         ItemHolder nodeL_G41 = graph4Root1.getNode("L");
-        Assert.assertEquals(2, nodeL_G41.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeL_G41.owner().nodeTable.size());
         assertExactMatch(nodeL_G41.owner().nodeTable.keySet(), new String[] {"K", "L"});
 
         ItemHolder nodeA_G41_updated = graph4Root1.getNode("A");
-        Assert.assertEquals(3, nodeA_G41_updated.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeA_G41_updated.owner().nodeTable.size());
         assertExactMatch(nodeA_G41_updated.owner().nodeTable.keySet(), new String[] {"K", "L", "A"});
 
         ItemHolder nodeB_G41_updated = graph4Root1.getNode("B");
-        Assert.assertEquals(4, nodeB_G41_updated.owner().nodeTable.size());
+        Assertions.assertEquals(4, nodeB_G41_updated.owner().nodeTable.size());
         assertExactMatch(nodeB_G41_updated.owner().nodeTable.keySet(), new String[] {"K", "L", "A", "B"});
 
         ItemHolder nodeC_G41_updated = graph4Root1.getNode("C");
-        Assert.assertEquals(5, nodeC_G41_updated.owner().nodeTable.size());
+        Assertions.assertEquals(5, nodeC_G41_updated.owner().nodeTable.size());
         assertExactMatch(nodeC_G41_updated.owner().nodeTable.keySet(), new String[] {"K", "L", "A", "B", "C"});
 
         ItemHolder nodeF_G41_updated = graph4Root1.getNode("F");
-        Assert.assertEquals(9, nodeF_G41_updated.owner().nodeTable.size());
+        Assertions.assertEquals(9, nodeF_G41_updated.owner().nodeTable.size());
         assertExactMatch(nodeF_G41_updated.owner().nodeTable.keySet(), new String[] {"K", "L", "A", "B", "C", "F", "E", "D", "G"});
 
         ItemHolder nodeG_G41_noUpdate = graph4Root1.getNode("G");
-        Assert.assertEquals(1, nodeG_G41_noUpdate.owner().nodeTable.size());
+        Assertions.assertEquals(1, nodeG_G41_noUpdate.owner().nodeTable.size());
         assertExactMatch(nodeG_G41_noUpdate.owner().nodeTable.keySet(), new String[] {"G"});
 
         ItemHolder nodeD_G41_noUpdate = graph4Root1.getNode("D");
-        Assert.assertEquals(2, nodeD_G41_noUpdate.owner().nodeTable.size());
+        Assertions.assertEquals(2, nodeD_G41_noUpdate.owner().nodeTable.size());
         assertExactMatch(nodeD_G41_noUpdate.owner().nodeTable.keySet(), new String[] {"D", "G"});
 
         ItemHolder nodeE_G41_noUpdate = graph4Root1.getNode("E");
-        Assert.assertEquals(3, nodeE_G41_noUpdate.owner().nodeTable.size());
+        Assertions.assertEquals(3, nodeE_G41_noUpdate.owner().nodeTable.size());
         assertExactMatch(nodeE_G41_noUpdate.owner().nodeTable.keySet(), new String[] {"E", "D", "G"});
     }
 
@@ -475,7 +475,7 @@ public class DAGraphTests {
 
         s.removeAll(Arrays.asList(values));
         if (s.size() != 0) {
-            Assert.assertTrue("Content of set " + set + " does not match with provided array " + Arrays.asList(values), false);
+            Assertions.assertTrue("Content of set " + set + " does not match with provided array " + Arrays.asList(values), false);
         }
     }
 }

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ExecutableWithCreatableTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ExecutableWithCreatableTests.java
@@ -6,7 +6,7 @@
 
 package com.azure.management.resources.fluentcore.dag;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExecutableWithCreatableTests {
     @Test

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/InvokeRootTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/InvokeRootTests.java
@@ -8,8 +8,8 @@ package com.azure.management.resources.fluentcore.dag;
 
 import com.azure.management.resources.fluentcore.arm.models.HasName;
 import com.azure.management.resources.fluentcore.model.Indexable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -36,15 +36,15 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(2, seen.size());
-        Assert.assertTrue(seen.containsKey("A"));
-        Assert.assertTrue(seen.containsKey("B"));
-        Assert.assertEquals(1, (long) seen.get("A"));
-        Assert.assertEquals(1, (long) seen.get("B"));
+        Assertions.assertEquals(2, seen.size());
+        Assertions.assertTrue(seen.containsKey("A"));
+        Assertions.assertTrue(seen.containsKey("B"));
+        Assertions.assertEquals(1, (long) seen.get("A"));
+        Assertions.assertEquals(1, (long) seen.get("B"));
 
 
-        Assert.assertEquals(1, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(1, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
 
         seen.clear();
 
@@ -60,15 +60,15 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(2, seen.size());
-        Assert.assertTrue(seen.containsKey("A"));
-        Assert.assertTrue(seen.containsKey("B"));
-        Assert.assertEquals(1, (long) seen.get("A"));
-        Assert.assertEquals(1, (long) seen.get("B"));
+        Assertions.assertEquals(2, seen.size());
+        Assertions.assertTrue(seen.containsKey("A"));
+        Assertions.assertTrue(seen.containsKey("B"));
+        Assertions.assertEquals(1, (long) seen.get("A"));
+        Assertions.assertEquals(1, (long) seen.get("B"));
 
 
-        Assert.assertEquals(2, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(2, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
     }
 
     @Test
@@ -94,18 +94,18 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(3, seen.size()); // X, Y, Z
+        Assertions.assertEquals(3, seen.size()); // X, Y, Z
 
-        Assert.assertTrue(seen.containsKey("X"));
-        Assert.assertTrue(seen.containsKey("Y"));
-        Assert.assertTrue(seen.containsKey("Z"));
-        Assert.assertEquals(2, (long) seen.get("X"));   // Due to proxy two Xs
-        Assert.assertEquals(1, (long) seen.get("Y"));
-        Assert.assertEquals(1, (long) seen.get("Z"));
+        Assertions.assertTrue(seen.containsKey("X"));
+        Assertions.assertTrue(seen.containsKey("Y"));
+        Assertions.assertTrue(seen.containsKey("Z"));
+        Assertions.assertEquals(2, (long) seen.get("X"));   // Due to proxy two Xs
+        Assertions.assertEquals(1, (long) seen.get("Y"));
+        Assertions.assertEquals(1, (long) seen.get("Z"));
 
-        Assert.assertEquals(1, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
-        Assert.assertEquals(1, taskItem3.getCallCount());
+        Assertions.assertEquals(1, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(1, taskItem3.getCallCount());
 
         seen.clear();
 
@@ -121,20 +121,20 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(3, seen.size());
+        Assertions.assertEquals(3, seen.size());
 
-        Assert.assertTrue(seen.containsKey("X"));
-        Assert.assertTrue(seen.containsKey("Y"));
-        Assert.assertTrue(seen.containsKey("Z"));
-        Assert.assertEquals(2, (long) seen.get("X")); // Due to proxy two Xs
-        Assert.assertEquals(1, (long) seen.get("Y"));
-        Assert.assertEquals(1, (long) seen.get("Z"));
+        Assertions.assertTrue(seen.containsKey("X"));
+        Assertions.assertTrue(seen.containsKey("Y"));
+        Assertions.assertTrue(seen.containsKey("Z"));
+        Assertions.assertEquals(2, (long) seen.get("X")); // Due to proxy two Xs
+        Assertions.assertEquals(1, (long) seen.get("Y"));
+        Assertions.assertEquals(1, (long) seen.get("Z"));
 
         // Though proxy is the root still actual must be called twice
         //
-        Assert.assertEquals(2, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
-        Assert.assertEquals(1, taskItem3.getCallCount());
+        Assertions.assertEquals(2, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(1, taskItem3.getCallCount());
     }
 
     @Test
@@ -164,25 +164,25 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(5, seen.size());
+        Assertions.assertEquals(5, seen.size());
 
-        Assert.assertTrue(seen.containsKey("1"));
-        Assert.assertTrue(seen.containsKey("2"));
-        Assert.assertTrue(seen.containsKey("3"));
-        Assert.assertTrue(seen.containsKey("4"));
-        Assert.assertTrue(seen.containsKey("5"));
+        Assertions.assertTrue(seen.containsKey("1"));
+        Assertions.assertTrue(seen.containsKey("2"));
+        Assertions.assertTrue(seen.containsKey("3"));
+        Assertions.assertTrue(seen.containsKey("4"));
+        Assertions.assertTrue(seen.containsKey("5"));
 
-        Assert.assertEquals(2, (long) seen.get("1")); // Due to proxy two 1s
-        Assert.assertEquals(1, (long) seen.get("2"));
-        Assert.assertEquals(1, (long) seen.get("3"));
-        Assert.assertEquals(2, (long) seen.get("4")); // Due to proxy two 1s
-        Assert.assertEquals(1, (long) seen.get("5"));
+        Assertions.assertEquals(2, (long) seen.get("1")); // Due to proxy two 1s
+        Assertions.assertEquals(1, (long) seen.get("2"));
+        Assertions.assertEquals(1, (long) seen.get("3"));
+        Assertions.assertEquals(2, (long) seen.get("4")); // Due to proxy two 1s
+        Assertions.assertEquals(1, (long) seen.get("5"));
 
-        Assert.assertEquals(1, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
-        Assert.assertEquals(1, taskItem3.getCallCount());
-        Assert.assertEquals(1, taskItem4.getCallCount());
-        Assert.assertEquals(1, taskItem5.getCallCount());
+        Assertions.assertEquals(1, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(1, taskItem3.getCallCount());
+        Assertions.assertEquals(1, taskItem4.getCallCount());
+        Assertions.assertEquals(1, taskItem5.getCallCount());
 
         seen.clear();
 
@@ -198,25 +198,25 @@ public class InvokeRootTests {
                     return item;
                 }).blockLast();
 
-        Assert.assertEquals(5, seen.size());
+        Assertions.assertEquals(5, seen.size());
 
-        Assert.assertTrue(seen.containsKey("1"));
-        Assert.assertTrue(seen.containsKey("2"));
-        Assert.assertTrue(seen.containsKey("3"));
-        Assert.assertTrue(seen.containsKey("4"));
-        Assert.assertTrue(seen.containsKey("5"));
+        Assertions.assertTrue(seen.containsKey("1"));
+        Assertions.assertTrue(seen.containsKey("2"));
+        Assertions.assertTrue(seen.containsKey("3"));
+        Assertions.assertTrue(seen.containsKey("4"));
+        Assertions.assertTrue(seen.containsKey("5"));
 
-        Assert.assertEquals(2, (long) seen.get("1")); // Due to proxy two 1s
-        Assert.assertEquals(1, (long) seen.get("2"));
-        Assert.assertEquals(1, (long) seen.get("3"));
-        Assert.assertEquals(2, (long) seen.get("4")); // Due to proxy two 1s
-        Assert.assertEquals(1, (long) seen.get("5"));
+        Assertions.assertEquals(2, (long) seen.get("1")); // Due to proxy two 1s
+        Assertions.assertEquals(1, (long) seen.get("2"));
+        Assertions.assertEquals(1, (long) seen.get("3"));
+        Assertions.assertEquals(2, (long) seen.get("4")); // Due to proxy two 1s
+        Assertions.assertEquals(1, (long) seen.get("5"));
 
-        Assert.assertEquals(1, taskItem1.getCallCount());
-        Assert.assertEquals(1, taskItem2.getCallCount());
-        Assert.assertEquals(1, taskItem3.getCallCount());
-        Assert.assertEquals(2, taskItem4.getCallCount());   // Only Root must be called twice
-        Assert.assertEquals(1, taskItem5.getCallCount());
+        Assertions.assertEquals(1, taskItem1.getCallCount());
+        Assertions.assertEquals(1, taskItem2.getCallCount());
+        Assertions.assertEquals(1, taskItem3.getCallCount());
+        Assertions.assertEquals(2, taskItem4.getCallCount());   // Only Root must be called twice
+        Assertions.assertEquals(1, taskItem5.getCallCount());
     }
 
     class TestTaskItem extends IndexableTaskItem implements SupportCountingAndHasName {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PanCakeImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PanCakeImpl.java
@@ -9,7 +9,7 @@ package com.azure.management.resources.fluentcore.dag;
 import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.implementation.CreatableUpdatableImpl;
 import com.azure.management.resources.fluentcore.model.implementation.CreateUpdateTask;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -69,7 +69,7 @@ class PancakeImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assert.assertFalse("PancakeImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse("PancakeImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPancake> pancake : this.delayedPancakes) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PanCakeImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PanCakeImpl.java
@@ -69,7 +69,7 @@ class PancakeImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assertions.assertFalse("PancakeImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse(this.prepareCalled, "PancakeImpl::beforeGroupCreateOrUpdate() should not be called multiple times");
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPancake> pancake : this.delayedPancakes) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PastaImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PastaImpl.java
@@ -9,7 +9,7 @@ package com.azure.management.resources.fluentcore.dag;
 import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.implementation.CreatableUpdatableImpl;
 import com.azure.management.resources.fluentcore.model.implementation.CreateUpdateTask;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -70,7 +70,7 @@ class PastaImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assert.assertFalse("PastaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse("PastaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPasta> pancake : this.delayedPastas) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PastaImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PastaImpl.java
@@ -70,7 +70,7 @@ class PastaImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assertions.assertFalse("PastaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse(this.prepareCalled, "PastaImpl::beforeGroupCreateOrUpdate() should not be called multiple times");
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPasta> pancake : this.delayedPastas) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PizzaImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PizzaImpl.java
@@ -9,7 +9,7 @@ package com.azure.management.resources.fluentcore.dag;
 import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.implementation.CreatableUpdatableImpl;
 import com.azure.management.resources.fluentcore.model.implementation.CreateUpdateTask;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -57,7 +57,7 @@ class PizzaImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assert.assertFalse("PizzaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse("PizzaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPizza> pizza : this.delayedPizzas) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PizzaImpl.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/PizzaImpl.java
@@ -57,7 +57,7 @@ class PizzaImpl
 
     @Override
     public void beforeGroupCreateOrUpdate() {
-        Assertions.assertFalse("PizzaImpl::beforeGroupCreateOrUpdate() should not be called multiple times", this.prepareCalled);
+        Assertions.assertFalse(this.prepareCalled, "PizzaImpl::beforeGroupCreateOrUpdate() should not be called multiple times");
         prepareCalled = true;
         int oldCount = this.taskGroup().getNode(this.key()).dependencyKeys().size();
         for (Creatable<IPizza> pizza : this.delayedPizzas) {

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ProxyTaskGroupTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ProxyTaskGroupTests.java
@@ -8,8 +8,8 @@ package com.azure.management.resources.fluentcore.dag;
 
 import com.azure.management.resources.fluentcore.model.Indexable;
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -53,11 +53,11 @@ public class ProxyTaskGroupTests {
         group.invokeAsync(group.newInvocationContext())
                 .subscribe(value -> {
                     StringIndexable stringIndexable = toStringIndexable(value);
-                    Assert.assertTrue(groupItems.contains(stringIndexable.str()));
+                    Assertions.assertTrue(groupItems.contains(stringIndexable.str()));
                     groupItems.remove(stringIndexable.str());
                 });
 
-        Assert.assertEquals(0, groupItems.size());
+        Assertions.assertEquals(0, groupItems.size());
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
 
@@ -87,17 +87,17 @@ public class ProxyTaskGroupTests {
         for (TaskGroupEntry<TaskItem> entry = group.getNext(); entry != null; entry = group.getNext()) {
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group.reportCompletion(entry);
         }
 
-        Assert.assertEquals(6, seen.size()); // 1 groups with 6 nodes
+        Assertions.assertEquals(6, seen.size()); // 1 groups with 6 nodes
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D", "E", "F"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
     }
 
     @Test
@@ -177,11 +177,11 @@ public class ProxyTaskGroupTests {
         group1.invokeAsync(group1.newInvocationContext())
                 .subscribe(value -> {
                     StringIndexable stringIndexable = toStringIndexable(value);
-                    Assert.assertTrue(group1Items.contains(stringIndexable.str()));
+                    Assertions.assertTrue(group1Items.contains(stringIndexable.str()));
                     group1Items.remove(stringIndexable.str());
                 });
 
-        Assert.assertEquals(0, group1Items.size());
+        Assertions.assertEquals(0, group1Items.size());
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
 
@@ -211,17 +211,17 @@ public class ProxyTaskGroupTests {
         for (TaskGroupEntry<TaskItem> entry = group1.getNext(); entry != null; entry = group1.getNext()) {
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group1.reportCompletion(entry);
         }
 
-        Assert.assertEquals(6, seen.size()); // 1 groups with 6 nodes
+        Assertions.assertEquals(6, seen.size()); // 1 groups with 6 nodes
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D", "E", "F"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
     }
 
     @Test
@@ -303,11 +303,11 @@ public class ProxyTaskGroupTests {
         group2.invokeAsync(group2.newInvocationContext())
                 .subscribe(value -> {
                     StringIndexable stringIndexable = toStringIndexable(value);
-                    Assert.assertTrue(group2Items.contains(stringIndexable.str()));
+                    Assertions.assertTrue(group2Items.contains(stringIndexable.str()));
                     group2Items.remove(stringIndexable.str());
                 });
 
-        Assert.assertEquals(0, group2Items.size());
+        Assertions.assertEquals(0, group2Items.size());
 
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
@@ -354,21 +354,21 @@ public class ProxyTaskGroupTests {
         //
         group2.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group2.getNext(); entry != null; entry = group2.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
         }
 
-        Assert.assertEquals(12, seen.size()); // 2 groups each with 6 nodes
+        Assertions.assertEquals(12, seen.size()); // 2 groups each with 6 nodes
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
     }
 
     @Test
@@ -453,12 +453,12 @@ public class ProxyTaskGroupTests {
         group1.invokeAsync(group1.newInvocationContext())
                 .subscribe(value -> {
                     StringIndexable stringIndexable = toStringIndexable(value);
-                    Assert.assertTrue(group1Items.contains(stringIndexable.str()));
+                    Assertions.assertTrue(group1Items.contains(stringIndexable.str()));
                     group1Items.remove(stringIndexable.str());
                 }, throwable -> {
                 });
 
-        Assert.assertEquals(0, group1Items.size());
+        Assertions.assertEquals(0, group1Items.size());
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
         // NotSeen entries for group-1
@@ -509,24 +509,24 @@ public class ProxyTaskGroupTests {
         for (TaskGroupEntry<TaskItem> entry = group1.proxyTaskGroupWrapper.taskGroup().getNext();
              entry != null;
              entry = group1.proxyTaskGroupWrapper.taskGroup().getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group1.proxyTaskGroupWrapper.taskGroup().reportCompletion(entry);
         }
 
-        Assert.assertEquals(13, seen.size()); // 2 groups each with 6 nodes + 1 proxy (proxy-F)
+        Assertions.assertEquals(13, seen.size()); // 2 groups each with 6 nodes + 1 proxy (proxy-F)
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
                 "E", "F", "G", "H",
                 "I", "J", "K", "L",
                 "proxy-F"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
 
 
         group1.invokeAsync(group1.newInvocationContext())
@@ -615,11 +615,11 @@ public class ProxyTaskGroupTests {
         group2.invokeAsync(group2.newInvocationContext())
                 .subscribe(value -> {
                     StringIndexable stringIndexable = toStringIndexable(value);
-                    Assert.assertTrue(group2Items.contains(stringIndexable.str()));
+                    Assertions.assertTrue(group2Items.contains(stringIndexable.str()));
                     group2Items.remove(stringIndexable.str());
                 });
 
-        Assert.assertEquals(0, group2Items.size());
+        Assertions.assertEquals(0, group2Items.size());
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
         // NotSeen entries for group-1
@@ -668,23 +668,23 @@ public class ProxyTaskGroupTests {
         //
         group2.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group2.getNext(); entry != null; entry = group2.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
         }
 
-        Assert.assertEquals(12, seen.size()); // 2 groups each with 6 nodes no proxy
+        Assertions.assertEquals(12, seen.size()); // 2 groups each with 6 nodes no proxy
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
                 "E", "F", "G", "H",
                 "I", "J", "K", "L"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
     }
 
     @Test
@@ -761,8 +761,8 @@ public class ProxyTaskGroupTests {
         group2.addDependencyTaskGroup(group1);
 
         // Check parent
-        Assert.assertEquals(1, group1.parentDAGs.size());
-        Assert.assertTrue(group1.parentDAGs.contains(group2));
+        Assertions.assertEquals(1, group1.parentDAGs.size());
+        Assertions.assertTrue(group1.parentDAGs.contains(group2));
 
         // Prepare group-3
         //
@@ -822,11 +822,11 @@ public class ProxyTaskGroupTests {
 
         // Check parent reassignment
         //
-        Assert.assertEquals(2, group1.parentDAGs.size());
-        Assert.assertTrue(group1.parentDAGs.contains(group3));
-        Assert.assertTrue(group1.parentDAGs.contains(group1.proxyTaskGroupWrapper.taskGroup()));
-        Assert.assertEquals(1, group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.size());
-        Assert.assertTrue(group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.contains(group2));
+        Assertions.assertEquals(2, group1.parentDAGs.size());
+        Assertions.assertTrue(group1.parentDAGs.contains(group3));
+        Assertions.assertTrue(group1.parentDAGs.contains(group1.proxyTaskGroupWrapper.taskGroup()));
+        Assertions.assertEquals(1, group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.size());
+        Assertions.assertTrue(group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.contains(group2));
 
         Map<String, Set<String>> shouldNotSee = new HashMap<>();
         // NotSeen entries for group-1
@@ -894,17 +894,17 @@ public class ProxyTaskGroupTests {
         //
         group2.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group2.getNext(); entry != null; entry = group2.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
         }
 
-        Assert.assertEquals(19, seen.size()); // 3 groups each with 6 nodes + one proxy (proxy-F)
+        Assertions.assertEquals(19, seen.size()); // 3 groups each with 6 nodes + one proxy (proxy-F)
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
                 "E", "F", "G", "H",
@@ -912,7 +912,7 @@ public class ProxyTaskGroupTests {
                 "M", "N", "O", "P",
                 "Q", "proxy-F", "R"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
 
         // Test invocation order for "group-1 proxy"
         //
@@ -920,17 +920,17 @@ public class ProxyTaskGroupTests {
         TaskGroup group1Proxy = group1.proxyTaskGroupWrapper.taskGroup();
         group1Proxy.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group1Proxy.getNext(); entry != null; entry = group1Proxy.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group1Proxy.reportCompletion(entry);
         }
 
-        Assert.assertEquals(13, seen.size()); // 2 groups each with 6 nodes + one proxy (proxy-F)
+        Assertions.assertEquals(13, seen.size()); // 2 groups each with 6 nodes + one proxy (proxy-F)
         expectedToSee.clear();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
                 "E", "F", "M", "N",
@@ -1012,8 +1012,8 @@ public class ProxyTaskGroupTests {
         group2.addDependencyTaskGroup(group1);
 
         // Check parent
-        Assert.assertEquals(1, group1.parentDAGs.size());
-        Assert.assertTrue(group1.parentDAGs.contains(group2));
+        Assertions.assertEquals(1, group1.parentDAGs.size());
+        Assertions.assertTrue(group1.parentDAGs.contains(group2));
 
         // Prepare group-3
         //
@@ -1073,11 +1073,11 @@ public class ProxyTaskGroupTests {
 
         // Check parent reassignment
         //
-        Assert.assertEquals(2, group1.parentDAGs.size());
-        Assert.assertTrue(group1.parentDAGs.contains(group3));
-        Assert.assertTrue(group1.parentDAGs.contains(group1.proxyTaskGroupWrapper.taskGroup()));
-        Assert.assertEquals(1, group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.size());
-        Assert.assertTrue(group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.contains(group2));
+        Assertions.assertEquals(2, group1.parentDAGs.size());
+        Assertions.assertTrue(group1.parentDAGs.contains(group3));
+        Assertions.assertTrue(group1.parentDAGs.contains(group1.proxyTaskGroupWrapper.taskGroup()));
+        Assertions.assertEquals(1, group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.size());
+        Assertions.assertTrue(group1.proxyTaskGroupWrapper.taskGroup().parentDAGs.contains(group2));
 
 
         // Prepare group-4
@@ -1326,17 +1326,17 @@ public class ProxyTaskGroupTests {
         TaskGroup group1Proxy = group1.proxyTaskGroupWrapper.taskGroup();
         group1Proxy.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group1Proxy.getNext(); entry != null; entry = group1Proxy.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group1Proxy.reportCompletion(entry);
         }
 
-        Assert.assertEquals(26, seen.size()); // 4 groups each with 6 nodes + two proxy (proxy-F and proxy-X)
+        Assertions.assertEquals(26, seen.size()); // 4 groups each with 6 nodes + two proxy (proxy-F and proxy-X)
         Set<String> expectedToSee = new HashSet<>();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
                 "E", "F", "M", "N",
@@ -1346,7 +1346,7 @@ public class ProxyTaskGroupTests {
                 "1", "proxy-F", "2",
                 "3", "4", "5", "6"}));
         Sets.SetView<String> diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
 
         // Test invocation order for group-1 (which gets delegated to group-1's proxy).
         // This cause -> group-1, group-4 and group-5 to invoked
@@ -1355,16 +1355,16 @@ public class ProxyTaskGroupTests {
         TaskGroup group4Proxy = group4.proxyTaskGroupWrapper.taskGroup();
         group4Proxy.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group4Proxy.getNext(); entry != null; entry = group4Proxy.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group4Proxy.reportCompletion(entry);
         }
-        Assert.assertEquals(19, seen.size()); // 3 groups each with 6 nodes + one proxy
+        Assertions.assertEquals(19, seen.size()); // 3 groups each with 6 nodes + one proxy
 
         expectedToSee.clear();
         expectedToSee.addAll(Arrays.asList(new String[]{"A", "B", "C", "D",
@@ -1374,7 +1374,7 @@ public class ProxyTaskGroupTests {
                 "3", "4", "5", "6"}));
 
         diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
 
         // Test invocation order for group-2.
         // This cause -> all groups to be invoked, group-1, group-3, group-4 and group-5 to invoked
@@ -1382,11 +1382,11 @@ public class ProxyTaskGroupTests {
         seen.clear();
         group2.prepareForEnumeration();
         for (TaskGroupEntry<TaskItem> entry = group2.getNext(); entry != null; entry = group2.getNext()) {
-            Assert.assertTrue(shouldNotSee.containsKey(entry.key()));
-            Assert.assertFalse(seen.contains(entry.key()));
+            Assertions.assertTrue(shouldNotSee.containsKey(entry.key()));
+            Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assert.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
@@ -1403,7 +1403,7 @@ public class ProxyTaskGroupTests {
                 "4", "5", "6"}));
 
         diff = Sets.difference(seen, expectedToSee);
-        Assert.assertEquals(0, diff.size());
+        Assertions.assertEquals(0, diff.size());
     }
 
     @Test
@@ -1465,11 +1465,11 @@ public class ProxyTaskGroupTests {
         boolean b2 = seen.equals(new ArrayList<>(Arrays.asList(new String[]{"C", "A", "B", "C"})));
 
         if (!b1 && !b2) {
-            Assert.assertTrue("Emission order should be either [A, C, B, C] or [C, A, B, C] but got " + seen, false);
+            Assertions.assertTrue("Emission order should be either [A, C, B, C] or [C, A, B, C] but got " + seen, false);
         }
 
-        Assert.assertEquals(beforeGroupInvokeCntB[0], 1);
-        Assert.assertEquals(beforeGroupInvokeCntC[0], 1);
+        Assertions.assertEquals(beforeGroupInvokeCntB[0], 1);
+        Assertions.assertEquals(beforeGroupInvokeCntC[0], 1);
 
         // ------ //
 
@@ -1527,10 +1527,10 @@ public class ProxyTaskGroupTests {
         monitor.await();
 
         b1 = seen.equals(new ArrayList<>(Arrays.asList(new String[]{"E", "D", "E", "F"})));
-        Assert.assertTrue("Emission order should be [E, D, E, F] but got " + seen, b1);
+        Assertions.assertTrue("Emission order should be [E, D, E, F] but got " + seen, b1);
 
-        Assert.assertEquals(beforeGroupInvokeCntE[0], 1);
-        Assert.assertEquals(beforeGroupInvokeCntF[0], 1);
+        Assertions.assertEquals(beforeGroupInvokeCntE[0], 1);
+        Assertions.assertEquals(beforeGroupInvokeCntF[0], 1);
     }
 
     private TaskGroup createSampleTaskGroup(String vertex1,

--- a/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ProxyTaskGroupTests.java
+++ b/azure-mgmt-resources/src/test/java/com/azure/management/resources/fluentcore/dag/ProxyTaskGroupTests.java
@@ -87,7 +87,7 @@ public class ProxyTaskGroupTests {
         for (TaskGroupEntry<TaskItem> entry = group.getNext(); entry != null; entry = group.getNext()) {
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group.reportCompletion(entry);
@@ -211,7 +211,7 @@ public class ProxyTaskGroupTests {
         for (TaskGroupEntry<TaskItem> entry = group1.getNext(); entry != null; entry = group1.getNext()) {
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group1.reportCompletion(entry);
@@ -358,7 +358,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
@@ -513,7 +513,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group1.proxyTaskGroupWrapper.taskGroup().reportCompletion(entry);
@@ -672,7 +672,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
@@ -898,7 +898,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
@@ -924,7 +924,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group1Proxy.reportCompletion(entry);
@@ -1330,7 +1330,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group1Proxy.reportCompletion(entry);
@@ -1359,7 +1359,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group4Proxy.reportCompletion(entry);
@@ -1386,7 +1386,7 @@ public class ProxyTaskGroupTests {
             Assertions.assertFalse(seen.contains(entry.key()));
             Sets.SetView<String> common = Sets.intersection(shouldNotSee.get(entry.key()), seen);
             if (common.size() > 0) {
-                Assertions.assertTrue("The entries " + common + " must be emitted before " + entry.key(), false);
+                Assertions.assertTrue(false, "The entries " + common + " must be emitted before " + entry.key());
             }
             seen.add(entry.key());
             group2.reportCompletion(entry);
@@ -1465,7 +1465,7 @@ public class ProxyTaskGroupTests {
         boolean b2 = seen.equals(new ArrayList<>(Arrays.asList(new String[]{"C", "A", "B", "C"})));
 
         if (!b1 && !b2) {
-            Assertions.assertTrue("Emission order should be either [A, C, B, C] or [C, A, B, C] but got " + seen, false);
+            Assertions.assertTrue(false, "Emission order should be either [A, C, B, C] or [C, A, B, C] but got " + seen);
         }
 
         Assertions.assertEquals(beforeGroupInvokeCntB[0], 1);
@@ -1527,7 +1527,7 @@ public class ProxyTaskGroupTests {
         monitor.await();
 
         b1 = seen.equals(new ArrayList<>(Arrays.asList(new String[]{"E", "D", "E", "F"})));
-        Assertions.assertTrue("Emission order should be [E, D, E, F] but got " + seen, b1);
+        Assertions.assertTrue(b1, "Emission order should be [E, D, E, F] but got " + seen);
 
         Assertions.assertEquals(beforeGroupInvokeCntE[0], 1);
         Assertions.assertEquals(beforeGroupInvokeCntF[0], 1);

--- a/azure-mgmt-resources/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-resources/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-mgmt-storage/pom.xml
+++ b/azure-mgmt-storage/pom.xml
@@ -69,8 +69,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageAccountNetworkRuleTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageAccountNetworkRuleTests.java
@@ -9,8 +9,8 @@ package com.azure.management.storage;
 import com.azure.management.RestClient;
 import com.azure.management.resources.ResourceGroup;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StorageAccountNetworkRuleTests extends StorageManagementTest {
     private static String RG_NAME = "";
@@ -40,19 +40,19 @@ public class StorageAccountNetworkRuleTests extends StorageManagementTest {
                 .withNewResourceGroup(RG_NAME)
                 .create();
 
-        Assert.assertNotNull(storageAccount1.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressesWithAccess());
-        Assert.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressesWithAccess());
+        Assertions.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
-        Assert.assertEquals(0, storageAccount1.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
+        Assertions.assertEquals(0, storageAccount1.ipAddressRangesWithAccess().size());
 
-        Assert.assertTrue(storageAccount1.isAccessAllowedFromAllNetworks());
-        Assert.assertTrue(storageAccount1.canAccessFromAzureServices());
-        Assert.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
-        Assert.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount1.isAccessAllowedFromAllNetworks());
+        Assertions.assertTrue(storageAccount1.canAccessFromAzureServices());
+        Assertions.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
 
         ResourceGroup resourceGroup = resourceManager
                 .resourceGroups()
@@ -65,23 +65,23 @@ public class StorageAccountNetworkRuleTests extends StorageManagementTest {
                 .withAccessFromIpAddress("23.20.0.0")
                 .create();
 
-        Assert.assertNotNull(storageAccount2.inner().getNetworkRuleSet());
-        Assert.assertNotNull(storageAccount2.inner().getNetworkRuleSet().getDefaultAction());
-        Assert.assertNotNull(storageAccount2.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.DENY));
+        Assertions.assertNotNull(storageAccount2.inner().getNetworkRuleSet());
+        Assertions.assertNotNull(storageAccount2.inner().getNetworkRuleSet().getDefaultAction());
+        Assertions.assertNotNull(storageAccount2.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.DENY));
 
-        Assert.assertNotNull(storageAccount2.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount2.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount2.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount2.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount2.ipAddressesWithAccess());
-        Assert.assertEquals(1, storageAccount2.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount2.ipAddressesWithAccess());
+        Assertions.assertEquals(1, storageAccount2.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount2.ipAddressRangesWithAccess());
-        Assert.assertEquals(0, storageAccount2.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount2.ipAddressRangesWithAccess());
+        Assertions.assertEquals(0, storageAccount2.ipAddressRangesWithAccess().size());
 
-        Assert.assertFalse(storageAccount2.isAccessAllowedFromAllNetworks());
-        Assert.assertFalse(storageAccount2.canAccessFromAzureServices());
-        Assert.assertFalse(storageAccount2.canReadMetricsFromAnyNetwork());
-        Assert.assertFalse(storageAccount2.canReadMetricsFromAnyNetwork());
+        Assertions.assertFalse(storageAccount2.isAccessAllowedFromAllNetworks());
+        Assertions.assertFalse(storageAccount2.canAccessFromAzureServices());
+        Assertions.assertFalse(storageAccount2.canReadMetricsFromAnyNetwork());
+        Assertions.assertFalse(storageAccount2.canReadMetricsFromAnyNetwork());
 
         StorageAccount storageAccount3 = storageManager.storageAccounts()
                 .define(SA_NAME3)
@@ -91,23 +91,23 @@ public class StorageAccountNetworkRuleTests extends StorageManagementTest {
                 .withAccessFromIpAddress("23.20.0.0")
                 .create();
 
-        Assert.assertNotNull(storageAccount3.inner().getNetworkRuleSet());
-        Assert.assertNotNull(storageAccount3.inner().getNetworkRuleSet().getDefaultAction());
-        Assert.assertNotNull(storageAccount3.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.ALLOW));
+        Assertions.assertNotNull(storageAccount3.inner().getNetworkRuleSet());
+        Assertions.assertNotNull(storageAccount3.inner().getNetworkRuleSet().getDefaultAction());
+        Assertions.assertNotNull(storageAccount3.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.ALLOW));
 
-        Assert.assertNotNull(storageAccount3.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount3.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount3.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount3.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount3.ipAddressesWithAccess());
-        Assert.assertEquals(1, storageAccount3.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount3.ipAddressesWithAccess());
+        Assertions.assertEquals(1, storageAccount3.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount3.ipAddressRangesWithAccess());
-        Assert.assertEquals(0, storageAccount3.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount3.ipAddressRangesWithAccess());
+        Assertions.assertEquals(0, storageAccount3.ipAddressRangesWithAccess().size());
 
-        Assert.assertTrue(storageAccount3.isAccessAllowedFromAllNetworks());
-        Assert.assertTrue(storageAccount3.canAccessFromAzureServices());
-        Assert.assertTrue(storageAccount3.canReadMetricsFromAnyNetwork());
-        Assert.assertTrue(storageAccount3.canReadLogEntriesFromAnyNetwork());
+        Assertions.assertTrue(storageAccount3.isAccessAllowedFromAllNetworks());
+        Assertions.assertTrue(storageAccount3.canAccessFromAzureServices());
+        Assertions.assertTrue(storageAccount3.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount3.canReadLogEntriesFromAnyNetwork());
 
         StorageAccount storageAccount4 = storageManager.storageAccounts()
                 .define(SA_NAME4)
@@ -117,23 +117,23 @@ public class StorageAccountNetworkRuleTests extends StorageManagementTest {
                 .withReadAccessToMetricsFromAnyNetwork()
                 .create();
 
-        Assert.assertNotNull(storageAccount4.inner().getNetworkRuleSet());
-        Assert.assertNotNull(storageAccount4.inner().getNetworkRuleSet().getDefaultAction());
-        Assert.assertNotNull(storageAccount4.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.DENY));
+        Assertions.assertNotNull(storageAccount4.inner().getNetworkRuleSet());
+        Assertions.assertNotNull(storageAccount4.inner().getNetworkRuleSet().getDefaultAction());
+        Assertions.assertNotNull(storageAccount4.inner().getNetworkRuleSet().getDefaultAction().equals(DefaultAction.DENY));
 
-        Assert.assertNotNull(storageAccount4.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount4.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount4.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount4.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount4.ipAddressesWithAccess());
-        Assert.assertEquals(0, storageAccount4.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount4.ipAddressesWithAccess());
+        Assertions.assertEquals(0, storageAccount4.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount3.ipAddressRangesWithAccess());
-        Assert.assertEquals(0, storageAccount4.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount3.ipAddressRangesWithAccess());
+        Assertions.assertEquals(0, storageAccount4.ipAddressRangesWithAccess().size());
 
-        Assert.assertFalse(storageAccount4.isAccessAllowedFromAllNetworks());
-        Assert.assertFalse(storageAccount4.canAccessFromAzureServices());
-        Assert.assertTrue(storageAccount4.canReadMetricsFromAnyNetwork());
-        Assert.assertTrue(storageAccount4.canReadLogEntriesFromAnyNetwork());
+        Assertions.assertFalse(storageAccount4.isAccessAllowedFromAllNetworks());
+        Assertions.assertFalse(storageAccount4.canAccessFromAzureServices());
+        Assertions.assertTrue(storageAccount4.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount4.canReadLogEntriesFromAnyNetwork());
     }
 
     @Test
@@ -146,37 +146,37 @@ public class StorageAccountNetworkRuleTests extends StorageManagementTest {
                 .withNewResourceGroup(RG_NAME)
                 .create();
 
-        Assert.assertNotNull(storageAccount1.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressesWithAccess());
-        Assert.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressesWithAccess());
+        Assertions.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
-        Assert.assertEquals(0, storageAccount1.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
+        Assertions.assertEquals(0, storageAccount1.ipAddressRangesWithAccess().size());
 
-        Assert.assertTrue(storageAccount1.isAccessAllowedFromAllNetworks());
-        Assert.assertTrue(storageAccount1.canAccessFromAzureServices());
-        Assert.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
-        Assert.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount1.isAccessAllowedFromAllNetworks());
+        Assertions.assertTrue(storageAccount1.canAccessFromAzureServices());
+        Assertions.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertTrue(storageAccount1.canReadMetricsFromAnyNetwork());
 
         storageAccount1.update()
                 .withAccessFromSelectedNetworks()
                 .withAccessFromIpAddressRange("23.20.0.0/20")
                 .apply();
 
-        Assert.assertNotNull(storageAccount1.networkSubnetsWithAccess());
-        Assert.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.networkSubnetsWithAccess());
+        Assertions.assertEquals(0, storageAccount1.networkSubnetsWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressesWithAccess());
-        Assert.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressesWithAccess());
+        Assertions.assertEquals(0, storageAccount1.ipAddressesWithAccess().size());
 
-        Assert.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
-        Assert.assertEquals(1, storageAccount1.ipAddressRangesWithAccess().size());
+        Assertions.assertNotNull(storageAccount1.ipAddressRangesWithAccess());
+        Assertions.assertEquals(1, storageAccount1.ipAddressRangesWithAccess().size());
 
-        Assert.assertFalse(storageAccount1.isAccessAllowedFromAllNetworks());
-        Assert.assertTrue(storageAccount1.canAccessFromAzureServices());
-        Assert.assertFalse(storageAccount1.canReadMetricsFromAnyNetwork());
-        Assert.assertFalse(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertFalse(storageAccount1.isAccessAllowedFromAllNetworks());
+        Assertions.assertTrue(storageAccount1.canAccessFromAzureServices());
+        Assertions.assertFalse(storageAccount1.canReadMetricsFromAnyNetwork());
+        Assertions.assertFalse(storageAccount1.canReadMetricsFromAnyNetwork());
     }
 }

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageAccountOperationsTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageAccountOperationsTests.java
@@ -11,8 +11,8 @@ import com.azure.management.RestClient;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.model.Indexable;
 import com.azure.management.resources.fluentcore.utils.Utils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -41,7 +41,7 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
         // Skipping checking name availability for now because of 503 error 'The service is not yet ready to process any requests. Please retry in a few moments.'
 //        CheckNameAvailabilityResult result = storageManager.storageAccounts()
 //                .checkNameAvailability(SA_NAME);
-//        Assert.assertEquals(true, result.isAvailable());
+//        Assertions.assertEquals(true, result.isAvailable());
         // Create
         Flux<Indexable> resourceStream = storageManager.storageAccounts()
                 .define(SA_NAME)
@@ -53,10 +53,10 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
                 .withAzureFilesAadIntegrationEnabled(false)
                 .createAsync();
         StorageAccount storageAccount = Utils.<StorageAccount>rootResource(resourceStream.last()).block();
-        Assert.assertEquals(RG_NAME, storageAccount.resourceGroupName());
-        Assert.assertEquals(SkuName.STANDARD_GRS, storageAccount.skuType().name());
-        Assert.assertTrue(storageAccount.isHnsEnabled());
-        // Assert.assertFalse(storageAccount.isAzureFilesAadIntegrationEnabled());
+        Assertions.assertEquals(RG_NAME, storageAccount.resourceGroupName());
+        Assertions.assertEquals(SkuName.STANDARD_GRS, storageAccount.skuType().name());
+        Assertions.assertTrue(storageAccount.isHnsEnabled());
+        // Assertions.assertFalse(storageAccount.isAzureFilesAadIntegrationEnabled());
         // List
         PagedIterable<StorageAccount> accounts = storageManager.storageAccounts().listByResourceGroup(RG_NAME);
         boolean found = false;
@@ -65,49 +65,49 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
                 found = true;
             }
         }
-        Assert.assertTrue(found);
-        Assert.assertEquals(1, storageAccount.tags().size());
+        Assertions.assertTrue(found);
+        Assertions.assertEquals(1, storageAccount.tags().size());
 
         // Get
         storageAccount = storageManager.storageAccounts().getByResourceGroup(RG_NAME, SA_NAME);
-        Assert.assertNotNull(storageAccount);
+        Assertions.assertNotNull(storageAccount);
 
         // Get Keys
         List<StorageAccountKey> keys = storageAccount.getKeys();
-        Assert.assertTrue(keys.size() > 0);
+        Assertions.assertTrue(keys.size() > 0);
 
         // Regen key
         StorageAccountKey oldKey = keys.get(0);
         List<StorageAccountKey> updatedKeys = storageAccount.regenerateKey(oldKey.getKeyName());
-        Assert.assertTrue(updatedKeys.size() > 0);
+        Assertions.assertTrue(updatedKeys.size() > 0);
         for (StorageAccountKey updatedKey : updatedKeys) {
             if (updatedKey.getKeyName().equalsIgnoreCase(oldKey.getKeyName())) {
-                Assert.assertNotEquals(oldKey.getValue(), updatedKey.getValue());
+                Assertions.assertNotEquals(oldKey.getValue(), updatedKey.getValue());
                 break;
             }
         }
 
         Map<StorageService, StorageAccountEncryptionStatus> statuses = storageAccount.encryptionStatuses();
-        Assert.assertNotNull(statuses);
-        Assert.assertTrue(statuses.size() > 0);
+        Assertions.assertNotNull(statuses);
+        Assertions.assertTrue(statuses.size() > 0);
 
-        Assert.assertTrue(statuses.containsKey(StorageService.BLOB));
+        Assertions.assertTrue(statuses.containsKey(StorageService.BLOB));
         StorageAccountEncryptionStatus blobServiceEncryptionStatus = statuses.get(StorageService.BLOB);
-        Assert.assertNotNull(blobServiceEncryptionStatus);
-        Assert.assertTrue(blobServiceEncryptionStatus.isEnabled()); // Service will enable this by default
+        Assertions.assertNotNull(blobServiceEncryptionStatus);
+        Assertions.assertTrue(blobServiceEncryptionStatus.isEnabled()); // Service will enable this by default
 
-        Assert.assertTrue(statuses.containsKey(StorageService.FILE));
+        Assertions.assertTrue(statuses.containsKey(StorageService.FILE));
         StorageAccountEncryptionStatus fileServiceEncryptionStatus = statuses.get(StorageService.FILE);
-        Assert.assertNotNull(fileServiceEncryptionStatus);
-        Assert.assertTrue(fileServiceEncryptionStatus.isEnabled()); // Service will enable this by default
+        Assertions.assertNotNull(fileServiceEncryptionStatus);
+        Assertions.assertTrue(fileServiceEncryptionStatus.isEnabled()); // Service will enable this by default
 
         // Update
         storageAccount = storageAccount.update()
                 .withSku(SkuName.STANDARD_LRS)
                 .withTag("tag2", "value2")
                 .apply();
-        Assert.assertEquals(SkuName.STANDARD_LRS, storageAccount.skuType().name());
-        Assert.assertEquals(2, storageAccount.tags().size());
+        Assertions.assertEquals(SkuName.STANDARD_LRS, storageAccount.skuType().name());
+        Assertions.assertEquals(2, storageAccount.tags().size());
     }
 
     @Test
@@ -120,14 +120,14 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
                 .create();
 
         Map<StorageService, StorageAccountEncryptionStatus> statuses = storageAccount.encryptionStatuses();
-        Assert.assertNotNull(statuses);
-        Assert.assertTrue(statuses.size() > 0);
+        Assertions.assertNotNull(statuses);
+        Assertions.assertTrue(statuses.size() > 0);
         StorageAccountEncryptionStatus blobServiceEncryptionStatus = statuses.get(StorageService.BLOB);
-        Assert.assertNotNull(blobServiceEncryptionStatus);
-        Assert.assertTrue(blobServiceEncryptionStatus.isEnabled());
-        Assert.assertNotNull(blobServiceEncryptionStatus.lastEnabledTime());
-        Assert.assertNotNull(storageAccount.encryptionKeySource());
-        Assert.assertTrue(storageAccount.encryptionKeySource().equals(StorageAccountEncryptionKeySource.MICROSOFT_STORAGE));
+        Assertions.assertNotNull(blobServiceEncryptionStatus);
+        Assertions.assertTrue(blobServiceEncryptionStatus.isEnabled());
+        Assertions.assertNotNull(blobServiceEncryptionStatus.lastEnabledTime());
+        Assertions.assertNotNull(storageAccount.encryptionKeySource());
+        Assertions.assertTrue(storageAccount.encryptionKeySource().equals(StorageAccountEncryptionKeySource.MICROSOFT_STORAGE));
 
 //        Storage no-longer support disabling encryption
 //
@@ -135,11 +135,11 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
 //                .withoutBlobEncryption()
 //                .apply();
 //        statuses = storageAccount.encryptionStatuses();
-//        Assert.assertNotNull(statuses);
-//        Assert.assertTrue(statuses.size() > 0);
+//        Assertions.assertNotNull(statuses);
+//        Assertions.assertTrue(statuses.size() > 0);
 //        blobServiceEncryptionStatus = statuses.get(StorageService.BLOB);
-//        Assert.assertNotNull(blobServiceEncryptionStatus);
-//        Assert.assertFalse(blobServiceEncryptionStatus.isEnabled());
+//        Assertions.assertNotNull(blobServiceEncryptionStatus);
+//        Assertions.assertFalse(blobServiceEncryptionStatus.isEnabled());
     }
 
 
@@ -153,7 +153,7 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
                 .withLargeFileShares(true)
                 .create();
 
-        Assert.assertTrue(storageAccount.isLargeFileSharesEnabled());
+        Assertions.assertTrue(storageAccount.isLargeFileSharesEnabled());
     }
 
     @Test
@@ -166,18 +166,18 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
                 .create();
 
         Map<StorageService, StorageAccountEncryptionStatus> statuses = storageAccount.encryptionStatuses();
-        Assert.assertNotNull(statuses);
-        Assert.assertTrue(statuses.size() > 0);
+        Assertions.assertNotNull(statuses);
+        Assertions.assertTrue(statuses.size() > 0);
 
-        Assert.assertTrue(statuses.containsKey(StorageService.BLOB));
+        Assertions.assertTrue(statuses.containsKey(StorageService.BLOB));
         StorageAccountEncryptionStatus blobServiceEncryptionStatus = statuses.get(StorageService.BLOB);
-        Assert.assertNotNull(blobServiceEncryptionStatus);
-        Assert.assertTrue(blobServiceEncryptionStatus.isEnabled()); // Enabled by default by default
+        Assertions.assertNotNull(blobServiceEncryptionStatus);
+        Assertions.assertTrue(blobServiceEncryptionStatus.isEnabled()); // Enabled by default by default
 
-        Assert.assertTrue(statuses.containsKey(StorageService.FILE));
+        Assertions.assertTrue(statuses.containsKey(StorageService.FILE));
         StorageAccountEncryptionStatus fileServiceEncryptionStatus = statuses.get(StorageService.FILE);
-        Assert.assertNotNull(fileServiceEncryptionStatus);
-        Assert.assertTrue(fileServiceEncryptionStatus.isEnabled());
+        Assertions.assertNotNull(fileServiceEncryptionStatus);
+        Assertions.assertTrue(fileServiceEncryptionStatus.isEnabled());
 
 // Service no longer support disabling file encryption
 //        storageAccount.update()
@@ -186,10 +186,10 @@ public class StorageAccountOperationsTests extends StorageManagementTest {
 //
 //        statuses = storageAccount.encryptionStatuses();
 //
-//        Assert.assertTrue(statuses.containsKey(StorageService.FILE));
+//        Assertions.assertTrue(statuses.containsKey(StorageService.FILE));
 //        fileServiceEncryptionStatus = statuses.get(StorageService.FILE);
-//        Assert.assertNotNull(fileServiceEncryptionStatus);
-//        Assert.assertFalse(fileServiceEncryptionStatus.isEnabled());
+//        Assertions.assertNotNull(fileServiceEncryptionStatus);
+//        Assertions.assertFalse(fileServiceEncryptionStatus.isEnabled());
 
     }
 }

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageBlobContainersTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageBlobContainersTests.java
@@ -2,8 +2,8 @@ package com.azure.management.storage;
 
 import com.azure.management.RestClient;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,9 +46,9 @@ public class StorageBlobContainersTests extends StorageManagementTest {
                 .create();
 
 
-        Assert.assertEquals("blob-test", blobContainer.name());
-        Assert.assertEquals(PublicAccess.CONTAINER, blobContainer.publicAccess());
-        Assert.assertEquals(metadataTest, blobContainer.metadata());
+        Assertions.assertEquals("blob-test", blobContainer.name());
+        Assertions.assertEquals(PublicAccess.CONTAINER, blobContainer.publicAccess());
+        Assertions.assertEquals(metadataTest, blobContainer.metadata());
     }
 
     @Test
@@ -82,8 +82,8 @@ public class StorageBlobContainersTests extends StorageManagementTest {
                 .withMetadata("e", "f")
                 .apply();
 
-        Assert.assertEquals("blob-test", blobContainer.name());
-        Assert.assertEquals(PublicAccess.BLOB, blobContainer.publicAccess());
-        Assert.assertEquals(metadataTest, blobContainer.metadata());
+        Assertions.assertEquals("blob-test", blobContainer.name());
+        Assertions.assertEquals(PublicAccess.BLOB, blobContainer.publicAccess());
+        Assertions.assertEquals(metadataTest, blobContainer.metadata());
     }
 }

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageBlobServicesTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageBlobServicesTests.java
@@ -2,8 +2,8 @@ package com.azure.management.storage;
 
 import com.azure.management.RestClient;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StorageBlobServicesTests extends StorageManagementTest {
     private static String RG_NAME = "";
@@ -37,8 +37,8 @@ public class StorageBlobServicesTests extends StorageManagementTest {
                 .withDeleteRetentionPolicyEnabled(5)
                 .create();
 
-        Assert.assertTrue(blobService.deleteRetentionPolicy().isEnabled());
-        Assert.assertEquals(5, blobService.deleteRetentionPolicy().getDays().intValue());
+        Assertions.assertTrue(blobService.deleteRetentionPolicy().isEnabled());
+        Assertions.assertEquals(5, blobService.deleteRetentionPolicy().getDays().intValue());
 
     }
 
@@ -62,7 +62,7 @@ public class StorageBlobServicesTests extends StorageManagementTest {
                 .withDeleteRetentionPolicyDisabled()
                 .apply();
 
-        Assert.assertFalse(blobService.deleteRetentionPolicy().isEnabled());
+        Assertions.assertFalse(blobService.deleteRetentionPolicy().isEnabled());
 
     }
 }

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageManagementPoliciesTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/StorageManagementPoliciesTests.java
@@ -2,8 +2,8 @@ package com.azure.management.storage;
 
 import com.azure.management.RestClient;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,14 +56,14 @@ public class StorageManagementPoliciesTests extends StorageManagementTest {
         List<String> prefixesToFilterFor = new ArrayList<>();
         prefixesToFilterFor.add("container1/foo");
 
-        //Assert.assertEquals("management-test", managementPolicy.policy().);
-        Assert.assertEquals("rule1", managementPolicy.policy().getRules().get(0).getName());
-        Assert.assertEquals(blobTypesToFilterFor, managementPolicy.policy().getRules().get(0).getDefinition().getFilters().getBlobTypes());
-        Assert.assertEquals(prefixesToFilterFor, managementPolicy.policy().getRules().get(0).getDefinition().getFilters().getPrefixMatch());
-        Assert.assertEquals(30, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getTierToCool().getDaysAfterModificationGreaterThan(), 0.001);
-        Assert.assertEquals(90, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getTierToArchive().getDaysAfterModificationGreaterThan(), 0.001);
-        Assert.assertEquals(2555, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getDelete().getDaysAfterModificationGreaterThan(), 0.001);
-        Assert.assertEquals(90, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getSnapshot().getDelete().getDaysAfterCreationGreaterThan(),0.001);
+        //Assertions.assertEquals("management-test", managementPolicy.policy().);
+        Assertions.assertEquals("rule1", managementPolicy.policy().getRules().get(0).getName());
+        Assertions.assertEquals(blobTypesToFilterFor, managementPolicy.policy().getRules().get(0).getDefinition().getFilters().getBlobTypes());
+        Assertions.assertEquals(prefixesToFilterFor, managementPolicy.policy().getRules().get(0).getDefinition().getFilters().getPrefixMatch());
+        Assertions.assertEquals(30, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getTierToCool().getDaysAfterModificationGreaterThan(), 0.001);
+        Assertions.assertEquals(90, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getTierToArchive().getDaysAfterModificationGreaterThan(), 0.001);
+        Assertions.assertEquals(2555, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getBaseBlob().getDelete().getDaysAfterModificationGreaterThan(), 0.001);
+        Assertions.assertEquals(90, managementPolicy.policy().getRules().get(0).getDefinition().getActions().getSnapshot().getDelete().getDaysAfterCreationGreaterThan(),0.001);
     }
 
     @Test
@@ -99,17 +99,17 @@ public class StorageManagementPoliciesTests extends StorageManagementTest {
         prefixesToFilterFor.add("container1/foo");
 
         List<PolicyRule> rules = managementPolicy.rules();
-        Assert.assertEquals("rule1", rules.get(0).name());
-        Assert.assertArrayEquals(Collections.unmodifiableList(blobTypesToFilterFor).toArray(), rules.get(0).blobTypesToFilterFor().toArray());
-        Assert.assertArrayEquals(Collections.unmodifiableList(prefixesToFilterFor).toArray(), rules.get(0).prefixesToFilterFor().toArray());
-        Assert.assertEquals(30, rules.get(0).daysAfterBaseBlobModificationUntilCooling().intValue());
-        Assert.assertTrue(rules.get(0).tierToCoolActionOnBaseBlobEnabled());
-        Assert.assertEquals(90, rules.get(0).daysAfterBaseBlobModificationUntilArchiving().intValue());
-        Assert.assertTrue(rules.get(0).tierToArchiveActionOnBaseBlobEnabled());
-        Assert.assertEquals(2555, rules.get(0).daysAfterBaseBlobModificationUntilDeleting().intValue());
-        Assert.assertTrue(rules.get(0).deleteActionOnBaseBlobEnabled());
-        Assert.assertEquals(90,rules.get(0).daysAfterSnapShotCreationUntilDeleting().intValue());
-        Assert.assertTrue(rules.get(0).deleteActionOnSnapShotEnabled());
+        Assertions.assertEquals("rule1", rules.get(0).name());
+        Assertions.assertArrayEquals(Collections.unmodifiableList(blobTypesToFilterFor).toArray(), rules.get(0).blobTypesToFilterFor().toArray());
+        Assertions.assertArrayEquals(Collections.unmodifiableList(prefixesToFilterFor).toArray(), rules.get(0).prefixesToFilterFor().toArray());
+        Assertions.assertEquals(30, rules.get(0).daysAfterBaseBlobModificationUntilCooling().intValue());
+        Assertions.assertTrue(rules.get(0).tierToCoolActionOnBaseBlobEnabled());
+        Assertions.assertEquals(90, rules.get(0).daysAfterBaseBlobModificationUntilArchiving().intValue());
+        Assertions.assertTrue(rules.get(0).tierToArchiveActionOnBaseBlobEnabled());
+        Assertions.assertEquals(2555, rules.get(0).daysAfterBaseBlobModificationUntilDeleting().intValue());
+        Assertions.assertTrue(rules.get(0).deleteActionOnBaseBlobEnabled());
+        Assertions.assertEquals(90,rules.get(0).daysAfterSnapShotCreationUntilDeleting().intValue());
+        Assertions.assertTrue(rules.get(0).deleteActionOnSnapShotEnabled());
     }
 
     @Test
@@ -158,17 +158,17 @@ public class StorageManagementPoliciesTests extends StorageManagementTest {
                 .apply();
 
         List<PolicyRule> rules = managementPolicy.rules();
-        Assert.assertEquals(1, rules.size());
-        Assert.assertEquals("rule1", rules.get(0).name());
-        Assert.assertArrayEquals(Collections.unmodifiableList(blobTypesToFilterFor).toArray(), rules.get(0).blobTypesToFilterFor().toArray());
-        Assert.assertArrayEquals(Collections.unmodifiableList(prefixesToFilterFor).toArray(), rules.get(0).prefixesToFilterFor().toArray());
-        Assert.assertEquals(30, rules.get(0).daysAfterBaseBlobModificationUntilCooling().intValue());
-        Assert.assertTrue(rules.get(0).tierToCoolActionOnBaseBlobEnabled());
-        Assert.assertEquals(90, rules.get(0).daysAfterBaseBlobModificationUntilArchiving().intValue());
-        Assert.assertTrue(rules.get(0).tierToArchiveActionOnBaseBlobEnabled());
-        Assert.assertEquals(2555, rules.get(0).daysAfterBaseBlobModificationUntilDeleting().intValue());
-        Assert.assertTrue(rules.get(0).deleteActionOnBaseBlobEnabled());
-        Assert.assertEquals(90,rules.get(0).daysAfterSnapShotCreationUntilDeleting().intValue());
-        Assert.assertTrue(rules.get(0).deleteActionOnSnapShotEnabled());
+        Assertions.assertEquals(1, rules.size());
+        Assertions.assertEquals("rule1", rules.get(0).name());
+        Assertions.assertArrayEquals(Collections.unmodifiableList(blobTypesToFilterFor).toArray(), rules.get(0).blobTypesToFilterFor().toArray());
+        Assertions.assertArrayEquals(Collections.unmodifiableList(prefixesToFilterFor).toArray(), rules.get(0).prefixesToFilterFor().toArray());
+        Assertions.assertEquals(30, rules.get(0).daysAfterBaseBlobModificationUntilCooling().intValue());
+        Assertions.assertTrue(rules.get(0).tierToCoolActionOnBaseBlobEnabled());
+        Assertions.assertEquals(90, rules.get(0).daysAfterBaseBlobModificationUntilArchiving().intValue());
+        Assertions.assertTrue(rules.get(0).tierToArchiveActionOnBaseBlobEnabled());
+        Assertions.assertEquals(2555, rules.get(0).daysAfterBaseBlobModificationUntilDeleting().intValue());
+        Assertions.assertTrue(rules.get(0).deleteActionOnBaseBlobEnabled());
+        Assertions.assertEquals(90,rules.get(0).daysAfterSnapShotCreationUntilDeleting().intValue());
+        Assertions.assertTrue(rules.get(0).deleteActionOnSnapShotEnabled());
     }
 }

--- a/azure-mgmt-storage/src/test/java/com/azure/management/storage/UsageOperationsTests.java
+++ b/azure-mgmt-storage/src/test/java/com/azure/management/storage/UsageOperationsTests.java
@@ -9,14 +9,14 @@ package com.azure.management.storage;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.management.resources.core.TestUtilities;
 import com.azure.management.storage.models.UsageInner;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 public class UsageOperationsTests extends StorageManagementTest {
     @Test
-    @Ignore("Service is no longer supporting listing")
+    @Disabled("Service is no longer supporting listing")
     public void canGetUsages() throws Exception {
         PagedIterable<UsageInner> usages = storageManager.usages().list();
         System.out.println(TestUtilities.getPagedIterableSize(usages));

--- a/azure-mgmt-storage/src/test/resources/junit-platform.properties
+++ b/azure-mgmt-storage/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=32

--- a/azure-samples/pom.xml
+++ b/azure-samples/pom.xml
@@ -158,8 +158,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/AppServiceSampleLiveOnlyTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/AppServiceSampleLiveOnlyTests.java
@@ -19,8 +19,8 @@ import com.microsoft.azure.management.appservice.samples.ManageWebAppLogs;
 import com.microsoft.azure.management.appservice.samples.ManageWebAppSourceControl;
 import com.microsoft.azure.management.appservice.samples.ManageWebAppStorageAccountConnection;
 import com.azure.management.resources.core.TestBase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AppServiceSampleLiveOnlyTests extends SamplesTestBase {
     public AppServiceSampleLiveOnlyTests() {
@@ -29,61 +29,61 @@ public class AppServiceSampleLiveOnlyTests extends SamplesTestBase {
 
     @Test
     public void testManageWebAppSourceControl() {
-        Assert.assertTrue(ManageWebAppSourceControl.runSample(azure));
+        Assertions.assertTrue(ManageWebAppSourceControl.runSample(azure));
     }
 
     @Test
     public void testManageWebAppStorageAccountConnection() {
-        Assert.assertTrue(ManageWebAppStorageAccountConnection.runSample(azure));
+        Assertions.assertTrue(ManageWebAppStorageAccountConnection.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppSourceControl() {
-        Assert.assertTrue(ManageLinuxWebAppSourceControl.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppSourceControl.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppStorageAccountConnection() {
-        Assert.assertTrue(ManageLinuxWebAppStorageAccountConnection.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppStorageAccountConnection.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppWithContainerRegistry() {
-        Assert.assertTrue(ManageLinuxWebAppWithContainerRegistry.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppWithContainerRegistry.runSample(azure));
     }
 
     @Test
     public void testManageFunctionAppWithAuthentication() {
-        Assert.assertTrue(ManageFunctionAppWithAuthentication.runSample(azure));
+        Assertions.assertTrue(ManageFunctionAppWithAuthentication.runSample(azure));
     }
 
     @Test
     public void testManageFunctionAppSourceControl() {
-        Assert.assertTrue(ManageFunctionAppSourceControl.runSample(azure));
+        Assertions.assertTrue(ManageFunctionAppSourceControl.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppCosmosDbByMsi() {
-        Assert.assertTrue(ManageLinuxWebAppCosmosDbByMsi.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppCosmosDbByMsi.runSample(azure));
     }
 
     @Test
     public void testManageWebAppCosmosDbByMsi() {
-        Assert.assertTrue(ManageWebAppCosmosDbByMsi.runSample(azure));
+        Assertions.assertTrue(ManageWebAppCosmosDbByMsi.runSample(azure));
     }
 
     @Test
     public void testManageWebAppCosmosDbThroughKeyVault() {
-        Assert.assertTrue(ManageWebAppCosmosDbThroughKeyVault.runSample(azure));
+        Assertions.assertTrue(ManageWebAppCosmosDbThroughKeyVault.runSample(azure));
     }
 
     @Test
     public void testManageFunctionAppLogs() {
-        Assert.assertTrue(ManageFunctionAppLogs.runSample(azure));
+        Assertions.assertTrue(ManageFunctionAppLogs.runSample(azure));
     }
 
     @Test
     public void testManageWebAppLogs() {
-        Assert.assertTrue(ManageWebAppLogs.runSample(azure));
+        Assertions.assertTrue(ManageWebAppLogs.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/AppServiceSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/AppServiceSampleTests.java
@@ -18,72 +18,72 @@ import com.microsoft.azure.management.appservice.samples.ManageWebAppSourceContr
 import com.microsoft.azure.management.appservice.samples.ManageWebAppSqlConnection;
 import com.microsoft.azure.management.appservice.samples.ManageWebAppWithDomainSsl;
 import com.microsoft.azure.management.appservice.samples.ManageWebAppWithTrafficManager;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class AppServiceSampleTests extends SamplesTestBase {
     @Test
     public void testManageWebAppBasic() {
-        Assert.assertTrue(ManageWebAppBasic.runSample(azure));
+        Assertions.assertTrue(ManageWebAppBasic.runSample(azure));
     }
 
     @Test
-    @Ignore("Fails randomly when creating one of the three slots")
+    @Disabled("Fails randomly when creating one of the three slots")
     public void testManageWebAppSlots() {
-        Assert.assertTrue(ManageWebAppSlots.runSample(azure));
+        Assertions.assertTrue(ManageWebAppSlots.runSample(azure));
     }
 
     @Test
-    @Ignore("Failing in playback - dependent on git")
+    @Disabled("Failing in playback - dependent on git")
     public void testManageWebAppSourceControlAsync() {
-        Assert.assertTrue(ManageWebAppSourceControlAsync.runSample(azure));
+        Assertions.assertTrue(ManageWebAppSourceControlAsync.runSample(azure));
     }
 
     @Test
-    @Ignore("Stops in between for user input")
+    @Disabled("Stops in between for user input")
     public void testManageWebAppSqlConnection() {
-        Assert.assertTrue(ManageWebAppSqlConnection.runSample(azure));
+        Assertions.assertTrue(ManageWebAppSqlConnection.runSample(azure));
     }
 
     @Test
     public void testManageWebAppWithDomainSsl() {
-        Assert.assertTrue(ManageWebAppWithDomainSsl.runSample(azure));
+        Assertions.assertTrue(ManageWebAppWithDomainSsl.runSample(azure));
     }
 
     @Test
     public void testManageWebAppWithTrafficManager() {
-        Assert.assertTrue(ManageWebAppWithTrafficManager.runSample(azure));
+        Assertions.assertTrue(ManageWebAppWithTrafficManager.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppBasic() {
-        Assert.assertTrue(ManageLinuxWebAppBasic.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppBasic.runSample(azure));
     }
 
     @Test
-    @Ignore("Stops in between for user input")
+    @Disabled("Stops in between for user input")
     public void testManageLinuxWebAppSqlConnection() {
-        Assert.assertTrue(ManageLinuxWebAppSqlConnection.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppSqlConnection.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppWithDomainSsl() {
-        Assert.assertTrue(ManageLinuxWebAppWithDomainSsl.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppWithDomainSsl.runSample(azure));
     }
 
     @Test
     public void testManageLinuxWebAppWithTrafficManager() {
-        Assert.assertTrue(ManageLinuxWebAppWithTrafficManager.runSample(azure));
+        Assertions.assertTrue(ManageLinuxWebAppWithTrafficManager.runSample(azure));
     }
 
     @Test
     public void testManageFunctionAppBasic() {
-        Assert.assertTrue(ManageFunctionAppBasic.runSample(azure));
+        Assertions.assertTrue(ManageFunctionAppBasic.runSample(azure));
     }
 
     @Test
     public void testManageFunctionAppWithDomainSsl() {
-        Assert.assertTrue(ManageFunctionAppWithDomainSsl.runSample(azure));
+        Assertions.assertTrue(ManageFunctionAppWithDomainSsl.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/BatchSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/BatchSampleTests.java
@@ -7,12 +7,12 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.batch.samples.ManageBatchAccount;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BatchSampleTests extends SamplesTestBase {
     @Test
     public void testManageBatchAccount() {
-        Assert.assertTrue(ManageBatchAccount.runSample(azure));
+        Assertions.assertTrue(ManageBatchAccount.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/CdnSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/CdnSampleTests.java
@@ -7,12 +7,12 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.cdn.samples.ManageCdn;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CdnSampleTests extends SamplesTestBase {
     @Test
     public void testManageCdn() {
-        Assert.assertTrue(ManageCdn.runSample(azure));
+        Assertions.assertTrue(ManageCdn.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ComputeSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ComputeSampleTests.java
@@ -33,148 +33,148 @@ import com.microsoft.azure.management.compute.samples.ManageVirtualMachinesInPar
 import com.microsoft.azure.management.compute.samples.ConvertVirtualMachineToManagedDisks;
 import com.microsoft.azure.management.compute.samples.ManageZonalVirtualMachine;
 import com.microsoft.azure.management.compute.samples.ManageZonalVirtualMachineScaleSet;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ComputeSampleTests extends SamplesTestBase {
 
     @Test
     public void testCreateVirtualMachinesInParallel() {
-        Assert.assertTrue(CreateVirtualMachinesInParallel.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachinesInParallel.runSample(azure));
     }
 
     @Test
-    @Ignore("Sample leverages true parallelization, which cannot be recorded, until GenericResources support deleteByIds()")
+    @Disabled("Sample leverages true parallelization, which cannot be recorded, until GenericResources support deleteByIds()")
     public void testCreateVirtualMachinesAsyncTrackingRelatedResources() {
-        Assert.assertTrue(CreateVirtualMachinesAsyncTrackingRelatedResources.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachinesAsyncTrackingRelatedResources.runSample(azure));
     }
 
     @Test
     public void testCreateVirtualMachinesUsingCustomImageOrSpecializedVHD() {
-        Assert.assertTrue(CreateVirtualMachinesUsingCustomImageOrSpecializedVHD.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachinesUsingCustomImageOrSpecializedVHD.runSample(azure));
     }
 
     @Test
     public void testCreateVirtualMachineUsingCustomImageFromVHD() {
-        Assert.assertTrue(CreateVirtualMachineUsingCustomImageFromVHD.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachineUsingCustomImageFromVHD.runSample(azure));
     }
 
     @Test
-    @Ignore("Need to investigate - 'Disks or snapshot cannot be resized down.'")
+    @Disabled("Need to investigate - 'Disks or snapshot cannot be resized down.'")
     public void testCreateVirtualMachineUsingCustomImageFromVM() {
-        Assert.assertTrue(CreateVirtualMachineUsingCustomImageFromVM.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachineUsingCustomImageFromVM.runSample(azure));
     }
 
     @Test
     public void testCreateVirtualMachineUsingSpecializedDiskFromSnapshot() {
-        Assert.assertTrue(CreateVirtualMachineUsingSpecializedDiskFromSnapshot.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachineUsingSpecializedDiskFromSnapshot.runSample(azure));
     }
 
     @Test
     public void testCreateVirtualMachineUsingSpecializedDiskFromVhd() {
-        Assert.assertTrue(CreateVirtualMachineUsingSpecializedDiskFromVhd.runSample(azure));
+        Assertions.assertTrue(CreateVirtualMachineUsingSpecializedDiskFromVhd.runSample(azure));
     }
 
     @Test
     public void testListVirtualMachineExtensionImages() {
-        Assert.assertTrue(ListVirtualMachineExtensionImages.runSample(azure));
+        Assertions.assertTrue(ListVirtualMachineExtensionImages.runSample(azure));
     }
 
     @Test
     public void testListVirtualMachineImages() {
-        Assert.assertTrue(ListVirtualMachineImages.runSample(azure));
+        Assertions.assertTrue(ListVirtualMachineImages.runSample(azure));
     }
 
     @Test
     public void testListListComputeSkus() {
-        Assert.assertTrue(ListComputeSkus.runSample(azure));
+        Assertions.assertTrue(ListComputeSkus.runSample(azure));
     }
 
     @Test
     public void testManageAvailabilitySet() {
-        Assert.assertTrue(ManageAvailabilitySet.runSample(azure));
+        Assertions.assertTrue(ManageAvailabilitySet.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineWithUnmanagedDisks() {
-        Assert.assertTrue(ManageVirtualMachineWithUnmanagedDisks.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineWithUnmanagedDisks.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachine() {
-        Assert.assertTrue(ManageVirtualMachine.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachine.runSample(azure));
     }
 
     @Test   
     public void testManageVirtualMachineAsync() {
-        Assert.assertTrue(ManageVirtualMachineAsync.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineAsync.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineExtension() {
-        Assert.assertTrue(ManageVirtualMachineExtension.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineExtension.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineScaleSet() {
-        Assert.assertTrue(ManageVirtualMachineScaleSet.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineScaleSet.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineScaleSetAsync() {
-        Assert.assertTrue(ManageVirtualMachineScaleSetAsync.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineScaleSetAsync.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineScaleSetWithUnmanagedDisks() {
-        Assert.assertTrue(ManageVirtualMachineScaleSetWithUnmanagedDisks.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineScaleSetWithUnmanagedDisks.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachinesInParallel() {
-        Assert.assertTrue(ManageVirtualMachinesInParallel.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachinesInParallel.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachineWithDisk() {
-        Assert.assertTrue(ManageVirtualMachineWithDisk.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachineWithDisk.runSample(azure));
     }
 
     @Test
     public void testConvertVirtualMachineToManagedDisks() {
-        Assert.assertTrue(ConvertVirtualMachineToManagedDisks.runSample(azure));
+        Assertions.assertTrue(ConvertVirtualMachineToManagedDisks.runSample(azure));
     }
 
     @Test
     public void testManageManagedDisks() {
-      Assert.assertTrue(ManageManagedDisks.runSample(azure));
+      Assertions.assertTrue(ManageManagedDisks.runSample(azure));
     }
 
     @Test
-    @Ignore("Skipping for now - looks like a service side issue")
+    @Disabled("Skipping for now - looks like a service side issue")
     public void testManageStorageFromMSIEnabledVirtualMachine() {
-        Assert.assertTrue(ManageStorageFromMSIEnabledVirtualMachine.runSample(azure));
+        Assertions.assertTrue(ManageStorageFromMSIEnabledVirtualMachine.runSample(azure));
     }
 
     @Test
-    @Ignore("Skipping for now - looks like a service side issue")
+    @Disabled("Skipping for now - looks like a service side issue")
     public void testManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup() {
-        Assert.assertTrue(ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup.runSample(azure));
+        Assertions.assertTrue(ManageResourceFromMSIEnabledVirtualMachineBelongsToAADGroup.runSample(azure));
     }
 
     @Test
     public void testManageUserAssignedMSIEnabledVirtualMachine() {
-        Assert.assertTrue(ManageUserAssignedMSIEnabledVirtualMachine.runSample(azure));
+        Assertions.assertTrue(ManageUserAssignedMSIEnabledVirtualMachine.runSample(azure));
     }
 
     @Test
     public void testManageZonalVirtualMachine() {
-        Assert.assertTrue(ManageZonalVirtualMachine.runSample(azure));
+        Assertions.assertTrue(ManageZonalVirtualMachine.runSample(azure));
     }
 
     @Test
     public void testManageZonalVirtualMachineScaleSet() {
-        Assert.assertTrue(ManageZonalVirtualMachineScaleSet.runSample(azure));
+        Assertions.assertTrue(ManageZonalVirtualMachineScaleSet.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerInstanceTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerInstanceTests.java
@@ -10,8 +10,8 @@ import com.microsoft.azure.management.containerinstance.samples.ManageContainerI
 import com.microsoft.azure.management.containerinstance.samples.ManageContainerInstanceWithManualAzureFileShareMountCreation;
 import com.microsoft.azure.management.containerinstance.samples.ManageContainerInstanceWithMultipleContainerImages;
 import com.microsoft.azure.management.containerinstance.samples.ManageContainerInstanceZeroToOneAndOneToManyUsingContainerServiceOrchestrator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ContainerInstanceTests extends SamplesTestBase {
 
@@ -19,7 +19,7 @@ public class ContainerInstanceTests extends SamplesTestBase {
     public void testManageContainerInstanceWithAzureFileShareMount() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageContainerInstanceWithAzureFileShareMount.runSample(azure));
+            Assertions.assertTrue(ManageContainerInstanceWithAzureFileShareMount.runSample(azure));
         }
     }
 
@@ -27,20 +27,20 @@ public class ContainerInstanceTests extends SamplesTestBase {
     public void testManageContainerInstanceWithManualAzureFileShareMountCreation() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageContainerInstanceWithManualAzureFileShareMountCreation.runSample(azure));
+            Assertions.assertTrue(ManageContainerInstanceWithManualAzureFileShareMountCreation.runSample(azure));
         }
     }
 
     @Test
     public void testManageContainerInstanceWithMultipleContainerImages() {
-        Assert.assertTrue(ManageContainerInstanceWithMultipleContainerImages.runSample(azure));
+        Assertions.assertTrue(ManageContainerInstanceWithMultipleContainerImages.runSample(azure));
     }
 
     @Test
     public void testManageContainerInstanceZeroToOneAndOneToManyUsingContainerServiceOrchestrator() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageContainerInstanceZeroToOneAndOneToManyUsingContainerServiceOrchestrator.runSample(azure, "", ""));
+            Assertions.assertTrue(ManageContainerInstanceZeroToOneAndOneToManyUsingContainerServiceOrchestrator.runSample(azure, "", ""));
         }
     }
 

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerRegistryTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerRegistryTests.java
@@ -8,8 +8,8 @@ package com.microsoft.azure.management.samples;
 import com.microsoft.azure.management.containerregistry.samples.ManageContainerRegistry;
 import com.microsoft.azure.management.containerregistry.samples.ManageContainerRegistryWithWebhooks;
 import com.azure.management.resources.core.TestBase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ContainerRegistryTests extends SamplesTestBase {
     public ContainerRegistryTests() {
@@ -19,11 +19,11 @@ public class ContainerRegistryTests extends SamplesTestBase {
 
     @Test
     public void testManageContainerRegistry() {
-        Assert.assertTrue(ManageContainerRegistry.runSample(azure));
+        Assertions.assertTrue(ManageContainerRegistry.runSample(azure));
     }
 
     @Test
     public void testManageContainerRegistryWithWebhooks() {
-        Assert.assertTrue(ManageContainerRegistryWithWebhooks.runSample(azure));
+        Assertions.assertTrue(ManageContainerRegistryWithWebhooks.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerServiceTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ContainerServiceTests.java
@@ -9,29 +9,29 @@ package com.microsoft.azure.management.samples;
 import com.microsoft.azure.management.containerservice.samples.DeployImageFromContainerRegistryToContainerServiceOrchestrator;
 import com.microsoft.azure.management.containerservice.samples.ManageContainerServiceWithDockerSwarmOrchestrator;
 import com.microsoft.azure.management.containerservice.samples.ManageContainerServiceWithKubernetesOrchestrator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ContainerServiceTests extends SamplesTestBase {
     @Test
     public void testManageContainerServiceWithKubernetesOrchestrator() {
         if (isPlaybackMode()) {
             // Disable mocked testing but keep it commented out in case we want to re-enable it later
-            // Assert.assertTrue(ManageContainerServiceWithKubernetesOrchestrator.runSample(azure, "client id", "secret"));
+            // Assertions.assertTrue(ManageContainerServiceWithKubernetesOrchestrator.runSample(azure, "client id", "secret"));
         } else {
-            Assert.assertTrue(ManageContainerServiceWithKubernetesOrchestrator.runSample(azure, "", ""));
+            Assertions.assertTrue(ManageContainerServiceWithKubernetesOrchestrator.runSample(azure, "", ""));
         }
     }
 
     @Test
     public void testManageContainerServiceWithDockerSwarmOrchestrator() {
-        Assert.assertTrue(ManageContainerServiceWithDockerSwarmOrchestrator.runSample(azure));
+        Assertions.assertTrue(ManageContainerServiceWithDockerSwarmOrchestrator.runSample(azure));
     }
 
     @Test
     public void testDeployImageFromContainerRegistryToContainerServiceOrchestrator() {
         if (!isPlaybackMode()) {
-            Assert.assertTrue(DeployImageFromContainerRegistryToContainerServiceOrchestrator.runSample(azure, "", ""));
+            Assertions.assertTrue(DeployImageFromContainerRegistryToContainerServiceOrchestrator.runSample(azure, "", ""));
         }
     }
 

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/CosmosDBTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/CosmosDBTests.java
@@ -11,8 +11,8 @@ import com.microsoft.azure.management.cosmosdb.samples.CreateCosmosDBWithIPRange
 import com.microsoft.azure.management.cosmosdb.samples.CreateCosmosDBWithKindMongoDB;
 import com.microsoft.azure.management.cosmosdb.samples.CreateCosmosDBTableWithVirtualNetworkRule;
 import com.microsoft.azure.management.cosmosdb.samples.ManageHACosmosDB;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CosmosDBTests extends SamplesTestBase {
 
@@ -20,25 +20,25 @@ public class CosmosDBTests extends SamplesTestBase {
     public void testCreateCosmosDBWithEventualConsistency() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(CreateCosmosDBWithEventualConsistency.runSample(azure, "clientId"));
+            Assertions.assertTrue(CreateCosmosDBWithEventualConsistency.runSample(azure, "clientId"));
         }
     }
 
     @Test
     public void testCreateCosmosDBWithIPRange() {
-        Assert.assertTrue(CreateCosmosDBWithIPRange.runSample(azure, "clientId"));
+        Assertions.assertTrue(CreateCosmosDBWithIPRange.runSample(azure, "clientId"));
     }
 
     @Test
     public void testCreateCosmosDBTableWithVirtualNetworkRule() {
-        Assert.assertTrue(CreateCosmosDBTableWithVirtualNetworkRule.runSample(azure, "clientId"));
+        Assertions.assertTrue(CreateCosmosDBTableWithVirtualNetworkRule.runSample(azure, "clientId"));
     }
 
     @Test
     public void testCreateCosmosDBWithKindMongoDB() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(CreateCosmosDBWithKindMongoDB.runSample(azure, "clientId"));
+            Assertions.assertTrue(CreateCosmosDBWithKindMongoDB.runSample(azure, "clientId"));
         }
     }
 
@@ -46,7 +46,7 @@ public class CosmosDBTests extends SamplesTestBase {
     public void testManageHACosmosDB() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageHACosmosDB.runSample(azure, "clientId"));
+            Assertions.assertTrue(ManageHACosmosDB.runSample(azure, "clientId"));
         }
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/DnsSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/DnsSampleTests.java
@@ -7,16 +7,16 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.dns.samples.ManageDns;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DnsSampleTests extends SamplesTestBase {
 
     @Test
-    @Ignore("The domain name 'the custom domain that you own (e.g. contoso.com)' is invalid.")
+    @Disabled("The domain name 'the custom domain that you own (e.g. contoso.com)' is invalid.")
     public void testManageDns() {
-        Assert.assertTrue(ManageDns.runSample(azure));
+        Assertions.assertTrue(ManageDns.runSample(azure));
     }
 
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/EventHubTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/EventHubTests.java
@@ -9,24 +9,24 @@ package com.microsoft.azure.management.samples;
 import com.microsoft.azure.management.eventhub.samples.ManageEventHub;
 import com.microsoft.azure.management.eventhub.samples.ManageEventHubEvents;
 import com.microsoft.azure.management.eventhub.samples.ManageEventHubGeoDisasterRecovery;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class EventHubTests extends SamplesTestBase {
     @Test
     public void testManageEventHubGeoDisasterRecovery() {
-        Assert.assertTrue(ManageEventHubGeoDisasterRecovery.runSample(azure));
+        Assertions.assertTrue(ManageEventHubGeoDisasterRecovery.runSample(azure));
     }
 
     @Test
-    @Ignore("Sample uses storage dataplane api which cannot be recorded")
+    @Disabled("Sample uses storage dataplane api which cannot be recorded")
     public void testManageEventHub() {
-        Assert.assertTrue(ManageEventHub.runSample(azure));
+        Assertions.assertTrue(ManageEventHub.runSample(azure));
     }
 
     @Test
     public void testManageEventHubEvents() {
-        Assert.assertTrue(ManageEventHubEvents.runSample(azure));
+        Assertions.assertTrue(ManageEventHubEvents.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/GraphRbacTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/GraphRbacTests.java
@@ -12,8 +12,8 @@ import com.microsoft.azure.management.graphrbac.samples.ManageServicePrincipalCr
 import com.microsoft.azure.management.graphrbac.samples.ManageUsersGroupsAndRoles;
 import com.azure.management.resources.core.TestBase;
 import com.microsoft.rest.RestClient;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GraphRbacTests extends TestBase {
     private Azure.Authenticated authenticated;
@@ -25,17 +25,17 @@ public class GraphRbacTests extends TestBase {
 
     @Test
     public void testManageUsersGroupsAndRoles() {
-        Assert.assertTrue(ManageUsersGroupsAndRoles.runSample(authenticated, defaultSubscription));
+        Assertions.assertTrue(ManageUsersGroupsAndRoles.runSample(authenticated, defaultSubscription));
     }
 
     @Test
     public void testManageServicePrincipal() {
-        Assert.assertTrue(ManageServicePrincipal.runSample(authenticated, defaultSubscription));
+        Assertions.assertTrue(ManageServicePrincipal.runSample(authenticated, defaultSubscription));
     }
 
     @Test
     public void testManageServicePrincipalCredentials() {
-        Assert.assertTrue(ManageServicePrincipalCredentials.runSample(authenticated, defaultSubscription, AzureEnvironment.AZURE));
+        Assertions.assertTrue(ManageServicePrincipalCredentials.runSample(authenticated, defaultSubscription, AzureEnvironment.AZURE));
     }
 
     @Override

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/KeyVaultSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/KeyVaultSampleTests.java
@@ -8,16 +8,16 @@ package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import com.azure.management.keyvault.samples.ManageKeyVault;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
 public class KeyVaultSampleTests extends SamplesTestBase {
     @Test
-    @Ignore("Some RBAC related issue with current credentials")
+    @Disabled("Some RBAC related issue with current credentials")
     public void testManageKeyVault() {
         String clientId = "";
         if (!isPlaybackMode()) {
@@ -28,6 +28,6 @@ public class KeyVaultSampleTests extends SamplesTestBase {
                 e.printStackTrace();
             }
         }
-        Assert.assertTrue(ManageKeyVault.runSample(azure, clientId));
+        Assertions.assertTrue(ManageKeyVault.runSample(azure, clientId));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/KubernetesClusterTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/KubernetesClusterTests.java
@@ -8,37 +8,37 @@ package com.microsoft.azure.management.samples;
 import com.microsoft.azure.management.kubernetescluster.samples.DeployImageFromContainerRegistryToKubernetes;
 import com.microsoft.azure.management.kubernetescluster.samples.ManageKubernetesCluster;
 import com.microsoft.azure.management.kubernetescluster.samples.ManagedKubernetesClusterWithAdvancedNetworking;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class KubernetesClusterTests extends SamplesTestBase {
     @Test
-    @Ignore("QuotaExceeded error: Public preview limit of 5 for managed cluster(AKS) has been reached for subscription sub-id in location ukwest. Same error even after deleting all clusters")
+    @Disabled("QuotaExceeded error: Public preview limit of 5 for managed cluster(AKS) has been reached for subscription sub-id in location ukwest. Same error even after deleting all clusters")
     public void testManageKubernetesCluster() {
         if (isPlaybackMode()) {
             // Disable mocked testing but keep it commented out in case we want to re-enable it later
-            // Assert.assertTrue(ManageKubernetesCluster.runSample(azure, "client id", "secret"));
+            // Assertions.assertTrue(ManageKubernetesCluster.runSample(azure, "client id", "secret"));
         } else {
-            Assert.assertTrue(ManageKubernetesCluster.runSample(azure, "", ""));
+            Assertions.assertTrue(ManageKubernetesCluster.runSample(azure, "", ""));
         }
     }
 
     @Test
-    @Ignore("QuotaExceeded error: Public preview limit of 5 for managed cluster(AKS) has been reached for subscription sub-id in location ukwest. Same error even after deleting all clusters")
+    @Disabled("QuotaExceeded error: Public preview limit of 5 for managed cluster(AKS) has been reached for subscription sub-id in location ukwest. Same error even after deleting all clusters")
     public void testManageKubernetesClusterWithAdvancedNetworking() {
         if (isPlaybackMode()) {
             // Disable mocked testing but keep it commented out in case we want to re-enable it later
-            // Assert.assertTrue(ManageKubernetesCluster.runSample(azure, "client id", "secret"));
+            // Assertions.assertTrue(ManageKubernetesCluster.runSample(azure, "client id", "secret"));
         } else {
-            Assert.assertTrue(ManagedKubernetesClusterWithAdvancedNetworking.runSample(azure, "", ""));
+            Assertions.assertTrue(ManagedKubernetesClusterWithAdvancedNetworking.runSample(azure, "", ""));
         }
     }
 
     @Test
     public void testDeployImageFromContainerRegistryToKubernetes() {
         if (!isPlaybackMode()) {
-            Assert.assertTrue(DeployImageFromContainerRegistryToKubernetes.runSample(azure, "", ""));
+            Assertions.assertTrue(DeployImageFromContainerRegistryToKubernetes.runSample(azure, "", ""));
         }
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/LocksTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/LocksTests.java
@@ -8,13 +8,13 @@ package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.locks.samples.ManageLocks;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LocksTests extends SamplesTestBase {
 
     @Test
     public void testManageLocks() {
-        Assert.assertTrue(ManageLocks.runSample(azure));
+        Assertions.assertTrue(ManageLocks.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/MonitorTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/MonitorTests.java
@@ -10,31 +10,31 @@ import com.microsoft.azure.management.monitor.samples.AutoscaleSettingsBasedOnPe
 import com.microsoft.azure.management.monitor.samples.QueryMetricsAndActivityLogs;
 import com.microsoft.azure.management.monitor.samples.SecurityBreachOrRiskActivityLogAlerts;
 import com.microsoft.azure.management.monitor.samples.WebAppPerformanceMonitoringAlerts;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class MonitorTests extends SamplesTestBase {
 
     @Test
-    @Ignore("Live only sample due to the need to query metrics at the current execution time which is always variable.")
+    @Disabled("Live only sample due to the need to query metrics at the current execution time which is always variable.")
     public void testQueryMetricsAndActivityLogs() {
-        Assert.assertTrue(QueryMetricsAndActivityLogs.runSample(azure));
+        Assertions.assertTrue(QueryMetricsAndActivityLogs.runSample(azure));
     }
 
     @Test
-    @Ignore("Live only sample due to the need to query metrics at the current execution time which is always variable.")
+    @Disabled("Live only sample due to the need to query metrics at the current execution time which is always variable.")
     public void testSecurityBreachOrRiskActivityLogAlerts() {
-        Assert.assertTrue(SecurityBreachOrRiskActivityLogAlerts.runSample(azure));
+        Assertions.assertTrue(SecurityBreachOrRiskActivityLogAlerts.runSample(azure));
     }
 
     @Test
     public void testWebAppPerformanceMonitoringAlerts() {
-        Assert.assertTrue(WebAppPerformanceMonitoringAlerts.runSample(azure));
+        Assertions.assertTrue(WebAppPerformanceMonitoringAlerts.runSample(azure));
     }
 
     @Test
     public void testAutoscaleSettingsBasedOnPerformanceOrSchedule() {
-        Assert.assertTrue(AutoscaleSettingsBasedOnPerformanceOrSchedule.runSample(azure));
+        Assertions.assertTrue(AutoscaleSettingsBasedOnPerformanceOrSchedule.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/NetworkSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/NetworkSampleTests.java
@@ -7,86 +7,86 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.network.samples.*;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class NetworkSampleTests extends SamplesTestBase {
 
     @Test
     public void testManageNetworkPeeringInSameSubscription() {
-        Assert.assertTrue(ManageNetworkPeeringInSameSubscription.runSample(azure));
+        Assertions.assertTrue(ManageNetworkPeeringInSameSubscription.runSample(azure));
     }
 
     @Test
-    @Ignore("Get error `Cannot create more than 1 network watchers for this subscription in this region.` with test subscription")
+    @Disabled("Get error `Cannot create more than 1 network watchers for this subscription in this region.` with test subscription")
     public void testVerifyNetworkPeeringWithNetworkWatcher() {
-        Assert.assertTrue(VerifyNetworkPeeringWithNetworkWatcher.runSample(azure));
+        Assertions.assertTrue(VerifyNetworkPeeringWithNetworkWatcher.runSample(azure));
     }
 
     @Test
     public void testManageApplicationGateway() {
-        Assert.assertTrue(ManageApplicationGateway.runSample(azure));
+        Assertions.assertTrue(ManageApplicationGateway.runSample(azure));
     }
 
     @Test
     public void testManageInternalLoadBalancer() {
-        Assert.assertTrue(ManageInternalLoadBalancer.runSample(azure));
+        Assertions.assertTrue(ManageInternalLoadBalancer.runSample(azure));
     }
 
     @Test
     public void testCreateSimpleInternetFacingLoadBalancer() {
-        Assert.assertTrue(CreateSimpleInternetFacingLoadBalancer.runSample(azure));
+        Assertions.assertTrue(CreateSimpleInternetFacingLoadBalancer.runSample(azure));
     }
 
     @Test
     public void testManageInternetFacingLoadBalancer() {
-        Assert.assertTrue(ManageInternetFacingLoadBalancer.runSample(azure));
+        Assertions.assertTrue(ManageInternetFacingLoadBalancer.runSample(azure));
     }
 
     @Test
     public void testManageIPAddress() {
-        Assert.assertTrue(ManageIPAddress.runSample(azure));
+        Assertions.assertTrue(ManageIPAddress.runSample(azure));
     }
 
     @Test
     public void testManageNetworkInterface() {
-        Assert.assertTrue(ManageNetworkInterface.runSample(azure));
+        Assertions.assertTrue(ManageNetworkInterface.runSample(azure));
     }
 
     @Test
     public void testManageNetworkSecurityGroup() {
-        Assert.assertTrue(ManageNetworkSecurityGroup.runSample(azure));
+        Assertions.assertTrue(ManageNetworkSecurityGroup.runSample(azure));
     }
 
     @Test
     public void testManageSimpleApplicationGateway() {
-        Assert.assertTrue(ManageSimpleApplicationGateway.runSample(azure));
+        Assertions.assertTrue(ManageSimpleApplicationGateway.runSample(azure));
     }
 
     @Test
     public void testManageVirtualMachinesInParallelWithNetwork() {
-        Assert.assertTrue(ManageVirtualMachinesInParallelWithNetwork.runSample(azure));
+        Assertions.assertTrue(ManageVirtualMachinesInParallelWithNetwork.runSample(azure));
     }
 
     @Test
     public void testManageVirtualNetwork() {
-        Assert.assertTrue(ManageVirtualNetwork.runSample(azure));
+        Assertions.assertTrue(ManageVirtualNetwork.runSample(azure));
     }
 
     @Test
     public void testManageVirtualNetworkAsync() {
-        Assert.assertTrue(ManageVirtualNetworkAsync.runSample(azure));
+        Assertions.assertTrue(ManageVirtualNetworkAsync.runSample(azure));
     }
 
     @Test
     public void testManageVpnGatewaySite2SiteConnection() {
-        Assert.assertTrue(ManageVpnGatewaySite2SiteConnection.runSample(azure));
+        Assertions.assertTrue(ManageVpnGatewaySite2SiteConnection.runSample(azure));
     }
 
     @Test
-    @Ignore("Need root certificate file and client certificate thumbprint to run the sample")
+    @Disabled("Need root certificate file and client certificate thumbprint to run the sample")
     public void testManageVpnGatewayPoint2SiteConnection() {
-        Assert.assertTrue(ManageVpnGatewayPoint2SiteConnection.runSample(azure));
+        Assertions.assertTrue(ManageVpnGatewayPoint2SiteConnection.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/NetworkWatcherSampleLiveOnlyTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/NetworkWatcherSampleLiveOnlyTests.java
@@ -7,8 +7,8 @@ package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.network.samples.ManageNetworkWatcher;
 import com.azure.management.resources.core.TestBase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NetworkWatcherSampleLiveOnlyTests extends SamplesTestBase {
     public NetworkWatcherSampleLiveOnlyTests() {
@@ -17,6 +17,6 @@ public class NetworkWatcherSampleLiveOnlyTests extends SamplesTestBase {
 
     @Test
     public void testManageNetworkWatcher() {
-        Assert.assertTrue(ManageNetworkWatcher.runSample(azure));
+        Assertions.assertTrue(ManageNetworkWatcher.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/RedisCacheSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/RedisCacheSampleTests.java
@@ -7,12 +7,12 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.rediscache.samples.ManageRedisCache;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RedisCacheSampleTests extends SamplesTestBase {
     @Test
     public void testManageRedisCache() {
-        Assert.assertTrue(ManageRedisCache.runSample(azure));
+        Assertions.assertTrue(ManageRedisCache.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ResourceSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ResourceSampleTests.java
@@ -14,9 +14,9 @@ import com.azure.management.resources.samples.DeployUsingARMTemplateWithTags;
 import com.azure.management.resources.samples.DeployVirtualMachineUsingARMTemplate;
 import com.azure.management.resources.samples.ManageResource;
 import com.azure.management.resources.samples.ManageResourceGroup;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ResourceSampleTests extends SamplesTestBase {
     @Test
@@ -24,45 +24,45 @@ public class ResourceSampleTests extends SamplesTestBase {
         if (isPlaybackMode()) {
             return;
         }
-        Assert.assertTrue(DeployUsingARMTemplate.runSample(azure));
+        Assertions.assertTrue(DeployUsingARMTemplate.runSample(azure));
     }
 
     @Test
     public void testDeployUsingARMTemplateWithProgress() {
-        Assert.assertTrue(DeployUsingARMTemplateWithProgress.runSample(azure));
+        Assertions.assertTrue(DeployUsingARMTemplateWithProgress.runSample(azure));
     }
 
     @Test
     public void testDeployUsingARMTemplateAsync() {
-        Assert.assertTrue(DeployUsingARMTemplateAsync.runSample(azure));
+        Assertions.assertTrue(DeployUsingARMTemplateAsync.runSample(azure));
     }
 
     @Test()
     public void testDeployUsingARMTemplateWithDeploymentOperations() {
         if (isPlaybackMode()) {
-            Assert.assertTrue(DeployUsingARMTemplateWithDeploymentOperations.runSample(azure, 0));
+            Assertions.assertTrue(DeployUsingARMTemplateWithDeploymentOperations.runSample(azure, 0));
         } else {
-            Assert.assertTrue(DeployUsingARMTemplateWithDeploymentOperations.runSample(azure, -1));
+            Assertions.assertTrue(DeployUsingARMTemplateWithDeploymentOperations.runSample(azure, -1));
         }
     }
 
     @Test
     public void testDeployUsingARMTemplateWithTags() {
-        Assert.assertTrue(DeployUsingARMTemplateWithTags.runSample(azure));
+        Assertions.assertTrue(DeployUsingARMTemplateWithTags.runSample(azure));
     }
 
     @Test
     public void testManageResource() {
-        Assert.assertTrue(ManageResource.runSample(azure));
+        Assertions.assertTrue(ManageResource.runSample(azure));
     }
 
     @Test
     public void testManageResourceGroup() {
-        Assert.assertTrue(ManageResourceGroup.runSample(azure));
+        Assertions.assertTrue(ManageResourceGroup.runSample(azure));
     }
 
     @Test
     public void testDeployVirtualMachineUsingARMTemplate() {
-        Assert.assertTrue(DeployVirtualMachineUsingARMTemplate.runSample(azure));
+        Assertions.assertTrue(DeployVirtualMachineUsingARMTemplate.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/SearchServiceTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/SearchServiceTests.java
@@ -7,12 +7,12 @@
 package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.search.samples.ManageSearchService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SearchServiceTests extends SamplesTestBase {
   @Test
   public void testManageSearchService() {
-    Assert.assertTrue(ManageSearchService.runSample(azure));
+    Assertions.assertTrue(ManageSearchService.runSample(azure));
   }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/ServiceBusSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/ServiceBusSampleTests.java
@@ -11,32 +11,32 @@ import com.microsoft.azure.management.servicebus.samples.ServiceBusPublishSubscr
 import com.microsoft.azure.management.servicebus.samples.ServiceBusQueueAdvanceFeatures;
 import com.microsoft.azure.management.servicebus.samples.ServiceBusQueueBasic;
 import com.microsoft.azure.management.servicebus.samples.ServiceBusWithClaimBasedAuthorization;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ServiceBusSampleTests extends SamplesTestBase {
     @Test
     public void testServiceBusQueueBasic() {
-        Assert.assertTrue(ServiceBusQueueBasic.runSample(azure));
+        Assertions.assertTrue(ServiceBusQueueBasic.runSample(azure));
     }
 
     @Test
     public void testServiceBusPublishSubscribeBasic() {
-        Assert.assertTrue(ServiceBusPublishSubscribeBasic.runSample(azure));
+        Assertions.assertTrue(ServiceBusPublishSubscribeBasic.runSample(azure));
     }
 
     @Test
     public void testServiceBusWithClaimBasedAuthorization() {
-        Assert.assertTrue(ServiceBusWithClaimBasedAuthorization.runSample(azure));
+        Assertions.assertTrue(ServiceBusWithClaimBasedAuthorization.runSample(azure));
     }
 
     @Test
     public void testServiceBusQueueAdvanceFeatures() {
-        Assert.assertTrue(ServiceBusQueueAdvanceFeatures.runSample(azure));
+        Assertions.assertTrue(ServiceBusQueueAdvanceFeatures.runSample(azure));
     }
 
     @Test
     public void testServiceBusPublishSubscribeAdvanceFeatures() {
-        Assert.assertTrue(ServiceBusPublishSubscribeAdvanceFeatures.runSample(azure));
+        Assertions.assertTrue(ServiceBusPublishSubscribeAdvanceFeatures.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/SqlSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/SqlSampleTests.java
@@ -120,7 +120,7 @@ public class SqlSampleTests extends SamplesTestBase {
                 try {
                     servicePrincipalClientId = Utils.getSecondaryServicePrincipalClientID(envSecondaryServicePrincipal);
                 } catch (Exception e) {
-                    Assertions.assertFalse("Unexpected exception trying to retrieve the client ID", true);
+                    Assertions.assertFalse(true, "Unexpected exception trying to retrieve the client ID");
                 }
             }
 

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/SqlSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/SqlSampleTests.java
@@ -19,8 +19,8 @@ import com.microsoft.azure.management.sql.samples.ManageSqlServerSecurityAlertPo
 import com.microsoft.azure.management.sql.samples.ManageSqlVirtualNetworkRules;
 import com.microsoft.azure.management.sql.samples.ManageSqlWithRecoveredOrRestoredDatabase;
 import com.microsoft.rest.RestClient;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -37,58 +37,58 @@ public class SqlSampleTests extends SamplesTestBase {
 
     @Test
     public void testManageSqlDatabase() {
-        Assert.assertTrue(ManageSqlDatabase.runSample(azure));
+        Assertions.assertTrue(ManageSqlDatabase.runSample(azure));
     }
 
     @Test
     public void testManageSqlDatabaseInElasticPool() {
-        Assert.assertTrue(ManageSqlDatabaseInElasticPool.runSample(azure));
+        Assertions.assertTrue(ManageSqlDatabaseInElasticPool.runSample(azure));
     }
 
     @Test
     public void testManageSqlDatabasesAcrossDifferentDataCenters() {
-        Assert.assertTrue(ManageSqlDatabasesAcrossDifferentDataCenters.runSample(azure));
+        Assertions.assertTrue(ManageSqlDatabasesAcrossDifferentDataCenters.runSample(azure));
     }
 
     @Test
     public void testManageSqlFirewallRules() {
-        Assert.assertTrue(ManageSqlFirewallRules.runSample(azure));
+        Assertions.assertTrue(ManageSqlFirewallRules.runSample(azure));
     }
 
     @Test
     public void testManageSqlServerSecurityAlertPolicy() {
-        Assert.assertTrue(ManageSqlServerSecurityAlertPolicy.runSample(azure));
+        Assertions.assertTrue(ManageSqlServerSecurityAlertPolicy.runSample(azure));
     }
 
     @Test
     public void testManageSqlVirtualNetworkRules() {
-        Assert.assertTrue(ManageSqlVirtualNetworkRules.runSample(azure));
+        Assertions.assertTrue(ManageSqlVirtualNetworkRules.runSample(azure));
     }
 
     @Test
     public void testManageSqlImportExportDatabase() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageSqlImportExportDatabase.runSample(azure));
+            Assertions.assertTrue(ManageSqlImportExportDatabase.runSample(azure));
         }
     }
 
     @Test
     public void testManageSqlWithRecoveredOrRestoredDatabase() {
         // This test can take significant time to run since it depends on the availability of certain resources on the service side.
-        Assert.assertTrue(ManageSqlWithRecoveredOrRestoredDatabase.runSample(azure));
+        Assertions.assertTrue(ManageSqlWithRecoveredOrRestoredDatabase.runSample(azure));
     }
 
     @Test
     public void testManageSqlFailoverGroups() {
-        Assert.assertTrue(ManageSqlFailoverGroups.runSample(azure));
+        Assertions.assertTrue(ManageSqlFailoverGroups.runSample(azure));
     }
 
     @Test
     public void testGettingSqlServerMetrics() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(GettingSqlServerMetrics.runSample(azure));
+            Assertions.assertTrue(GettingSqlServerMetrics.runSample(azure));
         }
     }
 
@@ -96,7 +96,7 @@ public class SqlSampleTests extends SamplesTestBase {
     public void testManageSqlServerDnsAliases() {
         // Skip test in "playback" mode due to HTTP calls made outside of the management plane which can not be recorded at this time
         if (!isPlaybackMode()) {
-            Assert.assertTrue(ManageSqlServerDnsAliases.runSample(azure));
+            Assertions.assertTrue(ManageSqlServerDnsAliases.runSample(azure));
         }
     }
 
@@ -120,11 +120,11 @@ public class SqlSampleTests extends SamplesTestBase {
                 try {
                     servicePrincipalClientId = Utils.getSecondaryServicePrincipalClientID(envSecondaryServicePrincipal);
                 } catch (Exception e) {
-                    Assert.assertFalse("Unexpected exception trying to retrieve the client ID", true);
+                    Assertions.assertFalse("Unexpected exception trying to retrieve the client ID", true);
                 }
             }
 
-            Assert.assertTrue(ManageSqlServerKeysWithAzureKeyVaultKey.runSample(azure, servicePrincipalClientId));
+            Assertions.assertTrue(ManageSqlServerKeysWithAzureKeyVaultKey.runSample(azure, servicePrincipalClientId));
         }
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/StorageSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/StorageSampleTests.java
@@ -9,22 +9,22 @@ package com.microsoft.azure.management.samples;
 import com.azure.management.storage.samples.ManageStorageAccount;
 import com.azure.management.storage.samples.ManageStorageAccountAsync;
 import com.azure.management.storage.samples.ManageStorageAccountNetworkRules;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StorageSampleTests extends SamplesTestBase {
     @Test
     public void testManageStorageAccount() {
-        Assert.assertTrue(ManageStorageAccount.runSample(azure));
+        Assertions.assertTrue(ManageStorageAccount.runSample(azure));
     }
 
     @Test
     public void testManageStorageAccountAsync() {
-        Assert.assertTrue(ManageStorageAccountAsync.runSample(azure));
+        Assertions.assertTrue(ManageStorageAccountAsync.runSample(azure));
     }
 
     @Test
     public void testManageStorageAccountNetworkRules() {
-        Assert.assertTrue(ManageStorageAccountNetworkRules.runSample(azure));
+        Assertions.assertTrue(ManageStorageAccountNetworkRules.runSample(azure));
     }
 }

--- a/azure-samples/src/test/java/com/microsoft/azure/management/samples/TrafficManagerSampleTests.java
+++ b/azure-samples/src/test/java/com/microsoft/azure/management/samples/TrafficManagerSampleTests.java
@@ -8,19 +8,19 @@ package com.microsoft.azure.management.samples;
 
 import com.microsoft.azure.management.trafficmanager.samples.ManageSimpleTrafficManager;
 import com.microsoft.azure.management.trafficmanager.samples.ManageTrafficManager;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TrafficManagerSampleTests extends SamplesTestBase {
     @Test
     public void testManageSimpleTrafficManager() {
-        Assert.assertTrue(ManageSimpleTrafficManager.runSample(azure));
+        Assertions.assertTrue(ManageSimpleTrafficManager.runSample(azure));
     }
 
     @Test
-    @Ignore("Failing -  The subscription is not registered to use namespace 'Microsoft.DomainRegistration'")
+    @Disabled("Failing -  The subscription is not registered to use namespace 'Microsoft.DomainRegistration'")
     public void testManageTrafficManager() {
-        Assert.assertTrue(ManageTrafficManager.runSample(azure));
+        Assertions.assertTrue(ManageTrafficManager.runSample(azure));
     }
 }

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -125,8 +125,8 @@
       <version>1.28.1-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/azure/src/test/java/com/microsoft/azure/management/ApplicationGatewayTests.java
+++ b/azure/src/test/java/com/microsoft/azure/management/ApplicationGatewayTests.java
@@ -24,8 +24,8 @@ import com.azure.management.resources.fluentcore.model.Creatable;
 import com.azure.management.resources.fluentcore.model.CreatedResources;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.microsoft.rest.RestClient;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -130,9 +130,9 @@ public class ApplicationGatewayTests extends TestBase {
 
             // Connect the 1st VM via NIC IP config
             NetworkInterface nic = vms[0].getPrimaryNetworkInterface();
-            Assert.assertNotNull(nic);
+            Assertions.assertNotNull(nic);
             ApplicationGatewayBackend appGatewayBackend = appGateway.backends().get("nicBackend");
-            Assert.assertNotNull(appGatewayBackend);
+            Assertions.assertNotNull(appGatewayBackend);
             nic.update().updateIPConfiguration(nic.primaryIPConfiguration().name())
                     .withExistingApplicationGatewayBackend(appGateway, appGatewayBackend.name())
                     .parent()
@@ -147,11 +147,11 @@ public class ApplicationGatewayTests extends TestBase {
             for (ApplicationGatewayBackendHealth backendHealth : backendHealths.values()) {
                 info.append("\n\tApplication gateway backend name: ").append(backendHealth.name())
                         .append("\n\t\tHTTP configuration healths: ").append(backendHealth.httpConfigurationHealths().size());
-                Assert.assertNotNull(backendHealth.backend());
+                Assertions.assertNotNull(backendHealth.backend());
                 for (ApplicationGatewayBackendHttpConfigurationHealth backendConfigHealth : backendHealth.httpConfigurationHealths().values()) {
                     info.append("\n\t\t\tHTTP configuration name: ").append(backendConfigHealth.name())
                             .append("\n\t\t\tServers: ").append(backendConfigHealth.inner().servers().size());
-                    Assert.assertNotNull(backendConfigHealth.backendHttpConfiguration());
+                    Assertions.assertNotNull(backendConfigHealth.backendHttpConfiguration());
                     for (ApplicationGatewayBackendServerHealth serverHealth : backendConfigHealth.serverHealths().values()) {
                         NicIPConfiguration ipConfig = serverHealth.getNetworkInterfaceIPConfiguration();
                         if (ipConfig != null) {
@@ -167,38 +167,38 @@ public class ApplicationGatewayTests extends TestBase {
             System.out.println(info.toString());
 
             // Verify app gateway
-            Assert.assertEquals(2,  appGateway.backends().size());
+            Assertions.assertEquals(2,  appGateway.backends().size());
             ApplicationGatewayRequestRoutingRule rule1 = appGateway.requestRoutingRules().get("rule1");
-            Assert.assertNotNull(rule1);
+            Assertions.assertNotNull(rule1);
             ApplicationGatewayBackend backend1 = rule1.backend();
-            Assert.assertNotNull(backend1);
+            Assertions.assertNotNull(backend1);
             ApplicationGatewayRequestRoutingRule rule2 = appGateway.requestRoutingRules().get("rule2");
-            Assert.assertNotNull(rule2);
+            Assertions.assertNotNull(rule2);
             ApplicationGatewayBackend backend2 = rule2.backend();
-            Assert.assertNotNull(backend2);
+            Assertions.assertNotNull(backend2);
 
-            Assert.assertEquals(2, backendHealths.size());
+            Assertions.assertEquals(2, backendHealths.size());
 
             // Verify first backend (IP address-based)
             ApplicationGatewayBackendHealth backendHealth1 = backendHealths.get(backend1.name());
-            Assert.assertNotNull(backendHealth1);
-            Assert.assertNotNull(backendHealth1.backend());
+            Assertions.assertNotNull(backendHealth1);
+            Assertions.assertNotNull(backendHealth1.backend());
             for (int i = 0; i < ipAddresses.length; i++) {
-                Assert.assertTrue(backend1.containsIPAddress(ipAddresses[i]));
+                Assertions.assertTrue(backend1.containsIPAddress(ipAddresses[i]));
             }
 
             // Verify second backend (NIC based)
             ApplicationGatewayBackendHealth backendHealth2 = backendHealths.get(backend2.name());
-            Assert.assertNotNull(backendHealth2);
-            Assert.assertNotNull(backendHealth2.backend());
-            Assert.assertEquals(backend2.name(), backendHealth2.name());
-            Assert.assertEquals(1,  backendHealth2.httpConfigurationHealths().size());
+            Assertions.assertNotNull(backendHealth2);
+            Assertions.assertNotNull(backendHealth2.backend());
+            Assertions.assertEquals(backend2.name(), backendHealth2.name());
+            Assertions.assertEquals(1,  backendHealth2.httpConfigurationHealths().size());
             ApplicationGatewayBackendHttpConfigurationHealth httpConfigHealth2 = backendHealth2.httpConfigurationHealths().values().iterator().next();
-            Assert.assertNotNull(httpConfigHealth2.backendHttpConfiguration());
-            Assert.assertEquals(1, httpConfigHealth2.serverHealths().size());
+            Assertions.assertNotNull(httpConfigHealth2.backendHttpConfiguration());
+            Assertions.assertEquals(1, httpConfigHealth2.serverHealths().size());
             ApplicationGatewayBackendServerHealth serverHealth = httpConfigHealth2.serverHealths().values().iterator().next();
             NicIPConfiguration ipConfig2 = serverHealth.getNetworkInterfaceIPConfiguration();
-            Assert.assertEquals(nic.primaryIPConfiguration().name(), ipConfig2.name());
+            Assertions.assertEquals(nic.primaryIPConfiguration().name(), ipConfig2.name());
         } catch (Exception e) {
             throw e;
         } finally {
@@ -239,9 +239,9 @@ public class ApplicationGatewayTests extends TestBase {
 
         // Test stop/start
         appGateway.stop();
-        Assert.assertEquals(ApplicationGatewayOperationalState.STOPPED, appGateway.operationalState());
+        Assertions.assertEquals(ApplicationGatewayOperationalState.STOPPED, appGateway.operationalState());
         appGateway.start();
-        Assert.assertEquals(ApplicationGatewayOperationalState.RUNNING, appGateway.operationalState());
+        Assertions.assertEquals(ApplicationGatewayOperationalState.RUNNING, appGateway.operationalState());
 
         azure.resourceGroups().beginDeleteByName(rgName);
     }
@@ -281,7 +281,7 @@ public class ApplicationGatewayTests extends TestBase {
         List<String> agIds = new ArrayList<>();
         for (Creatable<ApplicationGateway> creatable : agCreatables) {
             ApplicationGateway ag = created.get(creatable.key());
-            Assert.assertNotNull(ag);
+            Assertions.assertNotNull(ag);
             ags.add(ag);
             agIds.add(ag.id());
         }
@@ -289,18 +289,18 @@ public class ApplicationGatewayTests extends TestBase {
         azure.applicationGateways().stop(agIds);
 
         for (ApplicationGateway ag : ags) {
-            Assert.assertEquals(ApplicationGatewayOperationalState.STOPPED, ag.refresh().operationalState());
+            Assertions.assertEquals(ApplicationGatewayOperationalState.STOPPED, ag.refresh().operationalState());
         }
 
         azure.applicationGateways().start(agIds);
 
         for (ApplicationGateway ag : ags) {
-            Assert.assertEquals(ApplicationGatewayOperationalState.RUNNING, ag.refresh().operationalState());
+            Assertions.assertEquals(ApplicationGatewayOperationalState.RUNNING, ag.refresh().operationalState());
         }
 
         azure.applicationGateways().deleteByIds(agIds);
         for (String id : agIds) {
-            Assert.assertNull(azure.applicationGateways().getById(id));
+            Assertions.assertNull(azure.applicationGateways().getById(id));
         }
 
         azure.resourceGroups().beginDeleteByName(rgName);

--- a/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
+++ b/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
@@ -70,9 +70,9 @@ import com.microsoft.rest.RestClient;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -112,40 +112,40 @@ public class AzureTests extends TestBase {
         Runnable reader1 = new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals(CountryIsoCode.AFGHANISTAN, CountryIsoCode.fromString("AF"));
-                Assert.assertEquals(CountryIsoCode.ANTARCTICA, CountryIsoCode.fromString("AQ"));
-                Assert.assertEquals(CountryIsoCode.ANDORRA, CountryIsoCode.fromString("AD"));
-                Assert.assertEquals(CountryIsoCode.ARGENTINA, CountryIsoCode.fromString("AR"));
-                Assert.assertEquals(CountryIsoCode.ALBANIA, CountryIsoCode.fromString("AL"));
-                Assert.assertEquals(CountryIsoCode.ALGERIA, CountryIsoCode.fromString("DZ"));
-                Assert.assertEquals(CountryIsoCode.AMERICAN_SAMOA, CountryIsoCode.fromString("AS"));
-                Assert.assertEquals(CountryIsoCode.ANGOLA, CountryIsoCode.fromString("AO"));
-                Assert.assertEquals(CountryIsoCode.ANGUILLA, CountryIsoCode.fromString("AI"));
-                Assert.assertEquals(CountryIsoCode.ANTIGUA_AND_BARBUDA, CountryIsoCode.fromString("AG"));
-                Assert.assertEquals(CountryIsoCode.ARMENIA, CountryIsoCode.fromString("AM"));
-                Assert.assertEquals(CountryIsoCode.ARUBA, CountryIsoCode.fromString("AW"));
-                Assert.assertEquals(CountryIsoCode.AUSTRALIA, CountryIsoCode.fromString("AU"));
-                Assert.assertEquals(CountryIsoCode.AUSTRIA, CountryIsoCode.fromString("AT"));
-                Assert.assertEquals(CountryIsoCode.AZERBAIJAN, CountryIsoCode.fromString("AZ"));
-                Assert.assertEquals(PowerState.DEALLOCATED, PowerState.fromString("PowerState/deallocated"));
-                Assert.assertEquals(PowerState.DEALLOCATING, PowerState.fromString("PowerState/deallocating"));
-                Assert.assertEquals(PowerState.RUNNING, PowerState.fromString("PowerState/running"));
+                Assertions.assertEquals(CountryIsoCode.AFGHANISTAN, CountryIsoCode.fromString("AF"));
+                Assertions.assertEquals(CountryIsoCode.ANTARCTICA, CountryIsoCode.fromString("AQ"));
+                Assertions.assertEquals(CountryIsoCode.ANDORRA, CountryIsoCode.fromString("AD"));
+                Assertions.assertEquals(CountryIsoCode.ARGENTINA, CountryIsoCode.fromString("AR"));
+                Assertions.assertEquals(CountryIsoCode.ALBANIA, CountryIsoCode.fromString("AL"));
+                Assertions.assertEquals(CountryIsoCode.ALGERIA, CountryIsoCode.fromString("DZ"));
+                Assertions.assertEquals(CountryIsoCode.AMERICAN_SAMOA, CountryIsoCode.fromString("AS"));
+                Assertions.assertEquals(CountryIsoCode.ANGOLA, CountryIsoCode.fromString("AO"));
+                Assertions.assertEquals(CountryIsoCode.ANGUILLA, CountryIsoCode.fromString("AI"));
+                Assertions.assertEquals(CountryIsoCode.ANTIGUA_AND_BARBUDA, CountryIsoCode.fromString("AG"));
+                Assertions.assertEquals(CountryIsoCode.ARMENIA, CountryIsoCode.fromString("AM"));
+                Assertions.assertEquals(CountryIsoCode.ARUBA, CountryIsoCode.fromString("AW"));
+                Assertions.assertEquals(CountryIsoCode.AUSTRALIA, CountryIsoCode.fromString("AU"));
+                Assertions.assertEquals(CountryIsoCode.AUSTRIA, CountryIsoCode.fromString("AT"));
+                Assertions.assertEquals(CountryIsoCode.AZERBAIJAN, CountryIsoCode.fromString("AZ"));
+                Assertions.assertEquals(PowerState.DEALLOCATED, PowerState.fromString("PowerState/deallocated"));
+                Assertions.assertEquals(PowerState.DEALLOCATING, PowerState.fromString("PowerState/deallocating"));
+                Assertions.assertEquals(PowerState.RUNNING, PowerState.fromString("PowerState/running"));
             }
         };
 
         Runnable reader2 = new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals(CountryIsoCode.BAHAMAS, CountryIsoCode.fromString("BS"));
-                Assert.assertEquals(CountryIsoCode.BAHRAIN, CountryIsoCode.fromString("BH"));
-                Assert.assertEquals(CountryIsoCode.BANGLADESH, CountryIsoCode.fromString("BD"));
-                Assert.assertEquals(CountryIsoCode.BARBADOS, CountryIsoCode.fromString("BB"));
-                Assert.assertEquals(CountryIsoCode.BELARUS, CountryIsoCode.fromString("BY"));
-                Assert.assertEquals(CountryIsoCode.BELGIUM, CountryIsoCode.fromString("BE"));
-                Assert.assertEquals(PowerState.STARTING, PowerState.fromString("PowerState/starting"));
-                Assert.assertEquals(PowerState.STOPPED, PowerState.fromString("PowerState/stopped"));
-                Assert.assertEquals(PowerState.STOPPING, PowerState.fromString("PowerState/stopping"));
-                Assert.assertEquals(PowerState.UNKNOWN, PowerState.fromString("PowerState/unknown"));
+                Assertions.assertEquals(CountryIsoCode.BAHAMAS, CountryIsoCode.fromString("BS"));
+                Assertions.assertEquals(CountryIsoCode.BAHRAIN, CountryIsoCode.fromString("BH"));
+                Assertions.assertEquals(CountryIsoCode.BANGLADESH, CountryIsoCode.fromString("BD"));
+                Assertions.assertEquals(CountryIsoCode.BARBADOS, CountryIsoCode.fromString("BB"));
+                Assertions.assertEquals(CountryIsoCode.BELARUS, CountryIsoCode.fromString("BY"));
+                Assertions.assertEquals(CountryIsoCode.BELGIUM, CountryIsoCode.fromString("BE"));
+                Assertions.assertEquals(PowerState.STARTING, PowerState.fromString("PowerState/starting"));
+                Assertions.assertEquals(PowerState.STOPPED, PowerState.fromString("PowerState/stopped"));
+                Assertions.assertEquals(PowerState.STOPPING, PowerState.fromString("PowerState/stopping"));
+                Assertions.assertEquals(PowerState.UNKNOWN, PowerState.fromString("PowerState/unknown"));
             }
         };
 
@@ -188,7 +188,7 @@ public class AzureTests extends TestBase {
         for (CountryIsoCode value : countryIsoCodes) {
             System.out.println(value.toString());
         }
-        Assert.assertEquals(257, countryIsoCodes.size());
+        Assertions.assertEquals(257, countryIsoCodes.size());
 
         // Verify power states
         Collection<PowerState> powerStates = PowerState.values();
@@ -196,7 +196,7 @@ public class AzureTests extends TestBase {
         for (PowerState value : powerStates) {
             System.out.println(value.toString());
         }
-        Assert.assertEquals(27, powerStates.size());
+        Assertions.assertEquals(27, powerStates.size());
     }
 
     /**
@@ -242,7 +242,7 @@ public class AzureTests extends TestBase {
             .create();
 
         PagedList<GenericResource> resources = azure.genericResources().listByResourceGroup(nsg.resourceGroupName());
-        Assert.assertEquals(2, resources.size());
+        Assertions.assertEquals(2, resources.size());
         GenericResource firstResource = resources.get(0);
 
         GenericResource resourceById = azure.genericResources().getById(firstResource.id());
@@ -251,7 +251,7 @@ public class AzureTests extends TestBase {
                 firstResource.resourceProviderNamespace(),
                 firstResource.resourceType(),
                 firstResource.name());
-        Assert.assertTrue(resourceById.id().equalsIgnoreCase(resourceByDetails.id()));
+        Assertions.assertTrue(resourceById.id().equalsIgnoreCase(resourceByDetails.id()));
         azure.resourceGroups().beginDeleteByName(nsg.resourceGroupName());
     }
 
@@ -282,7 +282,7 @@ public class AzureTests extends TestBase {
             resourceGroup = azure.resourceGroups().define(rgName)
                     .withRegion(region)
                     .create();
-            Assert.assertNotNull(resourceGroup);
+            Assertions.assertNotNull(resourceGroup);
 
             Creatable<Network> netDefinition = azure.networks().define(netName)
                     .withRegion(region)
@@ -367,72 +367,72 @@ public class AzureTests extends TestBase {
                     .create();
 
             // Verify VM lock
-            Assert.assertEquals(2, azure.managementLocks().listForResource(vm.id()).size());
+            Assertions.assertEquals(2, azure.managementLocks().listForResource(vm.id()).size());
 
-            Assert.assertNotNull(lockVM);
+            Assertions.assertNotNull(lockVM);
             lockVM = azure.managementLocks().getById(lockVM.id());
-            Assert.assertNotNull(lockVM);
+            Assertions.assertNotNull(lockVM);
             TestUtils.print(lockVM);
-            Assert.assertEquals(LockLevel.READ_ONLY, lockVM.level());
-            Assert.assertTrue(vm.id().equalsIgnoreCase(lockVM.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.READ_ONLY, lockVM.level());
+            Assertions.assertTrue(vm.id().equalsIgnoreCase(lockVM.lockedResourceId()));
 
             // Verify resource group lock
-            Assert.assertNotNull(lockGroup);
+            Assertions.assertNotNull(lockGroup);
             lockGroup = azure.managementLocks().getByResourceGroup(resourceGroup.name(), "rglock");
-            Assert.assertNotNull(lockGroup);
+            Assertions.assertNotNull(lockGroup);
             TestUtils.print(lockVM);
-            Assert.assertEquals(LockLevel.CAN_NOT_DELETE, lockGroup.level());
-            Assert.assertTrue(resourceGroup.id().equalsIgnoreCase(lockGroup.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.CAN_NOT_DELETE, lockGroup.level());
+            Assertions.assertTrue(resourceGroup.id().equalsIgnoreCase(lockGroup.lockedResourceId()));
 
             // Verify storage account lock
-            Assert.assertEquals(2, azure.managementLocks().listForResource(storage.id()).size());
+            Assertions.assertEquals(2, azure.managementLocks().listForResource(storage.id()).size());
 
-            Assert.assertNotNull(lockStorage);
+            Assertions.assertNotNull(lockStorage);
             lockStorage = azure.managementLocks().getById(lockStorage.id());
-            Assert.assertNotNull(lockStorage);
+            Assertions.assertNotNull(lockStorage);
             TestUtils.print(lockStorage);
-            Assert.assertEquals(LockLevel.CAN_NOT_DELETE, lockStorage.level());
-            Assert.assertTrue(storage.id().equalsIgnoreCase(lockStorage.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.CAN_NOT_DELETE, lockStorage.level());
+            Assertions.assertTrue(storage.id().equalsIgnoreCase(lockStorage.lockedResourceId()));
 
             // Verify disk lock
-            Assert.assertEquals(3, azure.managementLocks().listForResource(disk.id()).size());
+            Assertions.assertEquals(3, azure.managementLocks().listForResource(disk.id()).size());
 
-            Assert.assertNotNull(lockDiskRO);
+            Assertions.assertNotNull(lockDiskRO);
             lockDiskRO = azure.managementLocks().getById(lockDiskRO.id());
-            Assert.assertNotNull(lockDiskRO);
+            Assertions.assertNotNull(lockDiskRO);
             TestUtils.print(lockDiskRO);
-            Assert.assertEquals(LockLevel.READ_ONLY, lockDiskRO.level());
-            Assert.assertTrue(disk.id().equalsIgnoreCase(lockDiskRO.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.READ_ONLY, lockDiskRO.level());
+            Assertions.assertTrue(disk.id().equalsIgnoreCase(lockDiskRO.lockedResourceId()));
 
-            Assert.assertNotNull(lockDiskDel);
+            Assertions.assertNotNull(lockDiskDel);
             lockDiskDel = azure.managementLocks().getById(lockDiskDel.id());
-            Assert.assertNotNull(lockDiskDel);
+            Assertions.assertNotNull(lockDiskDel);
             TestUtils.print(lockDiskDel);
-            Assert.assertEquals(LockLevel.CAN_NOT_DELETE, lockDiskDel.level());
-            Assert.assertTrue(disk.id().equalsIgnoreCase(lockDiskDel.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.CAN_NOT_DELETE, lockDiskDel.level());
+            Assertions.assertTrue(disk.id().equalsIgnoreCase(lockDiskDel.lockedResourceId()));
 
             // Verify subnet lock
-            Assert.assertEquals(2, azure.managementLocks().listForResource(network.id()).size());
+            Assertions.assertEquals(2, azure.managementLocks().listForResource(network.id()).size());
 
             lockSubnet = azure.managementLocks().getById(lockSubnet.id());
-            Assert.assertNotNull(lockSubnet);
+            Assertions.assertNotNull(lockSubnet);
             TestUtils.print(lockSubnet);
-            Assert.assertEquals(LockLevel.READ_ONLY, lockSubnet.level());
-            Assert.assertTrue(subnet.inner().id().equalsIgnoreCase(lockSubnet.lockedResourceId()));
+            Assertions.assertEquals(LockLevel.READ_ONLY, lockSubnet.level());
+            Assertions.assertTrue(subnet.inner().id().equalsIgnoreCase(lockSubnet.lockedResourceId()));
 
             // Verify lock collection
             List<ManagementLock> locksSubscription = azure.managementLocks().list();
             List<ManagementLock> locksGroup = azure.managementLocks().listByResourceGroup(vm.resourceGroupName());
-            Assert.assertNotNull(locksSubscription);
-            Assert.assertNotNull(locksGroup);
+            Assertions.assertNotNull(locksSubscription);
+            Assertions.assertNotNull(locksGroup);
 
             int locksAllCount = locksSubscription.size();
             System.out.println("All locks: " + locksAllCount);
-            Assert.assertTrue(6 <= locksAllCount);
+            Assertions.assertTrue(6 <= locksAllCount);
 
             int locksGroupCount = locksGroup.size();
             System.out.println("Group locks: " + locksGroupCount);
-            Assert.assertEquals(6, locksGroup.size());
+            Assertions.assertEquals(6, locksGroup.size());
         } catch (Exception ex) {
             ex.printStackTrace(System.out);
         } finally {
@@ -469,7 +469,7 @@ public class AzureTests extends TestBase {
     @Test
     public void testVMImages() throws CloudException, IOException {
         List<VirtualMachinePublisher> publishers = azure.virtualMachineImages().publishers().listByRegion(Region.US_WEST);
-        Assert.assertTrue(publishers.size() > 0);
+        Assertions.assertTrue(publishers.size() > 0);
         for (VirtualMachinePublisher p : publishers) {
             System.out.println(String.format("Publisher name: %s, region: %s", p.name(), p.region()));
             try {
@@ -488,7 +488,7 @@ public class AzureTests extends TestBase {
             }
         }
         List<VirtualMachineImage> images = azure.virtualMachineImages().listByRegion(Region.US_WEST);
-        Assert.assertTrue(images.size() > 0);
+        Assertions.assertTrue(images.size() > 0);
         // Seems to help avoid connection refused error on subsequent mock test
         SdkContext.sleep(2000);
     }
@@ -557,7 +557,7 @@ public class AzureTests extends TestBase {
      * @throws Exception
      */
     @Test
-    @Ignore("Though valid scenario, NRP is failing")
+    @Disabled("Though valid scenario, NRP is failing")
     public void testLoadBalancersInternalWithAvailabilityZone() throws Exception {
         new TestLoadBalancer.InternalWithZone(azure.virtualMachines().manager())
                 .runTest(azure.loadBalancers(), azure.resourceGroups());
@@ -684,15 +684,15 @@ public class AzureTests extends TestBase {
 
         // Look up built-in region
         Region region = Region.fromName("westus");
-        Assert.assertTrue(region == Region.US_WEST);
+        Assertions.assertTrue(region == Region.US_WEST);
 
         // Add a region
         Region region2 = Region.fromName("madeUpRegion");
-        Assert.assertNotNull(region2);
-        Assert.assertTrue(region2.name().equalsIgnoreCase("madeUpRegion"));
+        Assertions.assertNotNull(region2);
+        Assertions.assertTrue(region2.name().equalsIgnoreCase("madeUpRegion"));
         Region region3 = Region.fromName("madeupregion");
-        Assert.assertEquals(region3, region2);
-        Assert.assertEquals(Region.values().length, regionsCount + 1);
+        Assertions.assertEquals(region3, region2);
+        Assertions.assertEquals(Region.values().length, regionsCount + 1);
     }
 
     /**
@@ -738,21 +738,21 @@ public class AzureTests extends TestBase {
                     .withoutAutoStart()
                     .withMonitoringInterval(35)
                     .create();
-            Assert.assertEquals("value1", connectionMonitor.tags().get("tag1"));
-            Assert.assertEquals(35, connectionMonitor.monitoringIntervalInSeconds());
-            Assert.assertEquals("NotStarted", connectionMonitor.monitoringStatus());
-            Assert.assertEquals("NewConnectionMonitor", connectionMonitor.name());
+            Assertions.assertEquals("value1", connectionMonitor.tags().get("tag1"));
+            Assertions.assertEquals(35, connectionMonitor.monitoringIntervalInSeconds());
+            Assertions.assertEquals("NotStarted", connectionMonitor.monitoringStatus());
+            Assertions.assertEquals("NewConnectionMonitor", connectionMonitor.name());
 
             connectionMonitor.start();
-            Assert.assertEquals("Running", connectionMonitor.monitoringStatus());
+            Assertions.assertEquals("Running", connectionMonitor.monitoringStatus());
             Topology topology = nw.topology().withTargetResourceGroup(virtualMachines[0].resourceGroupName()).execute();
-            Assert.assertEquals(11, topology.resources().size());
-            Assert.assertTrue(topology.resources().containsKey(virtualMachines[0].getPrimaryNetworkInterface().networkSecurityGroupId()));
-            Assert.assertEquals(4, topology.resources().get(virtualMachines[0].primaryNetworkInterfaceId()).associations().size());
+            Assertions.assertEquals(11, topology.resources().size());
+            Assertions.assertTrue(topology.resources().containsKey(virtualMachines[0].getPrimaryNetworkInterface().networkSecurityGroupId()));
+            Assertions.assertEquals(4, topology.resources().get(virtualMachines[0].primaryNetworkInterfaceId()).associations().size());
 
             SecurityGroupView sgViewResult = nw.getSecurityGroupView(virtualMachines[0].id());
-            Assert.assertEquals(1, sgViewResult.networkInterfaces().size());
-            Assert.assertEquals(virtualMachines[0].primaryNetworkInterfaceId(), sgViewResult.networkInterfaces().keySet().iterator().next());
+            Assertions.assertEquals(1, sgViewResult.networkInterfaces().size());
+            Assertions.assertEquals(virtualMachines[0].primaryNetworkInterfaceId(), sgViewResult.networkInterfaces().keySet().iterator().next());
 
             FlowLogSettings flowLogSettings = nw.getFlowLogSettings(virtualMachines[0].getPrimaryNetworkInterface().networkSecurityGroupId());
             StorageAccount storageAccount = tnw.ensureStorageAccount(azure.storageAccounts());
@@ -762,17 +762,17 @@ public class AzureTests extends TestBase {
                     .withRetentionPolicyDays(5)
                     .withRetentionPolicyEnabled()
                     .apply();
-            Assert.assertEquals(true, flowLogSettings.enabled());
-            Assert.assertEquals(5, flowLogSettings.retentionDays());
-            Assert.assertEquals(storageAccount.id(), flowLogSettings.storageId());
+            Assertions.assertEquals(true, flowLogSettings.enabled());
+            Assertions.assertEquals(5, flowLogSettings.retentionDays());
+            Assertions.assertEquals(storageAccount.id(), flowLogSettings.storageId());
 
             NextHop nextHop = nw.nextHop().withTargetResourceId(virtualMachines[0].id())
                     .withSourceIPAddress("10.0.0.4")
                     .withDestinationIPAddress("8.8.8.8")
                     .execute();
-            Assert.assertEquals("System Route", nextHop.routeTableId());
-            Assert.assertEquals(NextHopType.INTERNET, nextHop.nextHopType());
-            Assert.assertNull(nextHop.nextHopIpAddress());
+            Assertions.assertEquals("System Route", nextHop.routeTableId());
+            Assertions.assertEquals(NextHopType.INTERNET, nextHop.nextHopType());
+            Assertions.assertNull(nextHop.nextHopIpAddress());
 
             VerificationIPFlow verificationIPFlow = nw.verifyIPFlow()
                     .withTargetResourceId(virtualMachines[0].id())
@@ -783,12 +783,12 @@ public class AzureTests extends TestBase {
                     .withLocalPort("443")
                     .withRemotePort("443")
                     .execute();
-            Assert.assertEquals(Access.ALLOW, verificationIPFlow.access());
-            Assert.assertTrue("defaultSecurityRules/AllowInternetOutBound".equalsIgnoreCase(verificationIPFlow.ruleName()));
+            Assertions.assertEquals(Access.ALLOW, verificationIPFlow.access());
+            Assertions.assertTrue("defaultSecurityRules/AllowInternetOutBound".equalsIgnoreCase(verificationIPFlow.ruleName()));
 
             // test packet capture
             List<PacketCapture> packetCaptures = nw.packetCaptures().list();
-            Assert.assertEquals(0, packetCaptures.size());
+            Assertions.assertEquals(0, packetCaptures.size());
             PacketCapture packetCapture = nw.packetCaptures()
                     .define("NewPacketCapture")
                     .withTarget(virtualMachines[0].id())
@@ -800,14 +800,14 @@ public class AzureTests extends TestBase {
                     .attach()
                     .create();
             packetCaptures = nw.packetCaptures().list();
-            Assert.assertEquals(1, packetCaptures.size());
-            Assert.assertEquals("NewPacketCapture", packetCapture.name());
-            Assert.assertEquals(1500, packetCapture.timeLimitInSeconds());
-            Assert.assertEquals(PcProtocol.TCP, packetCapture.filters().get(0).protocol());
-            Assert.assertEquals("127.0.0.1;127.0.0.5", packetCapture.filters().get(0).localIPAddress());
-//            Assert.assertEquals("Running", packetCapture.getStatus().packetCaptureStatus().toString());
+            Assertions.assertEquals(1, packetCaptures.size());
+            Assertions.assertEquals("NewPacketCapture", packetCapture.name());
+            Assertions.assertEquals(1500, packetCapture.timeLimitInSeconds());
+            Assertions.assertEquals(PcProtocol.TCP, packetCapture.filters().get(0).protocol());
+            Assertions.assertEquals("127.0.0.1;127.0.0.5", packetCapture.filters().get(0).localIPAddress());
+//            Assertions.assertEquals("Running", packetCapture.getStatus().packetCaptureStatus().toString());
             packetCapture.stop();
-            Assert.assertEquals(PcStatus.STOPPED, packetCapture.getStatus().packetCaptureStatus());
+            Assertions.assertEquals(PcStatus.STOPPED, packetCapture.getStatus().packetCaptureStatus());
             nw.packetCaptures().deleteByName(packetCapture.name());
 
             ConnectivityCheck connectivityCheck = nw.checkConnectivity()
@@ -815,13 +815,13 @@ public class AzureTests extends TestBase {
                     .toDestinationPort(80)
                     .fromSourceVirtualMachine(virtualMachines[0].id())
                     .execute();
-//            Assert.assertEquals("Reachable", connectivityCheck.connectionStatus().toString());    // not sure why it is Unknown now
+//            Assertions.assertEquals("Reachable", connectivityCheck.connectionStatus().toString());    // not sure why it is Unknown now
 
             ConnectionMonitorQueryResult queryResult = connectionMonitor.query();
 
             azure.virtualMachines().deleteById(virtualMachines[1].id());
             topology.execute();
-//            Assert.assertEquals(10, topology.resources().size());     // not sure why it is 18 now
+//            Assertions.assertEquals(10, topology.resources().size());     // not sure why it is 18 now
         } finally {
             if (nwrg != null)
                 azure.resourceGroups().deleteByName(nwrg);
@@ -862,7 +862,7 @@ public class AzureTests extends TestBase {
      * @throws Exception
      */
     @Test
-    @Ignore("osDiskSize is returned as 127 instead of 128 - known service bug")
+    @Disabled("osDiskSize is returned as 127 instead of 128 - known service bug")
     public void testVirtualMachines() throws Exception {
         // Future: This method needs to have a better specific name since we are going to include unit test for
         // different vm scenarios.
@@ -925,10 +925,10 @@ public class AzureTests extends TestBase {
      */
     @Test
     public void listSubscriptions() throws Exception {
-        Assert.assertTrue(0 < azure.subscriptions().list().size());
+        Assertions.assertTrue(0 < azure.subscriptions().list().size());
         Subscription subscription = azure.getCurrentSubscription();
-        Assert.assertNotNull(subscription);
-        Assert.assertTrue(azure.subscriptionId().equalsIgnoreCase(subscription.subscriptionId()));
+        Assertions.assertNotNull(subscription);
+        Assertions.assertTrue(azure.subscriptionId().equalsIgnoreCase(subscription.subscriptionId()));
     }
 
     /**
@@ -938,17 +938,17 @@ public class AzureTests extends TestBase {
     @Test
     public void listLocations() throws Exception {
         Subscription subscription = azure.getCurrentSubscription();
-        Assert.assertNotNull(subscription);
+        Assertions.assertNotNull(subscription);
         for (Location location : subscription.listLocations()) {
             Region region = Region.fromName(location.name());
-            Assert.assertNotNull("Could not find region " + location.name(), region);
-            Assert.assertEquals(region, location.region());
-            Assert.assertEquals(region.name().toLowerCase(), location.name().toLowerCase());
+            Assertions.assertNotNull("Could not find region " + location.name(), region);
+            Assertions.assertEquals(region, location.region());
+            Assertions.assertEquals(region.name().toLowerCase(), location.name().toLowerCase());
         }
 
         Location location = subscription.getLocationByRegion(Region.US_WEST);
-        Assert.assertNotNull(location);
-        Assert.assertTrue(Region.US_WEST.name().equalsIgnoreCase(location.name()));
+        Assertions.assertNotNull(location);
+        Assertions.assertTrue(Region.US_WEST.name().equalsIgnoreCase(location.name()));
     }
 
     /**
@@ -959,7 +959,7 @@ public class AzureTests extends TestBase {
     public void listResourceGroups() throws Exception {
         int groupCount = azure.resourceGroups().list().size();
         System.out.println(String.format("Group count: %s", groupCount));
-        Assert.assertTrue(0 < groupCount);
+        Assertions.assertTrue(0 < groupCount);
     }
 
     /**
@@ -968,7 +968,7 @@ public class AzureTests extends TestBase {
      */
     @Test
     public void listStorageAccounts() throws Exception {
-        Assert.assertTrue(0 < azure.storageAccounts().list().size());
+        Assertions.assertTrue(0 < azure.storageAccounts().list().size());
     }
 
     @Test
@@ -980,7 +980,7 @@ public class AzureTests extends TestBase {
                 .withSku(SkuName.PREMIUM_LRS)
                 .create();
 
-        Assert.assertEquals(storageAccount.name(), storageAccountName);
+        Assertions.assertEquals(storageAccount.name(), storageAccountName);
 
         azure.resourceGroups().beginDeleteByName(storageAccount.resourceGroupName());
     }
@@ -1017,8 +1017,8 @@ public class AzureTests extends TestBase {
                     .withPassword("MyPassword")
                     .withAutoScale(1, 1)
                     .create();
-            Assert.assertEquals("resizing", cluster.allocationState().toString());
-            Assert.assertEquals(userName, cluster.adminUserName());
+            Assertions.assertEquals("resizing", cluster.allocationState().toString());
+            Assertions.assertEquals(userName, cluster.adminUserName());
 
             BatchAIJob job = experiment.jobs().define("myJob")
                     .withExistingClusterId(cluster.id())
@@ -1036,20 +1036,20 @@ public class AzureTests extends TestBase {
                         .attach()
                     .withContainerImage("microsoft/cntk:2.1-gpu-python3.5-cuda8.0-cudnn6.0")
                     .create();
-            Assert.assertEquals(2,job.outputDirectories().size());
+            Assertions.assertEquals(2,job.outputDirectories().size());
             OutputDirectory outputDirectory = null;
             for (OutputDirectory directory : job.outputDirectories()) {
                 if ("OUTPUT".equalsIgnoreCase(directory.id())) {
                     outputDirectory = directory;
                 }
             }
-            Assert.assertNotNull(outputDirectory);
-            Assert.assertEquals("suffix", outputDirectory.pathSuffix().toLowerCase());
+            Assertions.assertNotNull(outputDirectory);
+            Assertions.assertEquals("suffix", outputDirectory.pathSuffix().toLowerCase());
 
             experiment.jobs().list();
 
             BatchAIJob job2 = experiment.jobs().getById(job.id());
-            Assert.assertEquals(cluster.id(), job2.cluster().id());
+            Assertions.assertEquals(cluster.id(), job2.cluster().id());
 
         } finally {
             azure.resourceGroups().beginDeleteByName(groupName);
@@ -1162,69 +1162,69 @@ public class AzureTests extends TestBase {
                 .withTag("tag1", "value1")
                 .create();
 
-        Assert.assertEquals(cgName, containerGroup.name());
-        Assert.assertEquals("Linux", containerGroup.osType().toString());
-        Assert.assertEquals(0, containerGroup.imageRegistryServers().size());
-        Assert.assertEquals(1, containerGroup.volumes().size());
-        Assert.assertNotNull(containerGroup.volumes().get("emptydir1"));
-        Assert.assertNotNull(containerGroup.ipAddress());
-        Assert.assertTrue(containerGroup.isIPAddressPublic());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(2, containerGroup.externalPorts().size());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
-        Assert.assertEquals(80, containerGroup.externalTcpPorts()[1]);
-        Assert.assertEquals(2, containerGroup.containers().size());
+        Assertions.assertEquals(cgName, containerGroup.name());
+        Assertions.assertEquals("Linux", containerGroup.osType().toString());
+        Assertions.assertEquals(0, containerGroup.imageRegistryServers().size());
+        Assertions.assertEquals(1, containerGroup.volumes().size());
+        Assertions.assertNotNull(containerGroup.volumes().get("emptydir1"));
+        Assertions.assertNotNull(containerGroup.ipAddress());
+        Assertions.assertTrue(containerGroup.isIPAddressPublic());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(2, containerGroup.externalPorts().size());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
+        Assertions.assertEquals(80, containerGroup.externalTcpPorts()[1]);
+        Assertions.assertEquals(2, containerGroup.containers().size());
         Container tomcatContainer = containerGroup.containers().get("tomcat");
-        Assert.assertNotNull(tomcatContainer);
+        Assertions.assertNotNull(tomcatContainer);
         Container nginxContainer = containerGroup.containers().get("nginx");
-        Assert.assertNotNull(nginxContainer);
-        Assert.assertEquals("tomcat", tomcatContainer.name());
-        Assert.assertEquals("tomcat", tomcatContainer.image());
-        Assert.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, tomcatContainer.ports().size());
-        Assert.assertEquals(8080, tomcatContainer.ports().get(0).port());
-        Assert.assertNull(tomcatContainer.volumeMounts());
-        Assert.assertNull(tomcatContainer.command());
-        Assert.assertNotNull(tomcatContainer.environmentVariables());
-        Assert.assertEquals(1, tomcatContainer.environmentVariables().size());
-        Assert.assertEquals("nginx", nginxContainer.name());
-        Assert.assertEquals("nginx", nginxContainer.image());
-        Assert.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, nginxContainer.ports().size());
-        Assert.assertEquals(80, nginxContainer.ports().get(0).port());
-        Assert.assertNull(nginxContainer.volumeMounts());
-        Assert.assertNull(nginxContainer.command());
-        Assert.assertNotNull(nginxContainer.environmentVariables());
-        Assert.assertEquals(1, nginxContainer.environmentVariables().size());
-        Assert.assertTrue(containerGroup.tags().containsKey("tag1"));
-        Assert.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
-        Assert.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
-        Assert.assertEquals(ResourceIdentityType.USER_ASSIGNED, containerGroup.managedServiceIdentityType());
-        Assert.assertNull(containerGroup.systemAssignedManagedServiceIdentityPrincipalId()); // No Local MSI enabled
+        Assertions.assertNotNull(nginxContainer);
+        Assertions.assertEquals("tomcat", tomcatContainer.name());
+        Assertions.assertEquals("tomcat", tomcatContainer.image());
+        Assertions.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, tomcatContainer.ports().size());
+        Assertions.assertEquals(8080, tomcatContainer.ports().get(0).port());
+        Assertions.assertNull(tomcatContainer.volumeMounts());
+        Assertions.assertNull(tomcatContainer.command());
+        Assertions.assertNotNull(tomcatContainer.environmentVariables());
+        Assertions.assertEquals(1, tomcatContainer.environmentVariables().size());
+        Assertions.assertEquals("nginx", nginxContainer.name());
+        Assertions.assertEquals("nginx", nginxContainer.image());
+        Assertions.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, nginxContainer.ports().size());
+        Assertions.assertEquals(80, nginxContainer.ports().get(0).port());
+        Assertions.assertNull(nginxContainer.volumeMounts());
+        Assertions.assertNull(nginxContainer.command());
+        Assertions.assertNotNull(nginxContainer.environmentVariables());
+        Assertions.assertEquals(1, nginxContainer.environmentVariables().size());
+        Assertions.assertTrue(containerGroup.tags().containsKey("tag1"));
+        Assertions.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
+        Assertions.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
+        Assertions.assertEquals(ResourceIdentityType.USER_ASSIGNED, containerGroup.managedServiceIdentityType());
+        Assertions.assertNull(containerGroup.systemAssignedManagedServiceIdentityPrincipalId()); // No Local MSI enabled
 
         // Ensure the "User Assigned (External) MSI" id can be retrieved from the virtual machine
         //
         Set<String> emsiIds = containerGroup.userAssignedManagedServiceIdentityIds();
-        Assert.assertNotNull(emsiIds);
-        Assert.assertEquals(2, emsiIds.size());
-        Assert.assertEquals(cgName, containerGroup.dnsPrefix());
+        Assertions.assertNotNull(emsiIds);
+        Assertions.assertEquals(2, emsiIds.size());
+        Assertions.assertEquals(cgName, containerGroup.dnsPrefix());
 
         //TODO: add network and dns testing when questions have been answered
 
         ContainerGroup containerGroup2 = azure.containerGroups().getByResourceGroup(rgName, cgName);
 
         List<ContainerGroup> containerGroupList = azure.containerGroups().listByResourceGroup(rgName);
-        Assert.assertTrue(containerGroupList.size() > 0);
-        Assert.assertNotNull(containerGroupList.get(0).state());
+        Assertions.assertTrue(containerGroupList.size() > 0);
+        Assertions.assertNotNull(containerGroupList.get(0).state());
 
         containerGroup.refresh();
 
         Set<Operation> containerGroupOperations = azure.containerGroups().listOperations();
         // Number of supported operation can change hence don't assert with a predefined number.
-        Assert.assertTrue(containerGroupOperations.size() > 0);
+        Assertions.assertTrue(containerGroupOperations.size() > 0);
     }
 
     @Test
@@ -1243,7 +1243,7 @@ public class AzureTests extends TestBase {
     }
 
     @Test
-    @Ignore("Runs locally find but fails for unknown reason on check in.")
+    @Disabled("Runs locally find but fails for unknown reason on check in.")
     public void testCosmosDB() throws Exception {
         new TestCosmosDB()
                 .runTest(azure.cosmosDBAccounts(), azure.resourceGroups());
@@ -1274,7 +1274,7 @@ public class AzureTests extends TestBase {
     }
 
     @Test
-    @Ignore("Util to generate missing regions")
+    @Disabled("Util to generate missing regions")
     public void generateMissingRegion() {
         // Please double check generated code and make adjustment e.g. GERMANY_WEST_CENTRAL -> GERMANY_WESTCENTRAL
 
@@ -1293,6 +1293,6 @@ public class AzureTests extends TestBase {
             }
         }
 
-        Assert.assertTrue(sb.toString(), sb.length() == 0);
+        Assertions.assertTrue(sb.toString(), sb.length() == 0);
     }
 }

--- a/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
+++ b/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
@@ -1293,6 +1293,6 @@ public class AzureTests extends TestBase {
             }
         }
 
-        Assertions.assertTrue(sb.toString(), sb.length() == 0);
+        Assertions.assertTrue(sb.length() == 0, sb.toString());
     }
 }

--- a/azure/src/test/java/com/microsoft/azure/management/TestApplicationGateway.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestApplicationGateway.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import com.microsoft.azure.management.network.ApplicationGatewayUrlPathMap;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.network.ApplicationGateway;
 import com.microsoft.azure.management.network.ApplicationGatewayAuthenticationCertificate;
@@ -110,47 +110,47 @@ public class TestApplicationGateway {
             // Get the resource as created so far
             String resourceId = createResourceId(resources.manager().subscriptionId());
             ApplicationGateway appGateway = resources.manager().applicationGateways().getById(resourceId);
-            Assert.assertTrue(appGateway != null);
-            Assert.assertTrue(ApplicationGatewayTier.STANDARD.equals(appGateway.tier()));
-            Assert.assertTrue(ApplicationGatewaySkuName.STANDARD_SMALL.equals(appGateway.size()));
-            Assert.assertTrue(appGateway.instanceCount() == 1);
+            Assertions.assertTrue(appGateway != null);
+            Assertions.assertTrue(ApplicationGatewayTier.STANDARD.equals(appGateway.tier()));
+            Assertions.assertTrue(ApplicationGatewaySkuName.STANDARD_SMALL.equals(appGateway.size()));
+            Assertions.assertTrue(appGateway.instanceCount() == 1);
 
             // Verify frontend ports
-            Assert.assertTrue(appGateway.frontendPorts().size() == 1);
-            Assert.assertTrue(appGateway.frontendPortNameFromNumber(80) != null);
+            Assertions.assertTrue(appGateway.frontendPorts().size() == 1);
+            Assertions.assertTrue(appGateway.frontendPortNameFromNumber(80) != null);
 
             // Verify frontends
-            Assert.assertTrue(appGateway.isPrivate());
-            Assert.assertTrue(!appGateway.isPublic());
-            Assert.assertTrue(appGateway.frontends().size() == 1);
+            Assertions.assertTrue(appGateway.isPrivate());
+            Assertions.assertTrue(!appGateway.isPublic());
+            Assertions.assertTrue(appGateway.frontends().size() == 1);
 
             // Verify listeners
-            Assert.assertTrue(appGateway.listeners().size() == 1);
-            Assert.assertTrue(appGateway.listenerByPortNumber(80) != null);
+            Assertions.assertTrue(appGateway.listeners().size() == 1);
+            Assertions.assertTrue(appGateway.listenerByPortNumber(80) != null);
 
             // Verify backends
-            Assert.assertTrue(appGateway.backends().size() == 1);
+            Assertions.assertTrue(appGateway.backends().size() == 1);
 
             // Verify backend HTTP configs
-            Assert.assertTrue(appGateway.backendHttpConfigurations().size() == 1);
+            Assertions.assertTrue(appGateway.backendHttpConfigurations().size() == 1);
 
             // Verify rules
-            Assert.assertTrue(appGateway.requestRoutingRules().size() == 1);
+            Assertions.assertTrue(appGateway.requestRoutingRules().size() == 1);
             ApplicationGatewayRequestRoutingRule rule = appGateway.requestRoutingRules().get("rule1");
-            Assert.assertTrue(rule != null);
-            Assert.assertTrue(rule.frontendPort() == 80);
-            Assert.assertTrue(ApplicationGatewayProtocol.HTTP.equals(rule.frontendProtocol()));
-            Assert.assertTrue(rule.listener() != null);
-            Assert.assertTrue(rule.listener().frontend() != null);
-            Assert.assertTrue(!rule.listener().frontend().isPublic());
-            Assert.assertTrue(rule.listener().frontend().isPrivate());
-            Assert.assertTrue(rule.listener().subnetName() != null);
-            Assert.assertTrue(rule.listener().networkId() != null);
-            Assert.assertTrue(rule.backendAddresses().size() == 2);
-            Assert.assertTrue(rule.backend() != null);
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
-            Assert.assertTrue(rule.backendPort() == 8080);
+            Assertions.assertTrue(rule != null);
+            Assertions.assertTrue(rule.frontendPort() == 80);
+            Assertions.assertTrue(ApplicationGatewayProtocol.HTTP.equals(rule.frontendProtocol()));
+            Assertions.assertTrue(rule.listener() != null);
+            Assertions.assertTrue(rule.listener().frontend() != null);
+            Assertions.assertTrue(!rule.listener().frontend().isPublic());
+            Assertions.assertTrue(rule.listener().frontend().isPrivate());
+            Assertions.assertTrue(rule.listener().subnetName() != null);
+            Assertions.assertTrue(rule.listener().networkId() != null);
+            Assertions.assertTrue(rule.backendAddresses().size() == 2);
+            Assertions.assertTrue(rule.backend() != null);
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
+            Assertions.assertTrue(rule.backendPort() == 8080);
 
             creationThread.join();
             return appGateway;
@@ -189,58 +189,58 @@ public class TestApplicationGateway {
 
             resource.refresh();
 
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(ApplicationGatewaySkuName.STANDARD_MEDIUM.equals(resource.size()));
-            Assert.assertTrue(resource.instanceCount() == 2);
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(ApplicationGatewaySkuName.STANDARD_MEDIUM.equals(resource.size()));
+            Assertions.assertTrue(resource.instanceCount() == 2);
 
             // Verify frontend ports
-            Assert.assertTrue(resource.frontendPorts().size() == 2);
-            Assert.assertTrue(resource.frontendPorts().containsKey("port81"));
-            Assert.assertTrue("port81".equalsIgnoreCase(resource.frontendPortNameFromNumber(81)));
+            Assertions.assertTrue(resource.frontendPorts().size() == 2);
+            Assertions.assertTrue(resource.frontendPorts().containsKey("port81"));
+            Assertions.assertTrue("port81".equalsIgnoreCase(resource.frontendPortNameFromNumber(81)));
 
             // Verify listeners
-            Assert.assertTrue(resource.listeners().size() == 2);
+            Assertions.assertTrue(resource.listeners().size() == 2);
             ApplicationGatewayListener listener = resource.listeners().get("listener2");
-            Assert.assertTrue(listener != null);
-            Assert.assertTrue(listener.frontend().isPrivate());
-            Assert.assertTrue(!listener.frontend().isPublic());
-            Assert.assertTrue("port81".equalsIgnoreCase(listener.frontendPortName()));
-            Assert.assertTrue(ApplicationGatewayProtocol.HTTPS.equals(listener.protocol()));
-            Assert.assertTrue(listener.sslCertificate() != null);
+            Assertions.assertTrue(listener != null);
+            Assertions.assertTrue(listener.frontend().isPrivate());
+            Assertions.assertTrue(!listener.frontend().isPublic());
+            Assertions.assertTrue("port81".equalsIgnoreCase(listener.frontendPortName()));
+            Assertions.assertTrue(ApplicationGatewayProtocol.HTTPS.equals(listener.protocol()));
+            Assertions.assertTrue(listener.sslCertificate() != null);
 
             // Verify backends
-            Assert.assertTrue(resource.backends().size() == 2);
+            Assertions.assertTrue(resource.backends().size() == 2);
             ApplicationGatewayBackend backend = resource.backends().get("backend2");
-            Assert.assertTrue(backend != null);
-            Assert.assertTrue(backend.addresses().size() == 1);
-            Assert.assertTrue(backend.containsIPAddress("11.1.1.3"));
+            Assertions.assertTrue(backend != null);
+            Assertions.assertTrue(backend.addresses().size() == 1);
+            Assertions.assertTrue(backend.containsIPAddress("11.1.1.3"));
 
             // Verify HTTP configs
-            Assert.assertTrue(resource.backendHttpConfigurations().size() == 2);
+            Assertions.assertTrue(resource.backendHttpConfigurations().size() == 2);
             ApplicationGatewayBackendHttpConfiguration config = resource.backendHttpConfigurations().get("config2");
-            Assert.assertTrue(config != null);
-            Assert.assertTrue(config.cookieBasedAffinity());
-            Assert.assertTrue(config.port() == 8081);
-            Assert.assertTrue(config.requestTimeout() == 33);
+            Assertions.assertTrue(config != null);
+            Assertions.assertTrue(config.cookieBasedAffinity());
+            Assertions.assertTrue(config.port() == 8081);
+            Assertions.assertTrue(config.requestTimeout() == 33);
 
             // Verify request routing rules
-            Assert.assertTrue(resource.requestRoutingRules().size() == 2);
+            Assertions.assertTrue(resource.requestRoutingRules().size() == 2);
             ApplicationGatewayRequestRoutingRule rule = resource.requestRoutingRules().get("rule2");
-            Assert.assertTrue(rule != null);
-            Assert.assertTrue(rule.listener() != null);
-            Assert.assertTrue("listener2".equals(rule.listener().name()));
-            Assert.assertTrue(rule.backendHttpConfiguration() != null);
-            Assert.assertTrue("config2".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
-            Assert.assertTrue(rule.backend() != null);
-            Assert.assertTrue("backend2".equalsIgnoreCase(rule.backend().name()));
+            Assertions.assertTrue(rule != null);
+            Assertions.assertTrue(rule.listener() != null);
+            Assertions.assertTrue("listener2".equals(rule.listener().name()));
+            Assertions.assertTrue(rule.backendHttpConfiguration() != null);
+            Assertions.assertTrue("config2".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
+            Assertions.assertTrue(rule.backend() != null);
+            Assertions.assertTrue("backend2".equalsIgnoreCase(rule.backend().name()));
 
             resource.updateTags()
                     .withTag("tag3", "value3")
                     .withoutTag("tag1")
                     .applyTags();
-            Assert.assertEquals("value3", resource.tags().get("tag3"));
-            Assert.assertFalse(resource.tags().containsKey("tag1"));
+            Assertions.assertEquals("value3", resource.tags().get("tag3"));
+            Assertions.assertFalse(resource.tags().containsKey("tag1"));
             return resource;
         }
     }
@@ -302,39 +302,39 @@ public class TestApplicationGateway {
             // Get the resource as created so far
             String resourceId = createResourceId(resources.manager().subscriptionId());
             ApplicationGateway appGateway = resources.manager().applicationGateways().getById(resourceId);
-            Assert.assertNotNull(appGateway);
-            Assert.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
-            Assert.assertEquals(ApplicationGatewaySkuName.STANDARD_SMALL, appGateway.size());
-            Assert.assertEquals(1, appGateway.instanceCount());
+            Assertions.assertNotNull(appGateway);
+            Assertions.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
+            Assertions.assertEquals(ApplicationGatewaySkuName.STANDARD_SMALL, appGateway.size());
+            Assertions.assertEquals(1, appGateway.instanceCount());
 
             // Verify frontend ports
-            Assert.assertEquals(1, appGateway.frontendPorts().size());
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(80));
+            Assertions.assertEquals(1, appGateway.frontendPorts().size());
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(80));
 
             // Verify frontends
-            Assert.assertTrue(appGateway.isPublic());
-            Assert.assertEquals(1, appGateway.frontends().size());
+            Assertions.assertTrue(appGateway.isPublic());
+            Assertions.assertEquals(1, appGateway.frontends().size());
 
             // Verify listeners
-            Assert.assertEquals(1, appGateway.listeners().size());
-            Assert.assertNotNull(appGateway.listenerByPortNumber(80));
+            Assertions.assertEquals(1, appGateway.listeners().size());
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(80));
 
             // Verify backends
-            Assert.assertEquals(1, appGateway.backends().size());
+            Assertions.assertEquals(1, appGateway.backends().size());
 
             // Verify backend HTTP configs
-            Assert.assertEquals(1, appGateway.backendHttpConfigurations().size());
+            Assertions.assertEquals(1, appGateway.backendHttpConfigurations().size());
 
             // Verify rules
-            Assert.assertEquals(1, appGateway.requestRoutingRules().size());
+            Assertions.assertEquals(1, appGateway.requestRoutingRules().size());
             ApplicationGatewayRequestRoutingRule rule = appGateway.requestRoutingRules().get("pathMap");
-            Assert.assertNotNull(rule);
-            Assert.assertEquals(80, rule.frontendPort());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTP, rule.frontendProtocol());
-            Assert.assertNotNull(rule.listener());
-            Assert.assertNotNull(rule.listener().frontend());
-            Assert.assertTrue(rule.listener().frontend().isPublic());
-            Assert.assertTrue(!rule.listener().frontend().isPrivate());
+            Assertions.assertNotNull(rule);
+            Assertions.assertEquals(80, rule.frontendPort());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTP, rule.frontendProtocol());
+            Assertions.assertNotNull(rule.listener());
+            Assertions.assertNotNull(rule.listener().frontend());
+            Assertions.assertTrue(rule.listener().frontend().isPublic());
+            Assertions.assertTrue(!rule.listener().frontend().isPrivate());
             creationThread.join();
             return appGateway;
         }
@@ -365,19 +365,19 @@ public class TestApplicationGateway {
                     .apply();
             resource.refresh();
             ApplicationGatewayRequestRoutingRule rule = resource.requestRoutingRules().get("rule2");
-            Assert.assertNotNull(rule);
-            Assert.assertEquals(0, rule.backendAddresses().size());
+            Assertions.assertNotNull(rule);
+            Assertions.assertEquals(0, rule.backendAddresses().size());
             ApplicationGatewayUrlPathMap pathMap = resource.urlPathMaps().get("rule2");
-            Assert.assertNotNull(pathMap.defaultBackend());
-            Assert.assertEquals(2, pathMap.defaultBackend().addresses().size());
-            Assert.assertTrue(pathMap.defaultBackend().containsIPAddress("11.1.1.1"));
-            Assert.assertTrue(pathMap.defaultBackend().containsIPAddress("11.1.1.2"));
-            Assert.assertEquals(8080, pathMap.defaultBackendHttpConfiguration().port());
-            Assert.assertEquals(1, resource.urlPathMaps().size());
-            Assert.assertFalse(resource.requestRoutingRules().containsKey("pathMap"));
-            Assert.assertTrue(resource.requestRoutingRules().containsKey("rule2"));
-            Assert.assertEquals(2, pathMap.pathRules().size());
-            Assert.assertEquals("/pictures/*", pathMap.pathRules().get("newRule").paths().get(0));
+            Assertions.assertNotNull(pathMap.defaultBackend());
+            Assertions.assertEquals(2, pathMap.defaultBackend().addresses().size());
+            Assertions.assertTrue(pathMap.defaultBackend().containsIPAddress("11.1.1.1"));
+            Assertions.assertTrue(pathMap.defaultBackend().containsIPAddress("11.1.1.2"));
+            Assertions.assertEquals(8080, pathMap.defaultBackendHttpConfiguration().port());
+            Assertions.assertEquals(1, resource.urlPathMaps().size());
+            Assertions.assertFalse(resource.requestRoutingRules().containsKey("pathMap"));
+            Assertions.assertTrue(resource.requestRoutingRules().containsKey("rule2"));
+            Assertions.assertEquals(2, pathMap.pathRules().size());
+            Assertions.assertEquals("/pictures/*", pathMap.pathRules().get("newRule").paths().get(0));
             return resource;
         }
     }
@@ -532,139 +532,139 @@ public class TestApplicationGateway {
             // Get the resource as created so far
             String resourceId = createResourceId(resources.manager().subscriptionId());
             ApplicationGateway appGateway = resources.getById(resourceId);
-            Assert.assertNotNull(appGateway);
-            Assert.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
-            Assert.assertEquals(ApplicationGatewaySkuName.STANDARD_MEDIUM, appGateway.size());
-            Assert.assertEquals(2, appGateway.instanceCount());
-            Assert.assertFalse(appGateway.isPublic());
-            Assert.assertTrue(appGateway.isPrivate());
-            Assert.assertEquals(1, appGateway.ipConfigurations().size());
+            Assertions.assertNotNull(appGateway);
+            Assertions.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
+            Assertions.assertEquals(ApplicationGatewaySkuName.STANDARD_MEDIUM, appGateway.size());
+            Assertions.assertEquals(2, appGateway.instanceCount());
+            Assertions.assertFalse(appGateway.isPublic());
+            Assertions.assertTrue(appGateway.isPrivate());
+            Assertions.assertEquals(1, appGateway.ipConfigurations().size());
 
             // Verify redirect configurations
-            Assert.assertEquals(2, appGateway.redirectConfigurations().size());
+            Assertions.assertEquals(2, appGateway.redirectConfigurations().size());
             ApplicationGatewayRedirectConfiguration redirect = appGateway.redirectConfigurations().get("redirect1");
-            Assert.assertNotNull(redirect);
-            Assert.assertEquals(ApplicationGatewayRedirectType.PERMANENT, redirect.type());
-            Assert.assertNotNull(redirect.targetListener());
-            Assert.assertEquals("listener1", redirect.targetListener().name());
-            Assert.assertNull(redirect.targetUrl());
-            Assert.assertTrue(redirect.isPathIncluded());
-            Assert.assertFalse(redirect.isQueryStringIncluded());
-            Assert.assertEquals(1, redirect.requestRoutingRules().size());
+            Assertions.assertNotNull(redirect);
+            Assertions.assertEquals(ApplicationGatewayRedirectType.PERMANENT, redirect.type());
+            Assertions.assertNotNull(redirect.targetListener());
+            Assertions.assertEquals("listener1", redirect.targetListener().name());
+            Assertions.assertNull(redirect.targetUrl());
+            Assertions.assertTrue(redirect.isPathIncluded());
+            Assertions.assertFalse(redirect.isQueryStringIncluded());
+            Assertions.assertEquals(1, redirect.requestRoutingRules().size());
 
             redirect = appGateway.redirectConfigurations().get("redirect2");
-            Assert.assertNotNull(redirect);
-            Assert.assertEquals(ApplicationGatewayRedirectType.TEMPORARY, redirect.type());
-            Assert.assertNull(redirect.targetListener());
-            Assert.assertNotNull(redirect.targetUrl());
-            Assert.assertEquals("http://www.microsoft.com", redirect.targetUrl());
-            Assert.assertTrue(redirect.isQueryStringIncluded());
-            Assert.assertFalse(redirect.isPathIncluded());
+            Assertions.assertNotNull(redirect);
+            Assertions.assertEquals(ApplicationGatewayRedirectType.TEMPORARY, redirect.type());
+            Assertions.assertNull(redirect.targetListener());
+            Assertions.assertNotNull(redirect.targetUrl());
+            Assertions.assertEquals("http://www.microsoft.com", redirect.targetUrl());
+            Assertions.assertTrue(redirect.isQueryStringIncluded());
+            Assertions.assertFalse(redirect.isPathIncluded());
 
             // Verify frontend ports
-            Assert.assertEquals(4, appGateway.frontendPorts().size());
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(80));
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(443));
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(9000));
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(444));
+            Assertions.assertEquals(4, appGateway.frontendPorts().size());
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(80));
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(443));
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(9000));
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(444));
 
             // Verify frontends
-            Assert.assertEquals(1, appGateway.frontends().size());
-            Assert.assertTrue(appGateway.publicFrontends().isEmpty());
-            Assert.assertEquals(1, appGateway.privateFrontends().size());
+            Assertions.assertEquals(1, appGateway.frontends().size());
+            Assertions.assertTrue(appGateway.publicFrontends().isEmpty());
+            Assertions.assertEquals(1, appGateway.privateFrontends().size());
             ApplicationGatewayFrontend frontend = appGateway.privateFrontends().values().iterator().next();
-            Assert.assertFalse(frontend.isPublic());
-            Assert.assertTrue(frontend.isPrivate());
+            Assertions.assertFalse(frontend.isPublic());
+            Assertions.assertTrue(frontend.isPrivate());
 
             // Verify listeners
-            Assert.assertEquals(4, appGateway.listeners().size());
+            Assertions.assertEquals(4, appGateway.listeners().size());
             ApplicationGatewayListener listener = appGateway.listeners().get("listener1");
-            Assert.assertNotNull(listener);
-            Assert.assertEquals(9000, listener.frontendPortNumber());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTP, listener.protocol());
-            Assert.assertNotNull(listener.frontend());
-            Assert.assertTrue(listener.frontend().isPrivate());
-            Assert.assertFalse(listener.frontend().isPublic());
-            Assert.assertNotNull(appGateway.listenerByPortNumber(80));
-            Assert.assertNotNull(appGateway.listenerByPortNumber(443));
-            Assert.assertNotNull(appGateway.listenerByPortNumber(444));
+            Assertions.assertNotNull(listener);
+            Assertions.assertEquals(9000, listener.frontendPortNumber());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTP, listener.protocol());
+            Assertions.assertNotNull(listener.frontend());
+            Assertions.assertTrue(listener.frontend().isPrivate());
+            Assertions.assertFalse(listener.frontend().isPublic());
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(80));
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(443));
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(444));
 
             // Verify SSL certificates
-            Assert.assertEquals(2, appGateway.sslCertificates().size());
-            Assert.assertTrue(appGateway.sslCertificates().containsKey("cert1"));
+            Assertions.assertEquals(2, appGateway.sslCertificates().size());
+            Assertions.assertTrue(appGateway.sslCertificates().containsKey("cert1"));
 
             // Verify backend HTTP settings configs
-            Assert.assertEquals(3, appGateway.backendHttpConfigurations().size());
+            Assertions.assertEquals(3, appGateway.backendHttpConfigurations().size());
             ApplicationGatewayBackendHttpConfiguration config = appGateway.backendHttpConfigurations().get("config1");
-            Assert.assertNotNull(config);
-            Assert.assertEquals(8081, config.port());
-            Assert.assertEquals(45, config.requestTimeout());
-            Assert.assertEquals(1, config.authenticationCertificates().size());
+            Assertions.assertNotNull(config);
+            Assertions.assertEquals(8081, config.port());
+            Assertions.assertEquals(45, config.requestTimeout());
+            Assertions.assertEquals(1, config.authenticationCertificates().size());
 
             ApplicationGatewayBackendHttpConfiguration config2 = appGateway.backendHttpConfigurations().get("config2");
-            Assert.assertNotNull(config2);
+            Assertions.assertNotNull(config2);
 
             // Verify authentication certificates
-            Assert.assertEquals(2, appGateway.authenticationCertificates().size());
+            Assertions.assertEquals(2, appGateway.authenticationCertificates().size());
             ApplicationGatewayAuthenticationCertificate authCert2 = appGateway.authenticationCertificates().get("auth2");
-            Assert.assertNotNull(authCert2);
-            Assert.assertNotNull(authCert2.data());
+            Assertions.assertNotNull(authCert2);
+            Assertions.assertNotNull(authCert2.data());
 
             ApplicationGatewayAuthenticationCertificate authCert = config.authenticationCertificates().values().iterator().next();
-            Assert.assertNotNull(authCert);
+            Assertions.assertNotNull(authCert);
 
-            Assert.assertEquals(1, config2.authenticationCertificates().size());
-            Assert.assertEquals(authCert2.name(), config2.authenticationCertificates().values().iterator().next().name());
+            Assertions.assertEquals(1, config2.authenticationCertificates().size());
+            Assertions.assertEquals(authCert2.name(), config2.authenticationCertificates().values().iterator().next().name());
 
             // Verify backends
-            Assert.assertEquals(3, appGateway.backends().size());
+            Assertions.assertEquals(3, appGateway.backends().size());
             ApplicationGatewayBackend backend = appGateway.backends().get("backend1");
-            Assert.assertNotNull(backend);
-            Assert.assertEquals(2, backend.addresses().size());
-            Assert.assertTrue(backend.containsIPAddress("11.1.1.3"));
-            Assert.assertTrue(backend.containsIPAddress("11.1.1.4"));
-            Assert.assertTrue(appGateway.backends().containsKey("backend2"));
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals(2, backend.addresses().size());
+            Assertions.assertTrue(backend.containsIPAddress("11.1.1.3"));
+            Assertions.assertTrue(backend.containsIPAddress("11.1.1.4"));
+            Assertions.assertTrue(appGateway.backends().containsKey("backend2"));
 
             // Verify request routing rules
-            Assert.assertEquals(4, appGateway.requestRoutingRules().size());
+            Assertions.assertEquals(4, appGateway.requestRoutingRules().size());
             ApplicationGatewayRequestRoutingRule rule;
 
             rule = appGateway.requestRoutingRules().get("rule80");
-            Assert.assertNotNull(rule);
-            Assert.assertTrue(vnet.id().equalsIgnoreCase(rule.listener().frontend().networkId()));
-            Assert.assertEquals(80, rule.frontendPort());
-            Assert.assertEquals(8080, rule.backendPort());
-            Assert.assertTrue(rule.cookieBasedAffinity());
-            Assert.assertEquals(2, rule.backendAddresses().size());
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
+            Assertions.assertNotNull(rule);
+            Assertions.assertTrue(vnet.id().equalsIgnoreCase(rule.listener().frontend().networkId()));
+            Assertions.assertEquals(80, rule.frontendPort());
+            Assertions.assertEquals(8080, rule.backendPort());
+            Assertions.assertTrue(rule.cookieBasedAffinity());
+            Assertions.assertEquals(2, rule.backendAddresses().size());
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
 
             rule = appGateway.requestRoutingRules().get("rule443");
-            Assert.assertNotNull(rule);
-            Assert.assertTrue(vnet.id().equalsIgnoreCase(rule.listener().frontend().networkId()));
-            Assert.assertEquals(443, rule.frontendPort());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTPS, rule.frontendProtocol());
-            Assert.assertNotNull(rule.sslCertificate());
-            Assert.assertNotNull(rule.backendHttpConfiguration());
-            Assert.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
+            Assertions.assertNotNull(rule);
+            Assertions.assertTrue(vnet.id().equalsIgnoreCase(rule.listener().frontend().networkId()));
+            Assertions.assertEquals(443, rule.frontendPort());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTPS, rule.frontendProtocol());
+            Assertions.assertNotNull(rule.sslCertificate());
+            Assertions.assertNotNull(rule.backendHttpConfiguration());
+            Assertions.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
 
             rule = appGateway.requestRoutingRules().get("rule9000");
-            Assert.assertNotNull(rule);
-            Assert.assertNotNull(rule.listener());
-            Assert.assertTrue(rule.listener().name().equalsIgnoreCase("listener1"));
-            Assert.assertNotNull(rule.listener().subnetName());
-            Assert.assertNotNull(rule.listener().networkId());
-            Assert.assertNotNull(rule.backendHttpConfiguration());
-            Assert.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
+            Assertions.assertNotNull(rule);
+            Assertions.assertNotNull(rule.listener());
+            Assertions.assertTrue(rule.listener().name().equalsIgnoreCase("listener1"));
+            Assertions.assertNotNull(rule.listener().subnetName());
+            Assertions.assertNotNull(rule.listener().networkId());
+            Assertions.assertNotNull(rule.backendHttpConfiguration());
+            Assertions.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
 
             rule = appGateway.requestRoutingRules().get("ruleRedirect");
-            Assert.assertNotNull(rule);
-            Assert.assertNotNull(rule.redirectConfiguration());
-            Assert.assertEquals("redirect1", rule.redirectConfiguration().name());
+            Assertions.assertNotNull(rule);
+            Assertions.assertNotNull(rule.redirectConfiguration());
+            Assertions.assertEquals("redirect1", rule.redirectConfiguration().name());
 
             creationThread.join();
 
@@ -682,13 +682,13 @@ public class TestApplicationGateway {
             final int sslCertCount = resource.sslCertificates().size();
             final int authCertCount = resource.authenticationCertificates().size();
             final ApplicationGatewayAuthenticationCertificate authCert1 = resource.backendHttpConfigurations().get("config1").authenticationCertificates().values().iterator().next();
-            Assert.assertNotNull(authCert1);
+            Assertions.assertNotNull(authCert1);
 
             PublicIPAddress pip = resource.manager().publicIPAddresses().getByResourceGroup(GROUP_NAME, PIP_NAMES[0]);
             ApplicationGatewayListener listener443 = resource.requestRoutingRules().get("rule443").listener();
-            Assert.assertNotNull(listener443);
+            Assertions.assertNotNull(listener443);
             ApplicationGatewayListener listenerRedirect = resource.requestRoutingRules().get("ruleRedirect").listener();
-            Assert.assertNotNull(listenerRedirect);
+            Assertions.assertNotNull(listenerRedirect);
 
             resource.update()
                 .withSize(ApplicationGatewaySkuName.STANDARD_SMALL)
@@ -745,82 +745,82 @@ public class TestApplicationGateway {
             resource.refresh();
 
             // Get the resource created so far
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertEquals(ApplicationGatewaySkuName.STANDARD_SMALL, resource.size());
-            Assert.assertEquals(1, resource.instanceCount());
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertEquals(ApplicationGatewaySkuName.STANDARD_SMALL, resource.size());
+            Assertions.assertEquals(1, resource.instanceCount());
 
             // Verify redirect configurations
-            Assert.assertEquals(1, resource.redirectConfigurations().size());
+            Assertions.assertEquals(1, resource.redirectConfigurations().size());
             ApplicationGatewayRedirectConfiguration redirect = resource.redirectConfigurations().get("redirect1");
-            Assert.assertNotNull(redirect);
-            Assert.assertEquals(ApplicationGatewayRedirectType.FOUND, redirect.type());
-            Assert.assertNull(redirect.targetListener());
-            Assert.assertNotNull(redirect.targetUrl());
-            Assert.assertEquals("http://azure.com", redirect.targetUrl());
+            Assertions.assertNotNull(redirect);
+            Assertions.assertEquals(ApplicationGatewayRedirectType.FOUND, redirect.type());
+            Assertions.assertNull(redirect.targetListener());
+            Assertions.assertNotNull(redirect.targetUrl());
+            Assertions.assertEquals("http://azure.com", redirect.targetUrl());
 
             // Verify frontend ports
-            Assert.assertEquals(portCount - 1, resource.frontendPorts().size());
-            Assert.assertNull(resource.frontendPortNameFromNumber(9000));
+            Assertions.assertEquals(portCount - 1, resource.frontendPorts().size());
+            Assertions.assertNull(resource.frontendPortNameFromNumber(9000));
 
             // Verify frontends
-            Assert.assertEquals(frontendCount + 1, resource.frontends().size());
-            Assert.assertEquals(1, resource.publicFrontends().size());
-            Assert.assertTrue(resource.publicFrontends().values().iterator().next().publicIPAddressId().equalsIgnoreCase(pip.id()));
-            Assert.assertEquals(1, resource.privateFrontends().size());
+            Assertions.assertEquals(frontendCount + 1, resource.frontends().size());
+            Assertions.assertEquals(1, resource.publicFrontends().size());
+            Assertions.assertTrue(resource.publicFrontends().values().iterator().next().publicIPAddressId().equalsIgnoreCase(pip.id()));
+            Assertions.assertEquals(1, resource.privateFrontends().size());
             ApplicationGatewayFrontend frontend = resource.privateFrontends().values().iterator().next();
-            Assert.assertFalse(frontend.isPublic());
-            Assert.assertTrue(frontend.isPrivate());
+            Assertions.assertFalse(frontend.isPublic());
+            Assertions.assertTrue(frontend.isPrivate());
 
             // Verify listeners
-            Assert.assertEquals(listenerCount - 1, resource.listeners().size());
-            Assert.assertFalse(resource.listeners().containsKey("listener1"));
+            Assertions.assertEquals(listenerCount - 1, resource.listeners().size());
+            Assertions.assertFalse(resource.listeners().containsKey("listener1"));
 
             // Verify backends
-            Assert.assertEquals(backendCount - 1, resource.backends().size());
-            Assert.assertFalse(resource.backends().containsKey("backend2"));
+            Assertions.assertEquals(backendCount - 1, resource.backends().size());
+            Assertions.assertFalse(resource.backends().containsKey("backend2"));
             ApplicationGatewayBackend backend = resource.backends().get("backend1");
-            Assert.assertNotNull(backend);
-            Assert.assertEquals(1, backend.addresses().size());
-            Assert.assertTrue(backend.containsIPAddress("11.1.1.5"));
-            Assert.assertFalse(backend.containsIPAddress("11.1.1.3"));
-            Assert.assertFalse(backend.containsIPAddress("11.1.1.4"));
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals(1, backend.addresses().size());
+            Assertions.assertTrue(backend.containsIPAddress("11.1.1.5"));
+            Assertions.assertFalse(backend.containsIPAddress("11.1.1.3"));
+            Assertions.assertFalse(backend.containsIPAddress("11.1.1.4"));
 
             // Verify HTTP configs
-            Assert.assertEquals(configCount - 1, resource.backendHttpConfigurations().size());
-            Assert.assertFalse(resource.backendHttpConfigurations().containsKey("config2"));
+            Assertions.assertEquals(configCount - 1, resource.backendHttpConfigurations().size());
+            Assertions.assertFalse(resource.backendHttpConfigurations().containsKey("config2"));
             ApplicationGatewayBackendHttpConfiguration config = resource.backendHttpConfigurations().get("config1");
-            Assert.assertEquals(8082, config.port());
-            Assert.assertEquals(20, config.requestTimeout());
-            Assert.assertTrue(config.cookieBasedAffinity());
-            Assert.assertEquals(1, config.authenticationCertificates().size());
-            Assert.assertFalse(config.authenticationCertificates().containsKey(authCert1.name()));
-            Assert.assertTrue(config.authenticationCertificates().containsKey("auth2"));
+            Assertions.assertEquals(8082, config.port());
+            Assertions.assertEquals(20, config.requestTimeout());
+            Assertions.assertTrue(config.cookieBasedAffinity());
+            Assertions.assertEquals(1, config.authenticationCertificates().size());
+            Assertions.assertFalse(config.authenticationCertificates().containsKey(authCert1.name()));
+            Assertions.assertTrue(config.authenticationCertificates().containsKey("auth2"));
 
             // Verify rules
-            Assert.assertEquals(ruleCount - 1, resource.requestRoutingRules().size());
-            Assert.assertFalse(resource.requestRoutingRules().containsKey("rule9000"));
+            Assertions.assertEquals(ruleCount - 1, resource.requestRoutingRules().size());
+            Assertions.assertFalse(resource.requestRoutingRules().containsKey("rule9000"));
 
             ApplicationGatewayRequestRoutingRule rule = resource.requestRoutingRules().get("rule80");
-            Assert.assertNotNull(rule);
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue("backend1".equalsIgnoreCase(rule.backend().name()));
-            Assert.assertNotNull(rule.backendHttpConfiguration());
-            Assert.assertTrue("config1".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
+            Assertions.assertNotNull(rule);
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue("backend1".equalsIgnoreCase(rule.backend().name()));
+            Assertions.assertNotNull(rule.backendHttpConfiguration());
+            Assertions.assertTrue("config1".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
 
             rule = resource.requestRoutingRules().get("rule443");
-            Assert.assertNotNull(rule);
-            Assert.assertNotNull(rule.listener());
-            Assert.assertTrue("foobar".equalsIgnoreCase(rule.listener().hostName()));
-            Assert.assertNull(rule.redirectConfiguration());
+            Assertions.assertNotNull(rule);
+            Assertions.assertNotNull(rule.listener());
+            Assertions.assertTrue("foobar".equalsIgnoreCase(rule.listener().hostName()));
+            Assertions.assertNull(rule.redirectConfiguration());
 
             // Verify SSL certificates
-            Assert.assertEquals(sslCertCount - 1, resource.sslCertificates().size());
-            Assert.assertFalse(resource.sslCertificates().containsKey("cert1"));
+            Assertions.assertEquals(sslCertCount - 1, resource.sslCertificates().size());
+            Assertions.assertFalse(resource.sslCertificates().containsKey("cert1"));
 
             // Verify authentication certificates
-            Assert.assertEquals(authCertCount - 1, resource.authenticationCertificates().size());
-            Assert.assertFalse(resource.authenticationCertificates().containsKey("auth1"));
+            Assertions.assertEquals(authCertCount - 1, resource.authenticationCertificates().size());
+            Assertions.assertFalse(resource.authenticationCertificates().containsKey("auth1"));
 
             return resource;
         }
@@ -960,132 +960,132 @@ public class TestApplicationGateway {
             // Get the resource as created so far
             String resourceId = createResourceId(resources.manager().subscriptionId());
             ApplicationGateway appGateway = resources.getById(resourceId);
-            Assert.assertNotNull(appGateway);
-            Assert.assertTrue(appGateway.isPublic());
-            Assert.assertTrue(!appGateway.isPrivate());
-            Assert.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
-            Assert.assertEquals(ApplicationGatewaySkuName.STANDARD_MEDIUM, appGateway.size());
-            Assert.assertEquals(2, appGateway.instanceCount());
-            Assert.assertEquals(1, appGateway.ipConfigurations().size());
-            Assert.assertTrue(appGateway.isHttp2Enabled());
+            Assertions.assertNotNull(appGateway);
+            Assertions.assertTrue(appGateway.isPublic());
+            Assertions.assertTrue(!appGateway.isPrivate());
+            Assertions.assertEquals(ApplicationGatewayTier.STANDARD, appGateway.tier());
+            Assertions.assertEquals(ApplicationGatewaySkuName.STANDARD_MEDIUM, appGateway.size());
+            Assertions.assertEquals(2, appGateway.instanceCount());
+            Assertions.assertEquals(1, appGateway.ipConfigurations().size());
+            Assertions.assertTrue(appGateway.isHttp2Enabled());
 
             // Verify frontend ports
-            Assert.assertEquals(3, appGateway.frontendPorts().size());
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(80));
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(443));
-            Assert.assertNotNull(appGateway.frontendPortNameFromNumber(9000));
+            Assertions.assertEquals(3, appGateway.frontendPorts().size());
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(80));
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(443));
+            Assertions.assertNotNull(appGateway.frontendPortNameFromNumber(9000));
 
             // Verify frontends
-            Assert.assertEquals(1, appGateway.frontends().size());
-            Assert.assertEquals(1, appGateway.publicFrontends().size());
-            Assert.assertEquals(0, appGateway.privateFrontends().size());
+            Assertions.assertEquals(1, appGateway.frontends().size());
+            Assertions.assertEquals(1, appGateway.publicFrontends().size());
+            Assertions.assertEquals(0, appGateway.privateFrontends().size());
             ApplicationGatewayFrontend frontend = appGateway.publicFrontends().values().iterator().next();
-            Assert.assertTrue(frontend.isPublic());
-            Assert.assertTrue(!frontend.isPrivate());
+            Assertions.assertTrue(frontend.isPublic());
+            Assertions.assertTrue(!frontend.isPrivate());
 
             // Verify listeners
-            Assert.assertEquals(3, appGateway.listeners().size());
+            Assertions.assertEquals(3, appGateway.listeners().size());
             ApplicationGatewayListener listener = appGateway.listeners().get("listener1");
-            Assert.assertNotNull(listener);
-            Assert.assertEquals(9000, listener.frontendPortNumber());
-            Assert.assertTrue("www.fabricam.com".equalsIgnoreCase(listener.hostName()));
-            Assert.assertTrue(listener.requiresServerNameIndication());
-            Assert.assertNotNull(listener.frontend());
-            Assert.assertFalse(listener.frontend().isPrivate());
-            Assert.assertTrue(listener.frontend().isPublic());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTPS, listener.protocol());
-            Assert.assertNotNull(appGateway.listenerByPortNumber(80));
-            Assert.assertNotNull(appGateway.listenerByPortNumber(443));
+            Assertions.assertNotNull(listener);
+            Assertions.assertEquals(9000, listener.frontendPortNumber());
+            Assertions.assertTrue("www.fabricam.com".equalsIgnoreCase(listener.hostName()));
+            Assertions.assertTrue(listener.requiresServerNameIndication());
+            Assertions.assertNotNull(listener.frontend());
+            Assertions.assertFalse(listener.frontend().isPrivate());
+            Assertions.assertTrue(listener.frontend().isPublic());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTPS, listener.protocol());
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(80));
+            Assertions.assertNotNull(appGateway.listenerByPortNumber(443));
 
             // Verify SSL certificates
-            Assert.assertEquals(2, appGateway.sslCertificates().size());
+            Assertions.assertEquals(2, appGateway.sslCertificates().size());
 
             // Verify backends
-            Assert.assertEquals(2, appGateway.backends().size());
+            Assertions.assertEquals(2, appGateway.backends().size());
             ApplicationGatewayBackend backend = appGateway.backends().get("backend1");
-            Assert.assertNotNull(backend);
-            Assert.assertEquals(2, backend.addresses().size());
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals(2, backend.addresses().size());
 
             // Verify request routing rules
-            Assert.assertEquals(3, appGateway.requestRoutingRules().size());
+            Assertions.assertEquals(3, appGateway.requestRoutingRules().size());
             ApplicationGatewayRequestRoutingRule rule, rule80;
 
             rule80 = appGateway.requestRoutingRules().get("rule80");
-            Assert.assertNotNull(rule80);
-            Assert.assertTrue(pip.id().equalsIgnoreCase(rule80.publicIPAddressId()));
-            Assert.assertEquals(80, rule80.frontendPort());
-            Assert.assertEquals(8080, rule80.backendPort());
-            Assert.assertTrue(rule80.cookieBasedAffinity());
-            Assert.assertEquals(4, rule80.backendAddresses().size());
-            Assert.assertTrue(rule80.backend().containsIPAddress("11.1.1.2"));
-            Assert.assertTrue(rule80.backend().containsIPAddress("11.1.1.1"));
-            Assert.assertTrue(rule80.backend().containsFqdn("www.microsoft.com"));
-            Assert.assertTrue(rule80.backend().containsFqdn("www.example.com"));
+            Assertions.assertNotNull(rule80);
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(rule80.publicIPAddressId()));
+            Assertions.assertEquals(80, rule80.frontendPort());
+            Assertions.assertEquals(8080, rule80.backendPort());
+            Assertions.assertTrue(rule80.cookieBasedAffinity());
+            Assertions.assertEquals(4, rule80.backendAddresses().size());
+            Assertions.assertTrue(rule80.backend().containsIPAddress("11.1.1.2"));
+            Assertions.assertTrue(rule80.backend().containsIPAddress("11.1.1.1"));
+            Assertions.assertTrue(rule80.backend().containsFqdn("www.microsoft.com"));
+            Assertions.assertTrue(rule80.backend().containsFqdn("www.example.com"));
 
             rule = appGateway.requestRoutingRules().get("rule443");
-            Assert.assertNotNull(rule);
-            Assert.assertTrue(pip.id().equalsIgnoreCase(rule.publicIPAddressId()));
-            Assert.assertEquals(443, rule.frontendPort());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTPS, rule.frontendProtocol());
-            Assert.assertNotNull(rule.sslCertificate());
-            Assert.assertNotNull(rule.backendHttpConfiguration());
-            Assert.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
+            Assertions.assertNotNull(rule);
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(rule.publicIPAddressId()));
+            Assertions.assertEquals(443, rule.frontendPort());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTPS, rule.frontendProtocol());
+            Assertions.assertNotNull(rule.sslCertificate());
+            Assertions.assertNotNull(rule.backendHttpConfiguration());
+            Assertions.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
 
             rule = appGateway.requestRoutingRules().get("rule9000");
-            Assert.assertNotNull(rule);
-            Assert.assertNotNull(rule.listener());
-            Assert.assertTrue(rule.listener().name().equalsIgnoreCase("listener1"));
-            Assert.assertNotNull(rule.backendHttpConfiguration());
-            Assert.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
+            Assertions.assertNotNull(rule);
+            Assertions.assertNotNull(rule.listener());
+            Assertions.assertTrue(rule.listener().name().equalsIgnoreCase("listener1"));
+            Assertions.assertNotNull(rule.backendHttpConfiguration());
+            Assertions.assertTrue(rule.backendHttpConfiguration().name().equalsIgnoreCase("config1"));
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue(rule.backend().name().equalsIgnoreCase("backend1"));
 
             // Verify backend HTTP settings configs
-            Assert.assertEquals(2, appGateway.backendHttpConfigurations().size());
+            Assertions.assertEquals(2, appGateway.backendHttpConfigurations().size());
             ApplicationGatewayBackendHttpConfiguration config = appGateway.backendHttpConfigurations().get("config1");
-            Assert.assertNotNull(config);
-            Assert.assertEquals(8081, config.port());
-            Assert.assertEquals(45, config.requestTimeout());
-            Assert.assertNotNull(config.probe());
-            Assert.assertEquals("probe1", config.probe().name());
-            Assert.assertFalse(config.isHostHeaderFromBackend());
-            Assert.assertEquals("foo", config.hostHeader());
-            Assert.assertEquals(100, config.connectionDrainingTimeoutInSeconds());
-            Assert.assertEquals("/path/", config.path());
-            Assert.assertEquals("cookie", config.affinityCookieName());
+            Assertions.assertNotNull(config);
+            Assertions.assertEquals(8081, config.port());
+            Assertions.assertEquals(45, config.requestTimeout());
+            Assertions.assertNotNull(config.probe());
+            Assertions.assertEquals("probe1", config.probe().name());
+            Assertions.assertFalse(config.isHostHeaderFromBackend());
+            Assertions.assertEquals("foo", config.hostHeader());
+            Assertions.assertEquals(100, config.connectionDrainingTimeoutInSeconds());
+            Assertions.assertEquals("/path/", config.path());
+            Assertions.assertEquals("cookie", config.affinityCookieName());
 
             // Verify probes
-            Assert.assertEquals(2, appGateway.probes().size());
+            Assertions.assertEquals(2, appGateway.probes().size());
             ApplicationGatewayProbe probe;
             probe = appGateway.probes().get("probe1");
-            Assert.assertNotNull(probe);
-            Assert.assertEquals("microsoft.com", probe.host().toLowerCase());
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTP, probe.protocol());
-            Assert.assertEquals("/", probe.path());
-            Assert.assertEquals(5,  probe.retriesBeforeUnhealthy());
-            Assert.assertEquals(9, probe.timeBetweenProbesInSeconds());
-            Assert.assertEquals(10, probe.timeoutInSeconds());
-            Assert.assertNotNull(probe.healthyHttpResponseStatusCodeRanges());
-            Assert.assertEquals(1, probe.healthyHttpResponseStatusCodeRanges().size());
-            Assert.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("200-249"));
+            Assertions.assertNotNull(probe);
+            Assertions.assertEquals("microsoft.com", probe.host().toLowerCase());
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTP, probe.protocol());
+            Assertions.assertEquals("/", probe.path());
+            Assertions.assertEquals(5,  probe.retriesBeforeUnhealthy());
+            Assertions.assertEquals(9, probe.timeBetweenProbesInSeconds());
+            Assertions.assertEquals(10, probe.timeoutInSeconds());
+            Assertions.assertNotNull(probe.healthyHttpResponseStatusCodeRanges());
+            Assertions.assertEquals(1, probe.healthyHttpResponseStatusCodeRanges().size());
+            Assertions.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("200-249"));
 
             probe = appGateway.probes().get("probe2");
-            Assert.assertNotNull(probe);
-            Assert.assertEquals(ApplicationGatewayProtocol.HTTPS, probe.protocol());
-            Assert.assertEquals(2, probe.healthyHttpResponseStatusCodeRanges().size());
-            Assert.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("600-610"));
-            Assert.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("650-660"));
-            Assert.assertEquals("I am too healthy for this test.", probe.healthyHttpResponseBodyContents());
+            Assertions.assertNotNull(probe);
+            Assertions.assertEquals(ApplicationGatewayProtocol.HTTPS, probe.protocol());
+            Assertions.assertEquals(2, probe.healthyHttpResponseStatusCodeRanges().size());
+            Assertions.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("600-610"));
+            Assertions.assertTrue(probe.healthyHttpResponseStatusCodeRanges().contains("650-660"));
+            Assertions.assertEquals("I am too healthy for this test.", probe.healthyHttpResponseBodyContents());
 
             creationThread.join();
 
             // Verify SSL policy - disabled protocols
-            Assert.assertEquals(2, appGateway.disabledSslProtocols().size());
-            Assert.assertTrue(appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_0));
-            Assert.assertTrue(appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_1));
-            Assert.assertTrue(!appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_2));
+            Assertions.assertEquals(2, appGateway.disabledSslProtocols().size());
+            Assertions.assertTrue(appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_0));
+            Assertions.assertTrue(appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_1));
+            Assertions.assertTrue(!appGateway.disabledSslProtocols().contains(ApplicationGatewaySslProtocol.TLSV1_2));
 
             return appGateway;
         }
@@ -1094,9 +1094,9 @@ public class TestApplicationGateway {
         public ApplicationGateway updateResource(final ApplicationGateway resource) throws Exception {
             final int rulesCount = resource.requestRoutingRules().size();
             ApplicationGatewayRequestRoutingRule rule80 = resource.requestRoutingRules().get("rule80");
-            Assert.assertNotNull(rule80);
+            Assertions.assertNotNull(rule80);
             ApplicationGatewayBackendHttpConfiguration backendConfig80 = rule80.backendHttpConfiguration();
-            Assert.assertNotNull(backendConfig80);
+            Assertions.assertNotNull(backendConfig80);
 
             resource.update()
                 .withSize(ApplicationGatewaySkuName.STANDARD_SMALL)
@@ -1131,48 +1131,48 @@ public class TestApplicationGateway {
             resource.refresh();
 
             // Get the resource created so far
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
-            Assert.assertTrue(resource.size().equals(ApplicationGatewaySkuName.STANDARD_SMALL));
-            Assert.assertTrue(resource.instanceCount() == 1);
-            Assert.assertFalse(resource.isHttp2Enabled());
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.size().equals(ApplicationGatewaySkuName.STANDARD_SMALL));
+            Assertions.assertTrue(resource.instanceCount() == 1);
+            Assertions.assertFalse(resource.isHttp2Enabled());
 
             // Verify listeners
             ApplicationGatewayListener listener = resource.listeners().get("listener1");
-            Assert.assertTrue("www.contoso.com".equalsIgnoreCase(listener.hostName()));
+            Assertions.assertTrue("www.contoso.com".equalsIgnoreCase(listener.hostName()));
 
             // Verify request routing rules
-            Assert.assertTrue(resource.requestRoutingRules().size() == rulesCount - 1);
-            Assert.assertTrue(!resource.requestRoutingRules().containsKey("rule9000"));
+            Assertions.assertTrue(resource.requestRoutingRules().size() == rulesCount - 1);
+            Assertions.assertTrue(!resource.requestRoutingRules().containsKey("rule9000"));
             ApplicationGatewayRequestRoutingRule rule = resource.requestRoutingRules().get("rule443");
-            Assert.assertTrue(rule != null);
-            Assert.assertTrue("listener1".equalsIgnoreCase(rule.listener().name()));
+            Assertions.assertTrue(rule != null);
+            Assertions.assertTrue("listener1".equalsIgnoreCase(rule.listener().name()));
 
             // Verify probes
-            Assert.assertEquals(1, resource.probes().size());
+            Assertions.assertEquals(1, resource.probes().size());
             ApplicationGatewayProbe probe = resource.probes().get("probe2");
-            Assert.assertNotNull(probe);
-            Assert.assertTrue(probe.healthyHttpResponseStatusCodeRanges().isEmpty());
-            Assert.assertNull(probe.healthyHttpResponseBodyContents());
+            Assertions.assertNotNull(probe);
+            Assertions.assertTrue(probe.healthyHttpResponseStatusCodeRanges().isEmpty());
+            Assertions.assertNull(probe.healthyHttpResponseBodyContents());
 
             // Verify backend configs
             ApplicationGatewayBackendHttpConfiguration backendConfig = resource.backendHttpConfigurations().get("config1");
-            Assert.assertNotNull(backendConfig);
-            Assert.assertNull(backendConfig.probe());
-            Assert.assertFalse(backendConfig.isHostHeaderFromBackend());
-            Assert.assertNull(backendConfig.hostHeader());
-            Assert.assertEquals(0, backendConfig.connectionDrainingTimeoutInSeconds());
-            Assert.assertNull(backendConfig.affinityCookieName());
-            Assert.assertNull(backendConfig.path());
+            Assertions.assertNotNull(backendConfig);
+            Assertions.assertNull(backendConfig.probe());
+            Assertions.assertFalse(backendConfig.isHostHeaderFromBackend());
+            Assertions.assertNull(backendConfig.hostHeader());
+            Assertions.assertEquals(0, backendConfig.connectionDrainingTimeoutInSeconds());
+            Assertions.assertNull(backendConfig.affinityCookieName());
+            Assertions.assertNull(backendConfig.path());
 
             rule80 = resource.requestRoutingRules().get("rule80");
-            Assert.assertNotNull(rule80);
+            Assertions.assertNotNull(rule80);
             backendConfig80 = rule80.backendHttpConfiguration();
-            Assert.assertNotNull(backendConfig80);
-            Assert.assertTrue(backendConfig80.isHostHeaderFromBackend());
-            Assert.assertNull(backendConfig80.hostHeader());
+            Assertions.assertNotNull(backendConfig80);
+            Assertions.assertTrue(backendConfig80.isHostHeaderFromBackend());
+            Assertions.assertNull(backendConfig80.hostHeader());
 
             // Verify SSL policy - disabled protocols
-            Assert.assertEquals(0, resource.disabledSslProtocols().size());
+            Assertions.assertEquals(0, resource.disabledSslProtocols().size());
             return resource;
         }
     }
@@ -1229,48 +1229,48 @@ public class TestApplicationGateway {
             // Get the resource as created so far
             String resourceId = createResourceId(resources.manager().subscriptionId());
             ApplicationGateway appGateway = resources.manager().applicationGateways().getById(resourceId);
-            Assert.assertTrue(appGateway != null);
-            Assert.assertTrue(ApplicationGatewayTier.STANDARD.equals(appGateway.tier()));
-            Assert.assertTrue(ApplicationGatewaySkuName.STANDARD_SMALL.equals(appGateway.size()));
-            Assert.assertTrue(appGateway.instanceCount() == 1);
+            Assertions.assertTrue(appGateway != null);
+            Assertions.assertTrue(ApplicationGatewayTier.STANDARD.equals(appGateway.tier()));
+            Assertions.assertTrue(ApplicationGatewaySkuName.STANDARD_SMALL.equals(appGateway.size()));
+            Assertions.assertTrue(appGateway.instanceCount() == 1);
 
             // Verify frontend ports
-            Assert.assertTrue(appGateway.frontendPorts().size() == 1);
-            Assert.assertTrue(appGateway.frontendPortNameFromNumber(443) != null);
+            Assertions.assertTrue(appGateway.frontendPorts().size() == 1);
+            Assertions.assertTrue(appGateway.frontendPortNameFromNumber(443) != null);
 
             // Verify frontends
-            Assert.assertTrue(!appGateway.isPrivate());
-            Assert.assertTrue(appGateway.isPublic());
-            Assert.assertTrue(appGateway.frontends().size() == 1);
+            Assertions.assertTrue(!appGateway.isPrivate());
+            Assertions.assertTrue(appGateway.isPublic());
+            Assertions.assertTrue(appGateway.frontends().size() == 1);
 
             // Verify listeners
-            Assert.assertTrue(appGateway.listeners().size() == 1);
-            Assert.assertTrue(appGateway.listenerByPortNumber(443) != null);
+            Assertions.assertTrue(appGateway.listeners().size() == 1);
+            Assertions.assertTrue(appGateway.listenerByPortNumber(443) != null);
 
             // Verify backends
-            Assert.assertTrue(appGateway.backends().size() == 1);
+            Assertions.assertTrue(appGateway.backends().size() == 1);
 
             // Verify backend HTTP configs
-            Assert.assertTrue(appGateway.backendHttpConfigurations().size() == 1);
+            Assertions.assertTrue(appGateway.backendHttpConfigurations().size() == 1);
 
             // Verify rules
-            Assert.assertTrue(appGateway.requestRoutingRules().size() == 1);
+            Assertions.assertTrue(appGateway.requestRoutingRules().size() == 1);
             ApplicationGatewayRequestRoutingRule rule = appGateway.requestRoutingRules().get("rule1");
-            Assert.assertTrue(rule != null);
-            Assert.assertTrue(rule.frontendPort() == 443);
-            Assert.assertTrue(ApplicationGatewayProtocol.HTTPS.equals(rule.frontendProtocol()));
-            Assert.assertTrue(rule.listener() != null);
-            Assert.assertTrue(rule.listener().frontend() != null);
-            Assert.assertTrue(rule.listener().frontend().isPublic());
-            Assert.assertTrue(!rule.listener().frontend().isPrivate());
-            Assert.assertTrue(rule.backendPort() == 8080);
-            Assert.assertTrue(rule.sslCertificate() != null);
-            Assert.assertTrue(rule.backendAddresses().size() == 2);
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
-            Assert.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
+            Assertions.assertTrue(rule != null);
+            Assertions.assertTrue(rule.frontendPort() == 443);
+            Assertions.assertTrue(ApplicationGatewayProtocol.HTTPS.equals(rule.frontendProtocol()));
+            Assertions.assertTrue(rule.listener() != null);
+            Assertions.assertTrue(rule.listener().frontend() != null);
+            Assertions.assertTrue(rule.listener().frontend().isPublic());
+            Assertions.assertTrue(!rule.listener().frontend().isPrivate());
+            Assertions.assertTrue(rule.backendPort() == 8080);
+            Assertions.assertTrue(rule.sslCertificate() != null);
+            Assertions.assertTrue(rule.backendAddresses().size() == 2);
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.1"));
+            Assertions.assertTrue(rule.backend().containsIPAddress("11.1.1.2"));
 
             // Verify certificates
-            Assert.assertTrue(appGateway.sslCertificates().size() == 1);
+            Assertions.assertTrue(appGateway.sslCertificates().size() == 1);
 
             creationThread.join();
             return appGateway;
@@ -1305,50 +1305,50 @@ public class TestApplicationGateway {
 
             resource.refresh();
 
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(ApplicationGatewaySkuName.STANDARD_MEDIUM.equals(resource.size()));
-            Assert.assertTrue(resource.instanceCount() == 2);
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(ApplicationGatewaySkuName.STANDARD_MEDIUM.equals(resource.size()));
+            Assertions.assertTrue(resource.instanceCount() == 2);
 
             // Verify frontend ports
-            Assert.assertTrue(resource.frontendPorts().size() == 2);
-            Assert.assertTrue(resource.frontendPortNameFromNumber(80) != null);
+            Assertions.assertTrue(resource.frontendPorts().size() == 2);
+            Assertions.assertTrue(resource.frontendPortNameFromNumber(80) != null);
 
             // Verify listeners
-            Assert.assertTrue(resource.listeners().size() == 2);
+            Assertions.assertTrue(resource.listeners().size() == 2);
             ApplicationGatewayListener listener = resource.listeners().get("listener2");
-            Assert.assertTrue(listener != null);
-            Assert.assertTrue(!listener.frontend().isPrivate());
-            Assert.assertTrue(listener.frontend().isPublic());
-            Assert.assertTrue(listener.frontendPortNumber() == 80);
-            Assert.assertTrue(ApplicationGatewayProtocol.HTTP.equals(listener.protocol()));
-            Assert.assertTrue(listener.sslCertificate() == null);
+            Assertions.assertTrue(listener != null);
+            Assertions.assertTrue(!listener.frontend().isPrivate());
+            Assertions.assertTrue(listener.frontend().isPublic());
+            Assertions.assertTrue(listener.frontendPortNumber() == 80);
+            Assertions.assertTrue(ApplicationGatewayProtocol.HTTP.equals(listener.protocol()));
+            Assertions.assertTrue(listener.sslCertificate() == null);
 
             // Verify backends
-            Assert.assertTrue(resource.backends().size() == 2);
+            Assertions.assertTrue(resource.backends().size() == 2);
             ApplicationGatewayBackend backend = resource.backends().get("backend2");
-            Assert.assertTrue(backend != null);
-            Assert.assertTrue(backend.addresses().size() == 1);
-            Assert.assertTrue(backend.containsIPAddress("11.1.1.3"));
+            Assertions.assertTrue(backend != null);
+            Assertions.assertTrue(backend.addresses().size() == 1);
+            Assertions.assertTrue(backend.containsIPAddress("11.1.1.3"));
 
             // Verify HTTP configs
-            Assert.assertTrue(resource.backendHttpConfigurations().size() == 2);
+            Assertions.assertTrue(resource.backendHttpConfigurations().size() == 2);
             ApplicationGatewayBackendHttpConfiguration config = resource.backendHttpConfigurations().get("config2");
-            Assert.assertTrue(config != null);
-            Assert.assertTrue(config.cookieBasedAffinity());
-            Assert.assertTrue(config.port() == 8081);
-            Assert.assertTrue(config.requestTimeout() == 33);
+            Assertions.assertTrue(config != null);
+            Assertions.assertTrue(config.cookieBasedAffinity());
+            Assertions.assertTrue(config.port() == 8081);
+            Assertions.assertTrue(config.requestTimeout() == 33);
 
             // Verify request routing rules
-            Assert.assertTrue(resource.requestRoutingRules().size() == 2);
+            Assertions.assertTrue(resource.requestRoutingRules().size() == 2);
             ApplicationGatewayRequestRoutingRule rule = resource.requestRoutingRules().get("rule2");
-            Assert.assertTrue(rule != null);
-            Assert.assertTrue(rule.listener() != null);
-            Assert.assertTrue("listener2".equals(rule.listener().name()));
-            Assert.assertTrue(rule.backendHttpConfiguration() != null);
-            Assert.assertTrue("config2".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
-            Assert.assertTrue(rule.backend() != null);
-            Assert.assertTrue("backend2".equalsIgnoreCase(rule.backend().name()));
+            Assertions.assertTrue(rule != null);
+            Assertions.assertTrue(rule.listener() != null);
+            Assertions.assertTrue("listener2".equals(rule.listener().name()));
+            Assertions.assertTrue(rule.backendHttpConfiguration() != null);
+            Assertions.assertTrue("config2".equalsIgnoreCase(rule.backendHttpConfiguration().name()));
+            Assertions.assertTrue(rule.backend() != null);
+            Assertions.assertTrue("backend2".equalsIgnoreCase(rule.backend().name()));
 
             return resource;
         }

--- a/azure/src/test/java/com/microsoft/azure/management/TestAvailabilitySet.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestAvailabilitySet.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.management;
 
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.compute.AvailabilitySet;
 import com.microsoft.azure.management.compute.AvailabilitySets;
@@ -25,9 +25,9 @@ public class TestAvailabilitySet extends TestTemplate<AvailabilitySet, Availabil
                 .withTag("tag1", "value1")
                 .create();
         PagedList<VirtualMachineSize> vmSizes = aset.listVirtualMachineSizes();
-        Assert.assertTrue(vmSizes.size() > 0);
+        Assertions.assertTrue(vmSizes.size() > 0);
         for (VirtualMachineSize vmSize : vmSizes) {
-            Assert.assertNotNull(vmSize.name());
+            Assertions.assertNotNull(vmSize.name());
         }
         return aset;
     }
@@ -40,8 +40,8 @@ public class TestAvailabilitySet extends TestTemplate<AvailabilitySet, Availabil
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .apply();
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertTrue(!resource.tags().containsKey("tag1"));
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertTrue(!resource.tags().containsKey("tag1"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestBatch.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestBatch.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.batch.BatchAccounts;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.model.Indexable;
 import com.azure.management.resources.fluentcore.utils.Utils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.Observable;
 import rx.functions.Action1;
 
@@ -39,7 +39,7 @@ public class TestBatch extends TestTemplate<BatchAccount, BatchAccounts>  {
                 });
 
         batchAccounts[0] = future.get();
-        Assert.assertNull(batchAccounts[0].autoStorage());
+        Assertions.assertNull(batchAccounts[0].autoStorage());
 
         return batchAccounts[0];
     }
@@ -52,7 +52,7 @@ public class TestBatch extends TestTemplate<BatchAccount, BatchAccounts>  {
                 .withNewStorageAccount(storageAccountName)
                 .apply();
 
-        Assert.assertNotNull(resource.autoStorage());
+        Assertions.assertNotNull(resource.autoStorage());
 
         return resource;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestBatchAI.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestBatchAI.java
@@ -22,7 +22,7 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.file.CloudFileShare;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import static com.azure.management.resources.core.TestBase.isPlaybackMode;
 
@@ -118,16 +118,16 @@ public class TestBatchAI {
                     .withInstrumentationKey("appInsightsKey")
                     .create();
             printBatchAICluster(cluster);
-            Assert.assertEquals("resizing", cluster.allocationState().toString());
-            Assert.assertEquals(userName, cluster.adminUserName());
-            Assert.assertEquals(VmPriority.LOWPRIORITY, cluster.vmPriority());
-            Assert.assertEquals(1, cluster.nodeSetup().mountVolumes().azureFileShares().size());
-            Assert.assertEquals(shareMountPath, cluster.nodeSetup().mountVolumes().azureFileShares().get(0).relativeMountPath());
-            Assert.assertEquals(1, cluster.nodeSetup().mountVolumes().azureBlobFileSystems().size());
-            Assert.assertEquals(blobFileSystemPath, cluster.nodeSetup().mountVolumes().azureBlobFileSystems().get(0).relativeMountPath());
-            Assert.assertEquals(network.id() + "/subnets/" + subnetName, cluster.subnet().id());
-            Assert.assertEquals("appinsightsId", cluster.nodeSetup().performanceCountersSettings().appInsightsReference().component().id());
-            Assert.assertEquals("linux-data-science-vm-ubuntu", cluster.virtualMachineConfiguration().imageReference().offer());
+            Assertions.assertEquals("resizing", cluster.allocationState().toString());
+            Assertions.assertEquals(userName, cluster.adminUserName());
+            Assertions.assertEquals(VmPriority.LOWPRIORITY, cluster.vmPriority());
+            Assertions.assertEquals(1, cluster.nodeSetup().mountVolumes().azureFileShares().size());
+            Assertions.assertEquals(shareMountPath, cluster.nodeSetup().mountVolumes().azureFileShares().get(0).relativeMountPath());
+            Assertions.assertEquals(1, cluster.nodeSetup().mountVolumes().azureBlobFileSystems().size());
+            Assertions.assertEquals(blobFileSystemPath, cluster.nodeSetup().mountVolumes().azureBlobFileSystems().get(0).relativeMountPath());
+            Assertions.assertEquals(network.id() + "/subnets/" + subnetName, cluster.subnet().id());
+            Assertions.assertEquals("appinsightsId", cluster.nodeSetup().performanceCountersSettings().appInsightsReference().component().id());
+            Assertions.assertEquals("linux-data-science-vm-ubuntu", cluster.virtualMachineConfiguration().imageReference().offer());
             return workspace;
         }
 
@@ -138,7 +138,7 @@ public class TestBatchAI {
             cluster.update()
                     .withAutoScale(1, 2, 2)
                     .apply();
-            Assert.assertEquals(2, cluster.scaleSettings().autoScale().maximumNodeCount());
+            Assertions.assertEquals(2, cluster.scaleSettings().autoScale().maximumNodeCount());
             return workspace;
         }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestBatchAIFileServers.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestBatchAIFileServers.java
@@ -15,7 +15,7 @@ import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.network.Networks;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestBatchAIFileServers extends TestTemplate<BatchAIWorkspace, BatchAIWorkspaces> {
     private Networks networks;
@@ -54,8 +54,8 @@ public class TestBatchAIFileServers extends TestTemplate<BatchAIWorkspace, Batch
                 .withSubnet(network.id(), subnetName)
                 .create();
 
-        Assert.assertEquals(network.id() + "/subnets/" + subnetName, fileServer.subnet().id());
-        Assert.assertEquals(CachingType.READWRITE, fileServer.dataDisks().cachingType());
+        Assertions.assertEquals(network.id() + "/subnets/" + subnetName, fileServer.subnet().id());
+        Assertions.assertEquals(CachingType.READWRITE, fileServer.dataDisks().cachingType());
         return workspace;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestCdn.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestCdn.java
@@ -17,7 +17,7 @@ import com.microsoft.azure.management.cdn.ResourceUsage;
 import com.microsoft.azure.management.cdn.SkuName;
 import com.azure.management.resources.fluentcore.arm.CountryIsoCode;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.Map;
 
@@ -51,39 +51,39 @@ public class TestCdn extends TestTemplate<CdnProfile, CdnProfiles> {
                     .attach()
                 .create();
 
-        Assert.assertTrue(cdnProfile.sku().name().equals(SkuName.STANDARD_AKAMAI));
-        Assert.assertNotNull(cdnProfile.endpoints());
-        Assert.assertEquals(1, cdnProfile.endpoints().size());
+        Assertions.assertTrue(cdnProfile.sku().name().equals(SkuName.STANDARD_AKAMAI));
+        Assertions.assertNotNull(cdnProfile.endpoints());
+        Assertions.assertEquals(1, cdnProfile.endpoints().size());
         CdnEndpoint endpoint = cdnProfile.endpoints().get(cdnEndpointName);
-        Assert.assertNotNull(endpoint);
-        Assert.assertEquals(cdnOriginHostName, endpoint.originHostName());
-        Assert.assertEquals(444, endpoint.httpsPort());
-        Assert.assertEquals(85, endpoint.httpPort());
-        Assert.assertFalse(endpoint.isHttpAllowed());
-        Assert.assertTrue(endpoint.isHttpsAllowed());
-        Assert.assertTrue(endpoint.isCompressionEnabled());
-        Assert.assertEquals(QueryStringCachingBehavior.BYPASS_CACHING, endpoint.queryStringCachingBehavior());
-        Assert.assertNotNull(endpoint.geoFilters());
-        Assert.assertEquals(QueryStringCachingBehavior.BYPASS_CACHING, endpoint.queryStringCachingBehavior());
+        Assertions.assertNotNull(endpoint);
+        Assertions.assertEquals(cdnOriginHostName, endpoint.originHostName());
+        Assertions.assertEquals(444, endpoint.httpsPort());
+        Assertions.assertEquals(85, endpoint.httpPort());
+        Assertions.assertFalse(endpoint.isHttpAllowed());
+        Assertions.assertTrue(endpoint.isHttpsAllowed());
+        Assertions.assertTrue(endpoint.isCompressionEnabled());
+        Assertions.assertEquals(QueryStringCachingBehavior.BYPASS_CACHING, endpoint.queryStringCachingBehavior());
+        Assertions.assertNotNull(endpoint.geoFilters());
+        Assertions.assertEquals(QueryStringCachingBehavior.BYPASS_CACHING, endpoint.queryStringCachingBehavior());
 
         for (ResourceUsage usage : profiles.listResourceUsage()) {
-            Assert.assertNotNull(usage);
-            Assert.assertEquals("profile", usage.resourceType());
+            Assertions.assertNotNull(usage);
+            Assertions.assertEquals("profile", usage.resourceType());
         }
 
         for (EdgeNode node : profiles.listEdgeNodes()) {
-            Assert.assertNotNull(node);
+            Assertions.assertNotNull(node);
         }
 
         for (ResourceUsage usage : cdnProfile.listResourceUsage()) {
-            Assert.assertNotNull(usage);
-            Assert.assertEquals("endpoint", usage.resourceType());
+            Assertions.assertNotNull(usage);
+            Assertions.assertEquals("endpoint", usage.resourceType());
         }
 
         for( CdnEndpoint ep : cdnProfile.endpoints().values()) {
             for (ResourceUsage usage : ep.listResourceUsage()) {
-                Assert.assertNotNull(usage);
-                Assert.assertTrue("customdomain".equals(usage.resourceType())
+                Assertions.assertNotNull(usage);
+                Assertions.assertTrue("customdomain".equals(usage.resourceType())
                                     || "geofilter".equals(usage.resourceType()));
             }
         }
@@ -110,11 +110,11 @@ public class TestCdn extends TestTemplate<CdnProfile, CdnProfiles> {
                     .parent()
                 .apply();
 
-        Assert.assertEquals(3, profile.endpoints().size());
+        Assertions.assertEquals(3, profile.endpoints().size());
         CdnEndpoint updatedEndpoint = profile.endpoints().get(firstEndpointName);
-        Assert.assertTrue(updatedEndpoint.isHttpsAllowed());
-        Assert.assertEquals(1111, updatedEndpoint.httpPort());
-        Assert.assertEquals(0, updatedEndpoint.geoFilters().size());
+        Assertions.assertTrue(updatedEndpoint.isHttpsAllowed());
+        Assertions.assertEquals(1111, updatedEndpoint.httpPort());
+        Assertions.assertEquals(0, updatedEndpoint.geoFilters().size());
 
         return profile;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestContainerInstanceWithPrivateIpAddress.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestContainerInstanceWithPrivateIpAddress.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.containerinstance.Volume;
 import com.microsoft.azure.management.containerinstance.VolumeMount;
 import com.microsoft.azure.management.graphrbac.BuiltInRole;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,64 +63,64 @@ public class TestContainerInstanceWithPrivateIpAddress extends TestTemplate<Cont
                 .withTag("tag1", "value1")
                 .create();
 
-        Assert.assertEquals(cgName, containerGroup.name());
-        Assert.assertEquals("Linux", containerGroup.osType().toString());
-        Assert.assertEquals(0, containerGroup.imageRegistryServers().size());
-        Assert.assertEquals(1, containerGroup.volumes().size());
-        Assert.assertNotNull(containerGroup.volumes().get("emptydir1"));
-        Assert.assertNotNull(containerGroup.ipAddress());
-        Assert.assertTrue(containerGroup.isIPAddressPrivate());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(2, containerGroup.externalPorts().size());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
-        Assert.assertEquals(80, containerGroup.externalTcpPorts()[1]);
-        Assert.assertEquals(2, containerGroup.containers().size());
+        Assertions.assertEquals(cgName, containerGroup.name());
+        Assertions.assertEquals("Linux", containerGroup.osType().toString());
+        Assertions.assertEquals(0, containerGroup.imageRegistryServers().size());
+        Assertions.assertEquals(1, containerGroup.volumes().size());
+        Assertions.assertNotNull(containerGroup.volumes().get("emptydir1"));
+        Assertions.assertNotNull(containerGroup.ipAddress());
+        Assertions.assertTrue(containerGroup.isIPAddressPrivate());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(2, containerGroup.externalPorts().size());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
+        Assertions.assertEquals(80, containerGroup.externalTcpPorts()[1]);
+        Assertions.assertEquals(2, containerGroup.containers().size());
         Container tomcatContainer = containerGroup.containers().get("tomcat");
-        Assert.assertNotNull(tomcatContainer);
+        Assertions.assertNotNull(tomcatContainer);
         Container nginxContainer = containerGroup.containers().get("nginx");
-        Assert.assertNotNull(nginxContainer);
-        Assert.assertEquals("tomcat", tomcatContainer.name());
-        Assert.assertEquals("tomcat", tomcatContainer.image());
-        Assert.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, tomcatContainer.ports().size());
-        Assert.assertEquals(8080, tomcatContainer.ports().get(0).port());
-        Assert.assertNull(tomcatContainer.volumeMounts());
-        Assert.assertNull(tomcatContainer.command());
-        Assert.assertNotNull(tomcatContainer.environmentVariables());
-        Assert.assertEquals(1, tomcatContainer.environmentVariables().size());
-        Assert.assertEquals("nginx", nginxContainer.name());
-        Assert.assertEquals("nginx", nginxContainer.image());
-        Assert.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, nginxContainer.ports().size());
-        Assert.assertEquals(80, nginxContainer.ports().get(0).port());
-        Assert.assertNull(nginxContainer.volumeMounts());
-        Assert.assertNull(nginxContainer.command());
-        Assert.assertNotNull(nginxContainer.environmentVariables());
-        Assert.assertEquals(1, nginxContainer.environmentVariables().size());
-        Assert.assertTrue(containerGroup.tags().containsKey("tag1"));
-        Assert.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
-        Assert.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
-        Assert.assertEquals(ResourceIdentityType.SYSTEM_ASSIGNED, containerGroup.managedServiceIdentityType());
-        Assert.assertEquals(logAnalyticsWorkspaceId, containerGroup.logAnalytics().workspaceId());
-        Assert.assertEquals("/subscriptions/" + networkProfileSubscriptionId + "/resourceGroups/" + networkProfileResourceGroupName + "/providers/Microsoft.Network/networkProfiles/" + networkProfileName, containerGroup.networkProfileId());
-        Assert.assertEquals("dnsServer1", containerGroup.dnsConfig().nameServers().get(0));
-        Assert.assertEquals("dnsSearchDomains", containerGroup.dnsConfig().searchDomains());
-        Assert.assertEquals("dnsOptions", containerGroup.dnsConfig().options());
+        Assertions.assertNotNull(nginxContainer);
+        Assertions.assertEquals("tomcat", tomcatContainer.name());
+        Assertions.assertEquals("tomcat", tomcatContainer.image());
+        Assertions.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, tomcatContainer.ports().size());
+        Assertions.assertEquals(8080, tomcatContainer.ports().get(0).port());
+        Assertions.assertNull(tomcatContainer.volumeMounts());
+        Assertions.assertNull(tomcatContainer.command());
+        Assertions.assertNotNull(tomcatContainer.environmentVariables());
+        Assertions.assertEquals(1, tomcatContainer.environmentVariables().size());
+        Assertions.assertEquals("nginx", nginxContainer.name());
+        Assertions.assertEquals("nginx", nginxContainer.image());
+        Assertions.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, nginxContainer.ports().size());
+        Assertions.assertEquals(80, nginxContainer.ports().get(0).port());
+        Assertions.assertNull(nginxContainer.volumeMounts());
+        Assertions.assertNull(nginxContainer.command());
+        Assertions.assertNotNull(nginxContainer.environmentVariables());
+        Assertions.assertEquals(1, nginxContainer.environmentVariables().size());
+        Assertions.assertTrue(containerGroup.tags().containsKey("tag1"));
+        Assertions.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
+        Assertions.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
+        Assertions.assertEquals(ResourceIdentityType.SYSTEM_ASSIGNED, containerGroup.managedServiceIdentityType());
+        Assertions.assertEquals(logAnalyticsWorkspaceId, containerGroup.logAnalytics().workspaceId());
+        Assertions.assertEquals("/subscriptions/" + networkProfileSubscriptionId + "/resourceGroups/" + networkProfileResourceGroupName + "/providers/Microsoft.Network/networkProfiles/" + networkProfileName, containerGroup.networkProfileId());
+        Assertions.assertEquals("dnsServer1", containerGroup.dnsConfig().nameServers().get(0));
+        Assertions.assertEquals("dnsSearchDomains", containerGroup.dnsConfig().searchDomains());
+        Assertions.assertEquals("dnsOptions", containerGroup.dnsConfig().options());
 
         ContainerGroup containerGroup2 = containerGroups.getByResourceGroup(rgName, cgName);
 
         List<ContainerGroup> containerGroupList = containerGroups.listByResourceGroup(rgName);
-        Assert.assertTrue(containerGroupList.size() > 0);
-        Assert.assertNotNull(containerGroupList.get(0).state());
+        Assertions.assertTrue(containerGroupList.size() > 0);
+        Assertions.assertNotNull(containerGroupList.get(0).state());
 
         containerGroup.refresh();
 
         Set<Operation> containerGroupOperations = containerGroups.listOperations();
         // Number of supported operation can change hence don't assert with a predefined number.
-        Assert.assertTrue(containerGroupOperations.size() > 0);
+        Assertions.assertTrue(containerGroupOperations.size() > 0);
 
         return containerGroup;
     }
@@ -131,8 +131,8 @@ public class TestContainerInstanceWithPrivateIpAddress extends TestTemplate<Cont
                 .withoutTag("tag1")
                 .withTag("tag2", "value2")
                 .apply();
-        Assert.assertFalse(containerGroup.tags().containsKey("tag"));
-        Assert.assertTrue(containerGroup.tags().containsKey("tag2"));
+        Assertions.assertFalse(containerGroup.tags().containsKey("tag"));
+        Assertions.assertTrue(containerGroup.tags().containsKey("tag2"));
 
         containerGroup.restart();
         containerGroup.stop();

--- a/azure/src/test/java/com/microsoft/azure/management/TestContainerInstanceWithPublicIpAddressWithSystemAssignedMSI.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestContainerInstanceWithPublicIpAddressWithSystemAssignedMSI.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.containerinstance.Volume;
 import com.microsoft.azure.management.containerinstance.VolumeMount;
 import com.microsoft.azure.management.graphrbac.BuiltInRole;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,59 +53,59 @@ public class TestContainerInstanceWithPublicIpAddressWithSystemAssignedMSI exten
             .withTag("tag1", "value1")
             .create();
 
-        Assert.assertEquals(cgName, containerGroup.name());
-        Assert.assertEquals("Linux", containerGroup.osType().toString());
-        Assert.assertEquals(0, containerGroup.imageRegistryServers().size());
-        Assert.assertEquals(1, containerGroup.volumes().size());
-        Assert.assertNotNull(containerGroup.volumes().get("emptydir1"));
-        Assert.assertNotNull(containerGroup.ipAddress());
-        Assert.assertTrue(containerGroup.isIPAddressPublic());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(2, containerGroup.externalPorts().size());
-        Assert.assertEquals(2, containerGroup.externalTcpPorts().length);
-        Assert.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
-        Assert.assertEquals(80, containerGroup.externalTcpPorts()[1]);
-        Assert.assertEquals(2, containerGroup.containers().size());
+        Assertions.assertEquals(cgName, containerGroup.name());
+        Assertions.assertEquals("Linux", containerGroup.osType().toString());
+        Assertions.assertEquals(0, containerGroup.imageRegistryServers().size());
+        Assertions.assertEquals(1, containerGroup.volumes().size());
+        Assertions.assertNotNull(containerGroup.volumes().get("emptydir1"));
+        Assertions.assertNotNull(containerGroup.ipAddress());
+        Assertions.assertTrue(containerGroup.isIPAddressPublic());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(2, containerGroup.externalPorts().size());
+        Assertions.assertEquals(2, containerGroup.externalTcpPorts().length);
+        Assertions.assertEquals(8080, containerGroup.externalTcpPorts()[0]);
+        Assertions.assertEquals(80, containerGroup.externalTcpPorts()[1]);
+        Assertions.assertEquals(2, containerGroup.containers().size());
         Container tomcatContainer = containerGroup.containers().get("tomcat");
-        Assert.assertNotNull(tomcatContainer);
+        Assertions.assertNotNull(tomcatContainer);
         Container nginxContainer = containerGroup.containers().get("nginx");
-        Assert.assertNotNull(nginxContainer);
-        Assert.assertEquals("tomcat", tomcatContainer.name());
-        Assert.assertEquals("tomcat", tomcatContainer.image());
-        Assert.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, tomcatContainer.ports().size());
-        Assert.assertEquals(8080, tomcatContainer.ports().get(0).port());
-        Assert.assertNull(tomcatContainer.volumeMounts());
-        Assert.assertNull(tomcatContainer.command());
-        Assert.assertNotNull(tomcatContainer.environmentVariables());
-        Assert.assertEquals(1, tomcatContainer.environmentVariables().size());
-        Assert.assertEquals("nginx", nginxContainer.name());
-        Assert.assertEquals("nginx", nginxContainer.image());
-        Assert.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
-        Assert.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
-        Assert.assertEquals(1, nginxContainer.ports().size());
-        Assert.assertEquals(80, nginxContainer.ports().get(0).port());
-        Assert.assertNull(nginxContainer.volumeMounts());
-        Assert.assertNull(nginxContainer.command());
-        Assert.assertNotNull(nginxContainer.environmentVariables());
-        Assert.assertEquals(1, nginxContainer.environmentVariables().size());
-        Assert.assertTrue(containerGroup.tags().containsKey("tag1"));
-        Assert.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
-        Assert.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
-        Assert.assertEquals(ResourceIdentityType.SYSTEM_ASSIGNED, containerGroup.managedServiceIdentityType());
-        Assert.assertEquals(cgName, containerGroup.dnsPrefix());
+        Assertions.assertNotNull(nginxContainer);
+        Assertions.assertEquals("tomcat", tomcatContainer.name());
+        Assertions.assertEquals("tomcat", tomcatContainer.image());
+        Assertions.assertEquals(1.0, tomcatContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, tomcatContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, tomcatContainer.ports().size());
+        Assertions.assertEquals(8080, tomcatContainer.ports().get(0).port());
+        Assertions.assertNull(tomcatContainer.volumeMounts());
+        Assertions.assertNull(tomcatContainer.command());
+        Assertions.assertNotNull(tomcatContainer.environmentVariables());
+        Assertions.assertEquals(1, tomcatContainer.environmentVariables().size());
+        Assertions.assertEquals("nginx", nginxContainer.name());
+        Assertions.assertEquals("nginx", nginxContainer.image());
+        Assertions.assertEquals(1.0, nginxContainer.resources().requests().cpu(), .1);
+        Assertions.assertEquals(1.5, nginxContainer.resources().requests().memoryInGB(), .1);
+        Assertions.assertEquals(1, nginxContainer.ports().size());
+        Assertions.assertEquals(80, nginxContainer.ports().get(0).port());
+        Assertions.assertNull(nginxContainer.volumeMounts());
+        Assertions.assertNull(nginxContainer.command());
+        Assertions.assertNotNull(nginxContainer.environmentVariables());
+        Assertions.assertEquals(1, nginxContainer.environmentVariables().size());
+        Assertions.assertTrue(containerGroup.tags().containsKey("tag1"));
+        Assertions.assertEquals(ContainerGroupRestartPolicy.NEVER, containerGroup.restartPolicy());
+        Assertions.assertTrue(containerGroup.isManagedServiceIdentityEnabled());
+        Assertions.assertEquals(ResourceIdentityType.SYSTEM_ASSIGNED, containerGroup.managedServiceIdentityType());
+        Assertions.assertEquals(cgName, containerGroup.dnsPrefix());
         ContainerGroup containerGroup2 = containerGroups.getByResourceGroup(rgName, cgName);
 
         List<ContainerGroup> containerGroupList = containerGroups.listByResourceGroup(rgName);
-        Assert.assertTrue(containerGroupList.size() > 0);
-        Assert.assertNotNull(containerGroupList.get(0).state());
+        Assertions.assertTrue(containerGroupList.size() > 0);
+        Assertions.assertNotNull(containerGroupList.get(0).state());
 
         containerGroup.refresh();
 
         Set<Operation> containerGroupOperations = containerGroups.listOperations();
         // Number of supported operation can change hence don't assert with a predefined number.
-        Assert.assertTrue(containerGroupOperations.size() > 0);
+        Assertions.assertTrue(containerGroupOperations.size() > 0);
 
         return containerGroup;
     }
@@ -116,8 +116,8 @@ public class TestContainerInstanceWithPublicIpAddressWithSystemAssignedMSI exten
             .withoutTag("tag1")
             .withTag("tag2", "value2")
             .apply();
-        Assert.assertFalse(containerGroup.tags().containsKey("tag"));
-        Assert.assertTrue(containerGroup.tags().containsKey("tag2"));
+        Assertions.assertFalse(containerGroup.tags().containsKey("tag"));
+        Assertions.assertTrue(containerGroup.tags().containsKey("tag2"));
 
         containerGroup.restart();
         containerGroup.stop();

--- a/azure/src/test/java/com/microsoft/azure/management/TestContainerRegistry.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestContainerRegistry.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.containerregistry.RegistryCredentials;
 import com.microsoft.azure.management.containerregistry.Webhook;
 import com.microsoft.azure.management.containerregistry.WebhookAction;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestContainerRegistry extends TestTemplate<Registry, Registries> {
 
@@ -30,14 +30,14 @@ public class TestContainerRegistry extends TestTemplate<Registry, Registries> {
 //                .withTag("tag1", "value1")
 //                .create();
 //
-//        Assert.assertTrue(registry.adminUserEnabled());
-//        Assert.assertEquals(registry.storageAccountName(), "crsa" + this.testId);
+//        Assertions.assertTrue(registry.adminUserEnabled());
+//        Assertions.assertEquals(registry.storageAccountName(), "crsa" + this.testId);
 //
 //        RegistryCredentials registryCredentials = registry.getCredentials();
-//        Assert.assertNotNull(registryCredentials);
-//        Assert.assertEquals(newName + "1", registryCredentials.username());
-//        Assert.assertEquals(2, registryCredentials.accessKeys().size());
-//        Assert.assertTrue(registry.webhooks().list().isEmpty());
+//        Assertions.assertNotNull(registryCredentials);
+//        Assertions.assertEquals(newName + "1", registryCredentials.username());
+//        Assertions.assertEquals(2, registryCredentials.accessKeys().size());
+//        Assertions.assertTrue(registry.webhooks().list().isEmpty());
 
         Registry registry2 = registries.define(newName + "2")
             .withRegion(Region.US_EAST)
@@ -62,34 +62,34 @@ public class TestContainerRegistry extends TestTemplate<Registry, Registries> {
             .withTag("tag1", "value1")
             .create();
 
-        Assert.assertTrue(registry2.adminUserEnabled());
+        Assertions.assertTrue(registry2.adminUserEnabled());
 
         RegistryCredentials registryCredentials2 = registry2.getCredentials();
-        Assert.assertNotNull(registryCredentials2);
-        Assert.assertEquals(newName + "2", registryCredentials2.username());
-        Assert.assertEquals(2, registryCredentials2.accessKeys().size());
+        Assertions.assertNotNull(registryCredentials2);
+        Assertions.assertEquals(newName + "2", registryCredentials2.username());
+        Assertions.assertEquals(2, registryCredentials2.accessKeys().size());
 
 
         PagedList<Webhook> webhooksList = registry2.webhooks().list();
 
-        Assert.assertFalse(webhooksList.isEmpty());
-        Assert.assertEquals(2, webhooksList.size());
+        Assertions.assertFalse(webhooksList.isEmpty());
+        Assertions.assertEquals(2, webhooksList.size());
         Webhook webhook = registry2.webhooks()
             .get("webhookbing1");
-        Assert.assertTrue(webhook.isEnabled());
-        Assert.assertTrue(webhook.tags().containsKey("tag"));
-        Assert.assertEquals("https://www.bing.com", webhook.serviceUri());
-        Assert.assertTrue(webhook.isEnabled());
-        Assert.assertEquals(2, webhook.triggers().size());
+        Assertions.assertTrue(webhook.isEnabled());
+        Assertions.assertTrue(webhook.tags().containsKey("tag"));
+        Assertions.assertEquals("https://www.bing.com", webhook.serviceUri());
+        Assertions.assertTrue(webhook.isEnabled());
+        Assertions.assertEquals(2, webhook.triggers().size());
 
         webhook = registries.webhooks()
             .get(rgName, registry2.name(), "webhookbing2");
-        Assert.assertFalse(webhook.isEnabled());
-        Assert.assertTrue(webhook.tags().containsKey("tag"));
-        Assert.assertEquals("https://www.bing.com", webhook.serviceUri());
-        Assert.assertFalse(webhook.isEnabled());
-        Assert.assertEquals(1, webhook.triggers().size());
-        Assert.assertEquals(WebhookAction.PUSH, webhook.triggers().toArray()[0]);
+        Assertions.assertFalse(webhook.isEnabled());
+        Assertions.assertTrue(webhook.tags().containsKey("tag"));
+        Assertions.assertEquals("https://www.bing.com", webhook.serviceUri());
+        Assertions.assertFalse(webhook.isEnabled());
+        Assertions.assertEquals(1, webhook.triggers().size());
+        Assertions.assertEquals(WebhookAction.PUSH, webhook.triggers().toArray()[0]);
 
         Registry registry3 = registries.getById(webhook.parentId());
 
@@ -118,21 +118,21 @@ public class TestContainerRegistry extends TestTemplate<Registry, Registries> {
             .withTag("tag2", "value")
             .apply();
 
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertFalse(resource.tags().containsKey("tag1"));
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertFalse(resource.tags().containsKey("tag1"));
 
         Webhook webhook = resource.webhooks()
             .get("webhookbing2");
-        Assert.assertFalse(webhook.tags().containsKey("tag"));
-        Assert.assertTrue(webhook.tags().containsKey("tag2"));
-        Assert.assertEquals("https://www.bing.com/maps", webhook.serviceUri());
-        Assert.assertFalse(webhook.isEnabled());
-        Assert.assertEquals(1, webhook.triggers().size());
-        Assert.assertEquals(WebhookAction.DELETE, webhook.triggers().toArray()[0]);
+        Assertions.assertFalse(webhook.tags().containsKey("tag"));
+        Assertions.assertTrue(webhook.tags().containsKey("tag2"));
+        Assertions.assertEquals("https://www.bing.com/maps", webhook.serviceUri());
+        Assertions.assertFalse(webhook.isEnabled());
+        Assertions.assertEquals(1, webhook.triggers().size());
+        Assertions.assertEquals(WebhookAction.DELETE, webhook.triggers().toArray()[0]);
 
         webhook.refresh();
         webhook.enable();
-        Assert.assertTrue(webhook.isEnabled());
+        Assertions.assertTrue(webhook.isEnabled());
 
         webhook.update()
             .withCustomHeader("header1", "value1")
@@ -144,15 +144,15 @@ public class TestContainerRegistry extends TestTemplate<Registry, Registries> {
             .withTag("tag3", "value")
             .apply();
 
-        Assert.assertFalse(webhook.isEnabled());
-        Assert.assertTrue(webhook.tags().containsKey("tag3"));
-        Assert.assertEquals("https://www.msn.com", webhook.serviceUri());
-        Assert.assertFalse(webhook.isEnabled());
-        Assert.assertEquals(1, webhook.triggers().size());
-        Assert.assertEquals(WebhookAction.PUSH, webhook.triggers().toArray()[0]);
+        Assertions.assertFalse(webhook.isEnabled());
+        Assertions.assertTrue(webhook.tags().containsKey("tag3"));
+        Assertions.assertEquals("https://www.msn.com", webhook.serviceUri());
+        Assertions.assertFalse(webhook.isEnabled());
+        Assertions.assertEquals(1, webhook.triggers().size());
+        Assertions.assertEquals(WebhookAction.PUSH, webhook.triggers().toArray()[0]);
 
         webhook.ping();
-        Assert.assertNotNull(webhook.listEvents());
+        Assertions.assertNotNull(webhook.listEvents());
 
         resource.webhooks()
             .delete("webhookbing2");

--- a/azure/src/test/java/com/microsoft/azure/management/TestContainerService.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestContainerService.java
@@ -73,7 +73,7 @@ public class TestContainerService extends TestTemplate<ContainerService, Contain
 
         Assertions.assertEquals(resource.agentPools().size(), 1);
         String agentPoolName = new ArrayList<>(resource.agentPools().keySet()).get(0);
-        Assertions.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
+        Assertions.assertTrue(resource.agentPools().get(agentPoolName).count() == 5, "Agent pool count was not updated.");
         Assertions.assertTrue(resource.tags().containsKey("tag2"));
         Assertions.assertTrue(!resource.tags().containsKey("tag1"));
         return resource;

--- a/azure/src/test/java/com/microsoft/azure/management/TestContainerService.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestContainerService.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.containerservice.ContainerServiceVMSizeTyp
 import com.microsoft.azure.management.containerservice.ContainerServices;
 import com.azure.management.resources.fluentcore.arm.Region;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -46,18 +46,18 @@ public class TestContainerService extends TestTemplate<ContainerService, Contain
                 .withDiagnostics()
                 .withTag("tag1", "value1")
                 .create();
-        Assert.assertNotNull("Container service not found.", resource.id());
-        Assert.assertEquals(resource.region(), Region.US_EAST);
-        Assert.assertEquals(resource.masterNodeCount(), ContainerServiceMasterProfileCount.MIN.count());
-        Assert.assertEquals(resource.linuxRootUsername(), "testUserName");
-        Assert.assertEquals(resource.agentPools().size(), 1);
-        Assert.assertNotNull(resource.agentPools().get("agentPool0" + newName));
-        Assert.assertEquals(resource.agentPools().get("agentPool0" + newName).count(), 1);
-        Assert.assertEquals(resource.agentPools().get("agentPool0" + newName).dnsPrefix(), "ap0" + dnsPrefix);
-        Assert.assertEquals(resource.agentPools().get("agentPool0" + newName).vmSize(), ContainerServiceVMSizeTypes.STANDARD_A1);
-        Assert.assertEquals(resource.orchestratorType(), ContainerServiceOrchestratorTypes.DCOS);
-        Assert.assertTrue(resource.isDiagnosticsEnabled());
-        Assert.assertTrue(resource.tags().containsKey("tag1"));
+        Assertions.assertNotNull("Container service not found.", resource.id());
+        Assertions.assertEquals(resource.region(), Region.US_EAST);
+        Assertions.assertEquals(resource.masterNodeCount(), ContainerServiceMasterProfileCount.MIN.count());
+        Assertions.assertEquals(resource.linuxRootUsername(), "testUserName");
+        Assertions.assertEquals(resource.agentPools().size(), 1);
+        Assertions.assertNotNull(resource.agentPools().get("agentPool0" + newName));
+        Assertions.assertEquals(resource.agentPools().get("agentPool0" + newName).count(), 1);
+        Assertions.assertEquals(resource.agentPools().get("agentPool0" + newName).dnsPrefix(), "ap0" + dnsPrefix);
+        Assertions.assertEquals(resource.agentPools().get("agentPool0" + newName).vmSize(), ContainerServiceVMSizeTypes.STANDARD_A1);
+        Assertions.assertEquals(resource.orchestratorType(), ContainerServiceOrchestratorTypes.DCOS);
+        Assertions.assertTrue(resource.isDiagnosticsEnabled());
+        Assertions.assertTrue(resource.tags().containsKey("tag1"));
         return resource;
     }
 
@@ -71,11 +71,11 @@ public class TestContainerService extends TestTemplate<ContainerService, Contain
                 .withoutTag("tag1")
                 .apply();
 
-        Assert.assertEquals(resource.agentPools().size(), 1);
+        Assertions.assertEquals(resource.agentPools().size(), 1);
         String agentPoolName = new ArrayList<>(resource.agentPools().keySet()).get(0);
-        Assert.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertTrue(!resource.tags().containsKey("tag1"));
+        Assertions.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertTrue(!resource.tags().containsKey("tag1"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestCosmosDB.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestCosmosDB.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.management;
 
 import com.microsoft.azure.management.cosmosdb.*;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestCosmosDB extends TestTemplate<CosmosDBAccount, CosmosDBAccounts> {
 
@@ -23,11 +23,11 @@ public class TestCosmosDB extends TestTemplate<CosmosDBAccount, CosmosDBAccounts
                 .withReadReplication(Region.US_CENTRAL)
                 .withIpRangeFilter("")
                 .create();
-        Assert.assertEquals(databaseAccount.name(), newName.toLowerCase());
-        Assert.assertEquals(databaseAccount.kind(), DatabaseAccountKind.GLOBAL_DOCUMENT_DB);
-        Assert.assertEquals(databaseAccount.writableReplications().size(), 1);
-        Assert.assertEquals(databaseAccount.readableReplications().size(), 2);
-        Assert.assertEquals(databaseAccount.defaultConsistencyLevel(), DefaultConsistencyLevel.SESSION);
+        Assertions.assertEquals(databaseAccount.name(), newName.toLowerCase());
+        Assertions.assertEquals(databaseAccount.kind(), DatabaseAccountKind.GLOBAL_DOCUMENT_DB);
+        Assertions.assertEquals(databaseAccount.writableReplications().size(), 1);
+        Assertions.assertEquals(databaseAccount.readableReplications().size(), 2);
+        Assertions.assertEquals(databaseAccount.defaultConsistencyLevel(), DefaultConsistencyLevel.SESSION);
         return databaseAccount;
     }
 
@@ -46,9 +46,9 @@ public class TestCosmosDB extends TestTemplate<CosmosDBAccount, CosmosDBAccounts
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .apply();
-        Assert.assertEquals(resource.defaultConsistencyLevel(), DefaultConsistencyLevel.EVENTUAL);
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertTrue(!resource.tags().containsKey("tag1"));
+        Assertions.assertEquals(resource.defaultConsistencyLevel(), DefaultConsistencyLevel.EVENTUAL);
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertTrue(!resource.tags().containsKey("tag1"));
 
         return resource;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestDns.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestDns.java
@@ -25,7 +25,7 @@ import com.microsoft.azure.management.dns.SrvRecordSet;
 import com.microsoft.azure.management.dns.TxtRecord;
 import com.microsoft.azure.management.dns.TxtRecordSet;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.HashMap;
 
@@ -89,64 +89,64 @@ public class TestDns extends TestTemplate<DnsZone, DnsZones> {
                 .create();
 
         // Check Dns zone properties
-        Assert.assertTrue(dnsZone.name().startsWith(topLevelDomain));
-        Assert.assertTrue(dnsZone.nameServers().size() > 0); // Default '@' name servers
-        Assert.assertTrue(dnsZone.tags().size() == 2);
+        Assertions.assertTrue(dnsZone.name().startsWith(topLevelDomain));
+        Assertions.assertTrue(dnsZone.nameServers().size() > 0); // Default '@' name servers
+        Assertions.assertTrue(dnsZone.tags().size() == 2);
 
         // Check SOA record - external child resource (created by default)
         SoaRecordSet soaRecordSet = dnsZone.getSoaRecordSet();
-        Assert.assertTrue(soaRecordSet.name().startsWith("@"));
+        Assertions.assertTrue(soaRecordSet.name().startsWith("@"));
         SoaRecord soaRecord = soaRecordSet.record();
-        Assert.assertNotNull(soaRecord);
+        Assertions.assertNotNull(soaRecord);
 
         // Check explicitly created external child resources [A, AAAA, MX, NS, TXT, SRV, PTR, CNAME]
         //
 
         // Check A records
         PagedList<ARecordSet> aRecordSets = dnsZone.aRecordSets().list();
-        Assert.assertTrue(aRecordSets.size() == 1);
-        Assert.assertTrue(aRecordSets.get(0).timeToLive() == 7200);
+        Assertions.assertTrue(aRecordSets.size() == 1);
+        Assertions.assertTrue(aRecordSets.get(0).timeToLive() == 7200);
 
         // Check AAAA records
         PagedList<AaaaRecordSet> aaaaRecordSets = dnsZone.aaaaRecordSets().list();
-        Assert.assertTrue(aaaaRecordSets.size() == 1);
-        Assert.assertTrue(aaaaRecordSets.get(0).name().startsWith("www"));
-        Assert.assertTrue(aaaaRecordSets.get(0).ipv6Addresses().size() == 2);
+        Assertions.assertTrue(aaaaRecordSets.size() == 1);
+        Assertions.assertTrue(aaaaRecordSets.get(0).name().startsWith("www"));
+        Assertions.assertTrue(aaaaRecordSets.get(0).ipv6Addresses().size() == 2);
 
         // Check MX records
         PagedList<MXRecordSet> mxRecordSets = dnsZone.mxRecordSets().list();
-        Assert.assertTrue(mxRecordSets.size() == 1);
+        Assertions.assertTrue(mxRecordSets.size() == 1);
         MXRecordSet mxRecordSet = mxRecordSets.get(0);
-        Assert.assertNotNull(mxRecordSet);
-        Assert.assertTrue(mxRecordSet.name().startsWith("email"));
-        Assert.assertTrue(mxRecordSet.metadata().size() == 2);
-        Assert.assertTrue(mxRecordSet.records().size() == 2);
+        Assertions.assertNotNull(mxRecordSet);
+        Assertions.assertTrue(mxRecordSet.name().startsWith("email"));
+        Assertions.assertTrue(mxRecordSet.metadata().size() == 2);
+        Assertions.assertTrue(mxRecordSet.records().size() == 2);
         for (MxRecord mxRecord : mxRecordSet.records()) {
-            Assert.assertTrue(mxRecord.exchange().startsWith("mail.contoso-mail-exchange1.com")
+            Assertions.assertTrue(mxRecord.exchange().startsWith("mail.contoso-mail-exchange1.com")
                     || mxRecord.exchange().startsWith("mail.contoso-mail-exchange2.com"));
-            Assert.assertTrue(mxRecord.preference() == 1
+            Assertions.assertTrue(mxRecord.preference() == 1
                     || mxRecord.preference() == 2);
         }
 
         // Check NS records
         PagedList<NSRecordSet> nsRecordSets = dnsZone.nsRecordSets().list();
-        Assert.assertTrue(nsRecordSets.size() == 2); // One created above with name 'partners' + the default '@'
+        Assertions.assertTrue(nsRecordSets.size() == 2); // One created above with name 'partners' + the default '@'
 
         // Check TXT records
         PagedList<TxtRecordSet> txtRecordSets = dnsZone.txtRecordSets().list();
-        Assert.assertTrue(txtRecordSets.size() == 2);
+        Assertions.assertTrue(txtRecordSets.size() == 2);
 
         // Check SRV records
         PagedList<SrvRecordSet> srvRecordSets = dnsZone.srvRecordSets().list();
-        Assert.assertTrue(srvRecordSets.size() == 1);
+        Assertions.assertTrue(srvRecordSets.size() == 1);
 
         // Check PTR records
         PagedList<PtrRecordSet> ptrRecordSets = dnsZone.ptrRecordSets().list();
-        Assert.assertTrue(ptrRecordSets.size() == 2);
+        Assertions.assertTrue(ptrRecordSets.size() == 2);
 
         // Check CNAME records
         PagedList<CNameRecordSet> cnameRecordSets = dnsZone.cNameRecordSets().list();
-        Assert.assertTrue(cnameRecordSets.size() == 2);
+        Assertions.assertTrue(cnameRecordSets.size() == 2);
 
         // Check Generic record set listing
         PagedList<DnsRecordSet> recordSets = dnsZone.listRecordSets();
@@ -161,64 +161,64 @@ public class TestDns extends TestTemplate<DnsZone, DnsZones> {
         typeToCount.put(RecordType.SRV, 0);
         typeToCount.put(RecordType.TXT, 0);
         for (DnsRecordSet recordSet : recordSets) {
-            Assert.assertNotNull(recordSet);
+            Assertions.assertNotNull(recordSet);
             switch (recordSet.recordType()) {
                 case TXT:
                     TxtRecordSet txtRS = (TxtRecordSet) recordSet;
-                    Assert.assertNotNull(txtRS);
+                    Assertions.assertNotNull(txtRS);
                     typeToCount.put(RecordType.TXT, typeToCount.get(RecordType.TXT) + 1);
                     break;
                 case SRV:
                     SrvRecordSet srvRS = (SrvRecordSet) recordSet;
-                    Assert.assertNotNull(srvRS);
+                    Assertions.assertNotNull(srvRS);
                     typeToCount.put(RecordType.SRV, typeToCount.get(RecordType.SRV) + 1);
                     break;
                 case SOA:
                     SoaRecordSet soaRS = (SoaRecordSet) recordSet;
-                    Assert.assertNotNull(soaRS);
+                    Assertions.assertNotNull(soaRS);
                     typeToCount.put(RecordType.SOA, typeToCount.get(RecordType.SOA) + 1);
                     break;
                 case PTR:
                     PtrRecordSet ptrRS = (PtrRecordSet) recordSet;
-                    Assert.assertNotNull(ptrRS);
+                    Assertions.assertNotNull(ptrRS);
                     typeToCount.put(RecordType.PTR, typeToCount.get(RecordType.PTR) + 1);
                     break;
                 case A:
                     ARecordSet aRS = (ARecordSet) recordSet;
-                    Assert.assertNotNull(aRS);
+                    Assertions.assertNotNull(aRS);
                     typeToCount.put(RecordType.A, typeToCount.get(RecordType.A) + 1);
                     break;
                 case AAAA:
                     AaaaRecordSet aaaaRS = (AaaaRecordSet) recordSet;
-                    Assert.assertNotNull(aaaaRS);
+                    Assertions.assertNotNull(aaaaRS);
                     typeToCount.put(RecordType.AAAA, typeToCount.get(RecordType.AAAA) + 1);
                     break;
                 case CNAME:
                     CNameRecordSet cnameRS = (CNameRecordSet) recordSet;
-                    Assert.assertNotNull(cnameRS);
+                    Assertions.assertNotNull(cnameRS);
                     typeToCount.put(RecordType.CNAME, typeToCount.get(RecordType.CNAME) + 1);
                     break;
                 case MX:
                     MXRecordSet mxRS = (MXRecordSet) recordSet;
-                    Assert.assertNotNull(mxRS);
+                    Assertions.assertNotNull(mxRS);
                     typeToCount.put(RecordType.MX, typeToCount.get(RecordType.MX) + 1);
                     break;
                 case NS:
                     NSRecordSet nsRS = (NSRecordSet) recordSet;
-                    Assert.assertNotNull(nsRS);
+                    Assertions.assertNotNull(nsRS);
                     typeToCount.put(RecordType.NS, typeToCount.get(RecordType.NS) + 1);
                     break;
             }
         }
-        Assert.assertTrue(typeToCount.get(RecordType.SOA) == 1);
-        Assert.assertTrue(typeToCount.get(RecordType.A) == 1);
-        Assert.assertTrue(typeToCount.get(RecordType.AAAA) == 1);
-        Assert.assertTrue(typeToCount.get(RecordType.MX) == 1);
-        Assert.assertTrue(typeToCount.get(RecordType.NS) == 2);
-        Assert.assertTrue(typeToCount.get(RecordType.TXT) == 2);
-        Assert.assertTrue(typeToCount.get(RecordType.SRV) == 1);
-        Assert.assertTrue(typeToCount.get(RecordType.PTR) == 2);
-        Assert.assertTrue(typeToCount.get(RecordType.CNAME) == 2);
+        Assertions.assertTrue(typeToCount.get(RecordType.SOA) == 1);
+        Assertions.assertTrue(typeToCount.get(RecordType.A) == 1);
+        Assertions.assertTrue(typeToCount.get(RecordType.AAAA) == 1);
+        Assertions.assertTrue(typeToCount.get(RecordType.MX) == 1);
+        Assertions.assertTrue(typeToCount.get(RecordType.NS) == 2);
+        Assertions.assertTrue(typeToCount.get(RecordType.TXT) == 2);
+        Assertions.assertTrue(typeToCount.get(RecordType.SRV) == 1);
+        Assertions.assertTrue(typeToCount.get(RecordType.PTR) == 2);
+        Assertions.assertTrue(typeToCount.get(RecordType.CNAME) == 2);
         return dnsZone;
     }
 
@@ -252,58 +252,58 @@ public class TestDns extends TestTemplate<DnsZone, DnsZones> {
 
         // Check TXT records
         PagedList<TxtRecordSet> txtRecordSets = dnsZone.txtRecordSets().list();
-        Assert.assertEquals(txtRecordSets.size(), 1);
+        Assertions.assertEquals(txtRecordSets.size(), 1);
 
         // Check CNAME records
         PagedList<CNameRecordSet> cnameRecordSets = dnsZone.cNameRecordSets().list();
-        Assert.assertEquals(cnameRecordSets.size(), 2);
+        Assertions.assertEquals(cnameRecordSets.size(), 2);
         for (CNameRecordSet cnameRecordSet : cnameRecordSets) {
-            Assert.assertTrue(cnameRecordSet.canonicalName().startsWith("doc.contoso.com"));
-            Assert.assertTrue(cnameRecordSet.name().startsWith("documents") || cnameRecordSet.name().startsWith("help"));
+            Assertions.assertTrue(cnameRecordSet.canonicalName().startsWith("doc.contoso.com"));
+            Assertions.assertTrue(cnameRecordSet.name().startsWith("documents") || cnameRecordSet.name().startsWith("help"));
         }
 
         // Check NS records
         PagedList<NSRecordSet> nsRecordSets = dnsZone.nsRecordSets().list();
-        Assert.assertTrue(nsRecordSets.size() == 2); // One created above with name 'partners' + the default '@'
+        Assertions.assertTrue(nsRecordSets.size() == 2); // One created above with name 'partners' + the default '@'
         for (NSRecordSet nsRecordSet : nsRecordSets) {
-            Assert.assertTrue(nsRecordSet.name().startsWith("partners") || nsRecordSet.name().startsWith("@"));
+            Assertions.assertTrue(nsRecordSet.name().startsWith("partners") || nsRecordSet.name().startsWith("@"));
             if (nsRecordSet.name().startsWith("partners")) {
-                Assert.assertEquals(nsRecordSet.nameServers().size(), 4);
+                Assertions.assertEquals(nsRecordSet.nameServers().size(), 4);
                 for (String nameServer : nsRecordSet.nameServers()) {
-                    Assert.assertFalse(nameServer.startsWith("ns4-05.azure-dns.info"));
+                    Assertions.assertFalse(nameServer.startsWith("ns4-05.azure-dns.info"));
                 }
             }
         }
 
         // Check A records
         PagedList<ARecordSet> aRecordSets = dnsZone.aRecordSets().list();
-        Assert.assertEquals(aRecordSets.size(), 1);
+        Assertions.assertEquals(aRecordSets.size(), 1);
         ARecordSet aRecordSet = aRecordSets.get(0);
-        Assert.assertEquals(aRecordSet.ipv4Addresses().size(), 2);
+        Assertions.assertEquals(aRecordSet.ipv4Addresses().size(), 2);
         for (String ipV4Address : aRecordSet.ipv4Addresses()) {
-            Assert.assertFalse(ipV4Address.startsWith("23.96.104.40"));
+            Assertions.assertFalse(ipV4Address.startsWith("23.96.104.40"));
         }
 
         // Check SRV records
         PagedList<SrvRecordSet> srvRecordSets = dnsZone.srvRecordSets().list();
-        Assert.assertTrue(srvRecordSets.size() == 1);
+        Assertions.assertTrue(srvRecordSets.size() == 1);
         SrvRecordSet srvRecordSet = srvRecordSets.get(0);
-        Assert.assertTrue(srvRecordSet.records().size() == 4);
+        Assertions.assertTrue(srvRecordSet.records().size() == 4);
         for (SrvRecord srvRecord : srvRecordSet.records()) {
-            Assert.assertFalse(srvRecord.target().startsWith("bigbox.contoso-service.com"));
+            Assertions.assertFalse(srvRecord.target().startsWith("bigbox.contoso-service.com"));
         }
 
         // Check SOA Records
         SoaRecordSet soaRecordSet = dnsZone.getSoaRecordSet();
-        Assert.assertTrue(soaRecordSet.name().startsWith("@"));
+        Assertions.assertTrue(soaRecordSet.name().startsWith("@"));
         SoaRecord soaRecord = soaRecordSet.record();
-        Assert.assertNotNull(soaRecord);
-        Assert.assertEquals(soaRecord.minimumTtl(), Long.valueOf(600));
-        Assert.assertTrue(soaRecordSet.timeToLive() == 7200);
+        Assertions.assertNotNull(soaRecord);
+        Assertions.assertEquals(soaRecord.minimumTtl(), Long.valueOf(600));
+        Assertions.assertTrue(soaRecordSet.timeToLive() == 7200);
 
         // Check MX records
         PagedList<MXRecordSet> mxRecordSets = dnsZone.mxRecordSets().list();
-        Assert.assertTrue(mxRecordSets.size() == 2);
+        Assertions.assertTrue(mxRecordSets.size() == 2);
 
         dnsZone.update()
                 .updateMXRecordSet("email")
@@ -315,12 +315,12 @@ public class TestDns extends TestTemplate<DnsZone, DnsZones> {
                 .withTag("d", "dd")
                 .apply();
 
-        Assert.assertTrue(dnsZone.tags().size() == 3);
+        Assertions.assertTrue(dnsZone.tags().size() == 3);
         // Check "mail" MX record
         MXRecordSet mxRecordSet = dnsZone.mxRecordSets().getByName("email");
-        Assert.assertTrue(mxRecordSet.records().size() == 1);
-        Assert.assertTrue(mxRecordSet.metadata().size() == 3);
-        Assert.assertTrue(mxRecordSet.records().get(0).exchange().startsWith("mail.contoso-mail-exchange1.com"));
+        Assertions.assertTrue(mxRecordSet.records().size() == 1);
+        Assertions.assertTrue(mxRecordSet.metadata().size() == 3);
+        Assertions.assertTrue(mxRecordSet.records().get(0).exchange().startsWith("mail.contoso-mail-exchange1.com"));
 
         return dnsZone;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestExpressRouteCircuit.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestExpressRouteCircuit.java
@@ -11,7 +11,7 @@ import com.microsoft.azure.management.network.ExpressRouteCircuits;
 import com.microsoft.azure.management.network.ExpressRoutePeeringType;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests Express Route Circuit.
@@ -56,17 +56,17 @@ public class TestExpressRouteCircuit {
                     .withSku(ExpressRouteCircuitSkuType.PREMIUM_UNLIMITEDDATA)
                     .apply();
             resource.refresh();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
-            Assert.assertEquals(Integer.valueOf(200), resource.serviceProviderProperties().bandwidthInMbps());
-            Assert.assertEquals(ExpressRouteCircuitSkuType.PREMIUM_UNLIMITEDDATA, resource.sku());
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertEquals(Integer.valueOf(200), resource.serviceProviderProperties().bandwidthInMbps());
+            Assertions.assertEquals(ExpressRouteCircuitSkuType.PREMIUM_UNLIMITEDDATA, resource.sku());
 
 //            resource.updateTags()
 //                    .withTag("tag3", "value3")
 //                    .withoutTag("tag2")
 //                    .applyTags();
-//            Assert.assertEquals("value3", resource.tags().get("tag3"));
-//            Assert.assertFalse(resource.tags().containsKey("tag2"));
+//            Assertions.assertEquals("value3", resource.tags().get("tag3"));
+//            Assertions.assertFalse(resource.tags().containsKey("tag2"));
 
             return resource;
         }
@@ -102,13 +102,13 @@ public class TestExpressRouteCircuit {
                     .withVlanId(200)
                     .withPeerAsn(100)
                     .create();
-            Assert.assertEquals(erc.peeringsMap().size(), 1);
+            Assertions.assertEquals(erc.peeringsMap().size(), 1);
             return erc;
         }
 
         @Override
         public ExpressRouteCircuit updateResource(ExpressRouteCircuit resource) throws Exception {
-            Assert.assertTrue(resource.peeringsMap().containsKey(ExpressRoutePeeringType.MICROSOFT_PEERING.toString()));
+            Assertions.assertTrue(resource.peeringsMap().containsKey(ExpressRoutePeeringType.MICROSOFT_PEERING.toString()));
             com.microsoft.azure.management.network.ExpressRouteCircuitPeering peering =
                     resource.peeringsMap().get(ExpressRoutePeeringType.MICROSOFT_PEERING.toString())
                     .update()
@@ -116,9 +116,9 @@ public class TestExpressRouteCircuit {
                     .withPeerAsn(101)
                     .withSecondaryPeerAddressPrefix("123.0.0.8/30")
                     .apply();
-            Assert.assertEquals(300, peering.vlanId());
-            Assert.assertEquals(101, peering.peerAsn());
-            Assert.assertEquals("123.0.0.8/30", peering.secondaryPeerAddressPrefix());
+            Assertions.assertEquals(300, peering.vlanId());
+            Assertions.assertEquals(101, peering.peerAsn());
+            Assertions.assertEquals("123.0.0.8/30", peering.secondaryPeerAddressPrefix());
             return resource;
         }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestKubernetesCluster.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestKubernetesCluster.java
@@ -10,7 +10,7 @@ import com.microsoft.azure.management.containerservice.KubernetesCluster;
 import com.microsoft.azure.management.containerservice.KubernetesClusters;
 import com.azure.management.resources.fluentcore.arm.Region;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -45,21 +45,21 @@ public class TestKubernetesCluster extends TestTemplate<KubernetesCluster, Kuber
             .withDnsPrefix(dnsPrefix)
             .withTag("tag1", "value1")
             .create();
-        Assert.assertNotNull("Container service not found.", resource.id());
-        Assert.assertEquals(Region.US_EAST, resource.region());
-        Assert.assertEquals("aksadmin", resource.linuxRootUsername());
-        Assert.assertEquals(1, resource.agentPools().size());
-        Assert.assertNotNull(resource.agentPools().get(agentPoolName));
-        Assert.assertEquals(1, resource.agentPools().get(agentPoolName).count());
-        Assert.assertEquals(ContainerServiceVMSizeTypes.STANDARD_D2_V2, resource.agentPools().get(agentPoolName).vmSize());
-        Assert.assertTrue(resource.tags().containsKey("tag1"));
+        Assertions.assertNotNull("Container service not found.", resource.id());
+        Assertions.assertEquals(Region.US_EAST, resource.region());
+        Assertions.assertEquals("aksadmin", resource.linuxRootUsername());
+        Assertions.assertEquals(1, resource.agentPools().size());
+        Assertions.assertNotNull(resource.agentPools().get(agentPoolName));
+        Assertions.assertEquals(1, resource.agentPools().get(agentPoolName).count());
+        Assertions.assertEquals(ContainerServiceVMSizeTypes.STANDARD_D2_V2, resource.agentPools().get(agentPoolName).vmSize());
+        Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
         resource = kubernetesClusters.getByResourceGroup(resource.resourceGroupName(), newName);
 
         byte[] kubeConfigAdmin = resource.adminKubeConfigContent();
-        Assert.assertTrue(kubeConfigAdmin != null && kubeConfigAdmin.length > 0);
+        Assertions.assertTrue(kubeConfigAdmin != null && kubeConfigAdmin.length > 0);
         byte[] kubeConfigUser = resource.userKubeConfigContent();
-        Assert.assertTrue(kubeConfigUser != null && kubeConfigUser.length > 0);
+        Assertions.assertTrue(kubeConfigUser != null && kubeConfigUser.length > 0);
 
         return resource;
     }
@@ -75,10 +75,10 @@ public class TestKubernetesCluster extends TestTemplate<KubernetesCluster, Kuber
             .withoutTag("tag1")
             .apply();
 
-        Assert.assertEquals(1, resource.agentPools().size());
-        Assert.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertTrue(!resource.tags().containsKey("tag1"));
+        Assertions.assertEquals(1, resource.agentPools().size());
+        Assertions.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertTrue(!resource.tags().containsKey("tag1"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestKubernetesCluster.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestKubernetesCluster.java
@@ -76,7 +76,7 @@ public class TestKubernetesCluster extends TestTemplate<KubernetesCluster, Kuber
             .apply();
 
         Assertions.assertEquals(1, resource.agentPools().size());
-        Assertions.assertTrue("Agent pool count was not updated.", resource.agentPools().get(agentPoolName).count() == 5);
+        Assertions.assertTrue(resource.agentPools().get(agentPoolName).count() == 5, "Agent pool count was not updated.");
         Assertions.assertTrue(resource.tags().containsKey("tag2"));
         Assertions.assertTrue(!resource.tags().containsKey("tag1"));
         return resource;

--- a/azure/src/test/java/com/microsoft/azure/management/TestLoadBalancer.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestLoadBalancer.java
@@ -15,7 +15,7 @@ import com.microsoft.azure.management.compute.AvailabilitySetSkuTypes;
 import com.microsoft.azure.management.network.LoadBalancerSkuType;
 import com.azure.management.resources.fluentcore.arm.AvailabilityZoneId;
 import com.azure.management.resources.fluentcore.model.CreatedResources;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.compute.AvailabilitySet;
 import com.microsoft.azure.management.compute.KnownLinuxVirtualMachineImage;
@@ -133,37 +133,37 @@ public class TestLoadBalancer {
                     .create();
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.publicFrontends().size());
-            Assert.assertEquals(0, lb.privateFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.publicFrontends().size());
+            Assertions.assertEquals(0, lb.privateFrontends().size());
             LoadBalancerFrontend frontend = lb.frontends().values().iterator().next();
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertTrue(frontend.isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) frontend;
-            Assert.assertTrue(pip0.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
+            Assertions.assertTrue(pip0.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
 
             // Verify backends
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertEquals(1, lb.backends().size());
 
             // Verify probes
-            Assert.assertEquals(1, lb.httpProbes().size());
-            Assert.assertTrue(lb.httpProbes().containsKey("httpProbe1"));
-            Assert.assertEquals(1, lb.tcpProbes().size());
-            Assert.assertTrue(lb.tcpProbes().containsKey("tcpProbe1"));
+            Assertions.assertEquals(1, lb.httpProbes().size());
+            Assertions.assertTrue(lb.httpProbes().containsKey("httpProbe1"));
+            Assertions.assertEquals(1, lb.tcpProbes().size());
+            Assertions.assertTrue(lb.tcpProbes().containsKey("tcpProbe1"));
 
             // Verify rules
-            Assert.assertEquals(1, lb.loadBalancingRules().size());
-            Assert.assertTrue(lb.loadBalancingRules().containsKey("rule1"));
+            Assertions.assertEquals(1, lb.loadBalancingRules().size());
+            Assertions.assertTrue(lb.loadBalancingRules().containsKey("rule1"));
             LoadBalancingRule rule = lb.loadBalancingRules().get("rule1");
-            Assert.assertNotNull(rule.backend());
-            Assert.assertTrue(rule.probe().name().equalsIgnoreCase("tcpProbe1"));
+            Assertions.assertNotNull(rule.backend());
+            Assertions.assertTrue(rule.probe().name().equalsIgnoreCase("tcpProbe1"));
 
             // Verify inbound NAT pools
-            Assert.assertTrue(lb.inboundNatPools().containsKey("natpool1"));
-            Assert.assertEquals(1, lb.inboundNatPools().size());
+            Assertions.assertTrue(lb.inboundNatPools().containsKey("natpool1"));
+            Assertions.assertEquals(1, lb.inboundNatPools().size());
             LoadBalancerInboundNatPool inboundNatPool = lb.inboundNatPools().get("natpool1");
-            Assert.assertEquals(2000, inboundNatPool.frontendPortRangeStart());
-            Assert.assertEquals(2001, inboundNatPool.frontendPortRangeEnd());
-            Assert.assertEquals(8080, inboundNatPool.backendPort());
+            Assertions.assertEquals(2000, inboundNatPool.frontendPortRangeStart());
+            Assertions.assertEquals(2001, inboundNatPool.frontendPortRangeEnd());
+            Assertions.assertEquals(8080, inboundNatPool.backendPort());
 
             return lb;
         }
@@ -181,28 +181,28 @@ public class TestLoadBalancer {
                     .apply();
 
             resource.refresh();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify frontends
-            Assert.assertEquals(1, resource.frontends().size());
-            Assert.assertEquals(1,  resource.publicFrontends().size());
-            Assert.assertEquals(0,  resource.privateFrontends().size());
+            Assertions.assertEquals(1, resource.frontends().size());
+            Assertions.assertEquals(1,  resource.publicFrontends().size());
+            Assertions.assertEquals(0,  resource.privateFrontends().size());
 
             // Verify probes
-            Assert.assertFalse(resource.httpProbes().containsKey("httpProbe1"));
-            Assert.assertFalse(resource.httpProbes().containsKey("tcpProbe1"));
-            Assert.assertEquals(0, resource.httpProbes().size());
-            Assert.assertEquals(0, resource.tcpProbes().size());
+            Assertions.assertFalse(resource.httpProbes().containsKey("httpProbe1"));
+            Assertions.assertFalse(resource.httpProbes().containsKey("tcpProbe1"));
+            Assertions.assertEquals(0, resource.httpProbes().size());
+            Assertions.assertEquals(0, resource.tcpProbes().size());
 
             // Verify backends
-            Assert.assertEquals(0, resource.backends().size());
+            Assertions.assertEquals(0, resource.backends().size());
 
             // Verify rules
-            Assert.assertFalse(resource.loadBalancingRules().containsKey("rule1"));
-            Assert.assertEquals(0, resource.loadBalancingRules().size());
+            Assertions.assertFalse(resource.loadBalancingRules().containsKey("rule1"));
+            Assertions.assertEquals(0, resource.loadBalancingRules().size());
 
             // Verify NAT pools
-            Assert.assertFalse(resource.inboundNatPools().containsKey("natpool1"));
+            Assertions.assertFalse(resource.inboundNatPools().containsKey("natpool1"));
 
             return resource;
         }
@@ -283,57 +283,57 @@ public class TestLoadBalancer {
                 .withExistingLoadBalancerInboundNatRule(lb,  "natrule1")
                 .apply();
             TestNetworkInterface.printNic(nic1);
-            Assert.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerBackends().get(0).name()
+            Assertions.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerBackends().get(0).name()
                     .equalsIgnoreCase(backendName));
-            Assert.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerInboundNatRules().get(0).name()
+            Assertions.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerInboundNatRules().get(0).name()
                     .equalsIgnoreCase("natrule1"));
 
             nic2.update()
                 .withExistingLoadBalancerBackend(lb, backendName)
                 .apply();
             TestNetworkInterface.printNic(nic2);
-            Assert.assertTrue(nic2.primaryIPConfiguration().listAssociatedLoadBalancerBackends().get(0).name()
+            Assertions.assertTrue(nic2.primaryIPConfiguration().listAssociatedLoadBalancerBackends().get(0).name()
                     .equalsIgnoreCase(backendName));
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.publicFrontends().size());
-            Assert.assertEquals(0, lb.privateFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.publicFrontends().size());
+            Assertions.assertEquals(0, lb.privateFrontends().size());
             LoadBalancerFrontend frontend = lb.frontends().get(frontendName);
-            Assert.assertNotNull(frontend);
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertNotNull(frontend);
+            Assertions.assertTrue(frontend.isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) frontend;
-            Assert.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
 
             pip.refresh();
-            Assert.assertTrue(pip.getAssignedLoadBalancerFrontend().name().equalsIgnoreCase(frontendName));
+            Assertions.assertTrue(pip.getAssignedLoadBalancerFrontend().name().equalsIgnoreCase(frontendName));
             TestPublicIPAddress.printPIP(pip.refresh());
 
             // Verify backends
-            Assert.assertTrue(lb.backends().containsKey(backendName));
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertTrue(lb.backends().containsKey(backendName));
+            Assertions.assertEquals(1, lb.backends().size());
 
             // Verify probes
-            Assert.assertTrue(lb.httpProbes().containsKey("httpProbe1"));
-            Assert.assertEquals(1, lb.httpProbes().size());
-            Assert.assertTrue(lb.tcpProbes().containsKey("tcpProbe1"));
-            Assert.assertEquals(1, lb.tcpProbes().size());
+            Assertions.assertTrue(lb.httpProbes().containsKey("httpProbe1"));
+            Assertions.assertEquals(1, lb.httpProbes().size());
+            Assertions.assertTrue(lb.tcpProbes().containsKey("tcpProbe1"));
+            Assertions.assertEquals(1, lb.tcpProbes().size());
 
             // Verify rules
-            Assert.assertEquals(1, lb.loadBalancingRules().size());
-            Assert.assertTrue(lb.loadBalancingRules().containsKey("rule1"));
+            Assertions.assertEquals(1, lb.loadBalancingRules().size());
+            Assertions.assertTrue(lb.loadBalancingRules().containsKey("rule1"));
             LoadBalancingRule rule = lb.loadBalancingRules().get("rule1");
-            Assert.assertTrue(rule.backend().name().equalsIgnoreCase(backendName));
-            Assert.assertTrue(rule.frontend().name().equalsIgnoreCase(frontendName));
-            Assert.assertTrue(rule.probe().name().equalsIgnoreCase("tcpProbe1"));
+            Assertions.assertTrue(rule.backend().name().equalsIgnoreCase(backendName));
+            Assertions.assertTrue(rule.frontend().name().equalsIgnoreCase(frontendName));
+            Assertions.assertTrue(rule.probe().name().equalsIgnoreCase("tcpProbe1"));
 
             // Verify inbound NAT rules
-            Assert.assertEquals(1, lb.inboundNatRules().size());
-            Assert.assertTrue(lb.inboundNatRules().containsKey("natrule1"));
+            Assertions.assertEquals(1, lb.inboundNatRules().size());
+            Assertions.assertTrue(lb.inboundNatRules().containsKey("natrule1"));
             LoadBalancerInboundNatRule inboundNatRule = lb.inboundNatRules().get("natrule1");
-            Assert.assertTrue(inboundNatRule.frontend().name().equalsIgnoreCase(frontendName));
-            Assert.assertEquals(88, inboundNatRule.frontendPort());
-            Assert.assertEquals(88, inboundNatRule.backendPort());
+            Assertions.assertTrue(inboundNatRule.frontend().name().equalsIgnoreCase(frontendName));
+            Assertions.assertEquals(88, inboundNatRule.frontendPort());
+            Assertions.assertEquals(88, inboundNatRule.backendPort());
 
             return lb;
         }
@@ -355,13 +355,13 @@ public class TestLoadBalancer {
                 .withoutLoadBalancerBackends()
                 .withoutLoadBalancerInboundNatRules()
                 .apply();
-            Assert.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerBackends().size() == 0);
+            Assertions.assertTrue(nic1.primaryIPConfiguration().listAssociatedLoadBalancerBackends().size() == 0);
 
             nic2.update()
                 .withoutLoadBalancerBackends()
                 .withoutLoadBalancerInboundNatRules()
                 .apply();
-            Assert.assertTrue(nic2.primaryIPConfiguration().listAssociatedLoadBalancerBackends().size() == 0);
+            Assertions.assertTrue(nic2.primaryIPConfiguration().listAssociatedLoadBalancerBackends().size() == 0);
 
             // Update the load balancer
             ensurePIPs(resource.manager().publicIPAddresses());
@@ -375,17 +375,17 @@ public class TestLoadBalancer {
                     .withTag("tag1", "value1")
                     .withTag("tag2", "value2")
                     .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
-            Assert.assertEquals(0, resource.inboundNatRules().size());
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertEquals(0, resource.inboundNatRules().size());
 
             // Verify frontends
             LoadBalancerFrontend frontend = resource.frontends().get(frontendName);
-            Assert.assertEquals(1,  resource.publicFrontends().size());
-            Assert.assertEquals(0,  resource.privateFrontends().size());
-            Assert.assertNotNull(frontend);
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertEquals(1,  resource.publicFrontends().size());
+            Assertions.assertEquals(0,  resource.privateFrontends().size());
+            Assertions.assertNotNull(frontend);
+            Assertions.assertTrue(frontend.isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) frontend;
-            Assert.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
 
             return resource;
         }
@@ -437,41 +437,41 @@ public class TestLoadBalancer {
                     .create();
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.publicFrontends().size());
-            Assert.assertEquals(0,  lb.privateFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.publicFrontends().size());
+            Assertions.assertEquals(0,  lb.privateFrontends().size());
             LoadBalancerPublicFrontend frontend = lb.publicFrontends().values().iterator().next();
-            Assert.assertNotNull(frontend);
-            Assert.assertNotNull(frontend.publicIPAddressId());
+            Assertions.assertNotNull(frontend);
+            Assertions.assertNotNull(frontend.publicIPAddressId());
 
             // Verify probes
-            Assert.assertTrue(lb.tcpProbes().isEmpty());
-            Assert.assertTrue(lb.httpProbes().isEmpty());
+            Assertions.assertTrue(lb.tcpProbes().isEmpty());
+            Assertions.assertTrue(lb.httpProbes().isEmpty());
 
             // Verify LB rules
-            Assert.assertEquals(0, lb.loadBalancingRules().size());
+            Assertions.assertEquals(0, lb.loadBalancingRules().size());
 
             // Verify NAT rules
-            Assert.assertEquals(1, lb.inboundNatRules().size());
+            Assertions.assertEquals(1, lb.inboundNatRules().size());
             LoadBalancerInboundNatRule natRule = lb.inboundNatRules().get("natrule1");
-            Assert.assertNotNull(natRule);
-            Assert.assertEquals(TransportProtocol.TCP, natRule.protocol());
-            Assert.assertNotNull(natRule.frontend());
-            Assert.assertTrue(natRule.frontend().isPublic());
+            Assertions.assertNotNull(natRule);
+            Assertions.assertEquals(TransportProtocol.TCP, natRule.protocol());
+            Assertions.assertNotNull(natRule.frontend());
+            Assertions.assertTrue(natRule.frontend().isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) natRule.frontend();
             PublicIPAddress pip = publicFrontend.getPublicIPAddress();
-            Assert.assertNotNull(pip);
-            Assert.assertEquals(pip.name(), PIP_NAMES[0]);
-            Assert.assertEquals(pip.leafDomainLabel(), PIP_NAMES[0]);
-            Assert.assertEquals(88, natRule.frontendPort());
+            Assertions.assertNotNull(pip);
+            Assertions.assertEquals(pip.name(), PIP_NAMES[0]);
+            Assertions.assertEquals(pip.leafDomainLabel(), PIP_NAMES[0]);
+            Assertions.assertEquals(88, natRule.frontendPort());
 
             // Verify backends
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertEquals(1, lb.backends().size());
             LoadBalancerBackend backend = lb.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
-            Assert.assertEquals(2, backend.backendNicIPConfigurationNames().size());
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals(2, backend.backendNicIPConfigurationNames().size());
             for (VirtualMachine vm : existingVMs) {
-                Assert.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
+                Assertions.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
             }
 
             return lb;
@@ -480,9 +480,9 @@ public class TestLoadBalancer {
         @Override
         public LoadBalancer updateResource(LoadBalancer resource) throws Exception {
             LoadBalancerBackend backend = resource.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
+            Assertions.assertNotNull(backend);
             LoadBalancerInboundNatRule natRule = resource.inboundNatRules().values().iterator().next();
-            Assert.assertNotNull(natRule);
+            Assertions.assertNotNull(natRule);
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) natRule.frontend();
             PublicIPAddress pip = resource.manager().publicIPAddresses().define(PIP_NAMES[1])
                     .withRegion(TestLoadBalancer.REGION)
@@ -501,31 +501,31 @@ public class TestLoadBalancer {
                     .withTag("tag1", "value1")
                     .withTag("tag2", "value2")
                     .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify frontends
-            Assert.assertEquals(1, resource.frontends().size());
-            Assert.assertEquals(1, resource.publicFrontends().size());
-            Assert.assertEquals(0,  resource.privateFrontends().size());
+            Assertions.assertEquals(1, resource.frontends().size());
+            Assertions.assertEquals(1, resource.publicFrontends().size());
+            Assertions.assertEquals(0,  resource.privateFrontends().size());
             LoadBalancerFrontend frontend = resource.frontends().get(publicFrontend.name());
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertTrue(frontend.isPublic());
             publicFrontend = (LoadBalancerPublicFrontend) frontend;
-            Assert.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
-            Assert.assertEquals(0, publicFrontend.loadBalancingRules().size());
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
+            Assertions.assertEquals(0, publicFrontend.loadBalancingRules().size());
 
             // Verify probes
-            Assert.assertTrue(resource.tcpProbes().isEmpty());
-            Assert.assertTrue(resource.httpProbes().isEmpty());
+            Assertions.assertTrue(resource.tcpProbes().isEmpty());
+            Assertions.assertTrue(resource.httpProbes().isEmpty());
 
             // Verify backends
-            Assert.assertTrue(resource.backends().containsKey("backend2"));
-            Assert.assertTrue(!resource.backends().containsKey(backend.name()));
+            Assertions.assertTrue(resource.backends().containsKey("backend2"));
+            Assertions.assertTrue(!resource.backends().containsKey(backend.name()));
 
             // Verify NAT rules
-            Assert.assertTrue(resource.inboundNatRules().isEmpty());
+            Assertions.assertTrue(resource.inboundNatRules().isEmpty());
 
             // Verify load balancing rules
-            Assert.assertEquals(0, resource.loadBalancingRules().size());
+            Assertions.assertEquals(0, resource.loadBalancingRules().size());
 
             return resource;
         }
@@ -570,38 +570,38 @@ public class TestLoadBalancer {
                     .create();
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.publicFrontends().size());
-            Assert.assertEquals(0, lb.privateFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.publicFrontends().size());
+            Assertions.assertEquals(0, lb.privateFrontends().size());
             LoadBalancerFrontend frontend = lb.frontends().values().iterator().next();
-            Assert.assertEquals(1, frontend.loadBalancingRules().size());
-            Assert.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertEquals(1, frontend.loadBalancingRules().size());
+            Assertions.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
+            Assertions.assertTrue(frontend.isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) frontend;
             PublicIPAddress pip = publicFrontend.getPublicIPAddress();
-            Assert.assertNotNull(pip);
-            Assert.assertTrue(pip.leafDomainLabel().equalsIgnoreCase(pipDnsLabel));
+            Assertions.assertNotNull(pip);
+            Assertions.assertTrue(pip.leafDomainLabel().equalsIgnoreCase(pipDnsLabel));
 
             // Verify TCP probes
-            Assert.assertEquals(0, lb.tcpProbes().size());
+            Assertions.assertEquals(0, lb.tcpProbes().size());
 
             // Verify rules
-            Assert.assertEquals(1, lb.loadBalancingRules().size());
+            Assertions.assertEquals(1, lb.loadBalancingRules().size());
             LoadBalancingRule lbrule = lb.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbrule.frontend());
-            Assert.assertEquals(80, lbrule.backendPort());
-            Assert.assertEquals(80, lbrule.frontendPort());
-            Assert.assertNull(lbrule.probe());
-            Assert.assertEquals(TransportProtocol.TCP, lbrule.protocol());
-            Assert.assertNotNull(lbrule.backend());
+            Assertions.assertNotNull(lbrule.frontend());
+            Assertions.assertEquals(80, lbrule.backendPort());
+            Assertions.assertEquals(80, lbrule.frontendPort());
+            Assertions.assertNull(lbrule.probe());
+            Assertions.assertEquals(TransportProtocol.TCP, lbrule.protocol());
+            Assertions.assertNotNull(lbrule.backend());
 
             // Verify backends
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertEquals(1, lb.backends().size());
             LoadBalancerBackend backend = lb.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
-            Assert.assertEquals(2, backend.backendNicIPConfigurationNames().size());
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals(2, backend.backendNicIPConfigurationNames().size());
             for (VirtualMachine vm : existingVMs) {
-                Assert.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
+                Assertions.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
             }
 
             return lb;
@@ -611,11 +611,11 @@ public class TestLoadBalancer {
         public LoadBalancer updateResource(LoadBalancer resource) throws Exception {
             ensurePIPs(resource.manager().publicIPAddresses());
             PublicIPAddress pip = resource.manager().publicIPAddresses().getByResourceGroup(TestLoadBalancer.GROUP_NAME, PIP_NAMES[0]);
-            Assert.assertNotNull(pip);
+            Assertions.assertNotNull(pip);
             LoadBalancerBackend backend = resource.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
+            Assertions.assertNotNull(backend);
             LoadBalancingRule lbRule = resource.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbRule);
+            Assertions.assertNotNull(lbRule);
 
             resource =  resource.update()
                     .updatePublicFrontend(lbRule.frontend().name())
@@ -645,54 +645,54 @@ public class TestLoadBalancer {
                     .withTag("tag1", "value1")
                     .withTag("tag2", "value2")
                     .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify frontends
-            Assert.assertEquals(1, resource.frontends().size());
-            Assert.assertEquals(1, resource.publicFrontends().size());
-            Assert.assertEquals(0, resource.privateFrontends().size());
+            Assertions.assertEquals(1, resource.frontends().size());
+            Assertions.assertEquals(1, resource.publicFrontends().size());
+            Assertions.assertEquals(0, resource.privateFrontends().size());
             LoadBalancerFrontend frontend = lbRule.frontend();
-            Assert.assertTrue(frontend.isPublic());
+            Assertions.assertTrue(frontend.isPublic());
             LoadBalancerPublicFrontend publicFrontend = (LoadBalancerPublicFrontend) frontend;
-            Assert.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
-            Assert.assertEquals(2, publicFrontend.loadBalancingRules().size());
+            Assertions.assertTrue(pip.id().equalsIgnoreCase(publicFrontend.publicIPAddressId()));
+            Assertions.assertEquals(2, publicFrontend.loadBalancingRules().size());
 
             // Verify probes
             LoadBalancerTcpProbe tcpProbe = resource.tcpProbes().get("tcpprobe");
-            Assert.assertNotNull(tcpProbe);
-            Assert.assertEquals(22, tcpProbe.port());
-            Assert.assertEquals(1, tcpProbe.loadBalancingRules().size());
-            Assert.assertTrue(tcpProbe.loadBalancingRules().containsKey("lbrule1"));
+            Assertions.assertNotNull(tcpProbe);
+            Assertions.assertEquals(22, tcpProbe.port());
+            Assertions.assertEquals(1, tcpProbe.loadBalancingRules().size());
+            Assertions.assertTrue(tcpProbe.loadBalancingRules().containsKey("lbrule1"));
 
             LoadBalancerHttpProbe httpProbe = resource.httpProbes().get("httpprobe");
-            Assert.assertNotNull(httpProbe);
-            Assert.assertEquals(3, httpProbe.numberOfProbes());
-            Assert.assertTrue("/foo".equalsIgnoreCase(httpProbe.requestPath()));
-            Assert.assertTrue(httpProbe.loadBalancingRules().containsKey("lbrule2"));
+            Assertions.assertNotNull(httpProbe);
+            Assertions.assertEquals(3, httpProbe.numberOfProbes());
+            Assertions.assertTrue("/foo".equalsIgnoreCase(httpProbe.requestPath()));
+            Assertions.assertTrue(httpProbe.loadBalancingRules().containsKey("lbrule2"));
 
             // Verify backends
-            Assert.assertEquals(1, resource.backends().size());
-            Assert.assertTrue(resource.backends().containsKey("backend2"));
-            Assert.assertTrue(!resource.backends().containsKey(backend.name()));
+            Assertions.assertEquals(1, resource.backends().size());
+            Assertions.assertTrue(resource.backends().containsKey("backend2"));
+            Assertions.assertTrue(!resource.backends().containsKey(backend.name()));
 
             // Verify load balancing rules
             lbRule = resource.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbRule);
-            Assert.assertNull(lbRule.backend());
-            Assert.assertEquals(8080, lbRule.backendPort());
-            Assert.assertNotNull(lbRule.frontend());
-            Assert.assertEquals(11,  lbRule.idleTimeoutInMinutes());
-            Assert.assertNotNull(lbRule.probe());
-            Assert.assertEquals(tcpProbe.name(), lbRule.probe().name());
+            Assertions.assertNotNull(lbRule);
+            Assertions.assertNull(lbRule.backend());
+            Assertions.assertEquals(8080, lbRule.backendPort());
+            Assertions.assertNotNull(lbRule.frontend());
+            Assertions.assertEquals(11,  lbRule.idleTimeoutInMinutes());
+            Assertions.assertNotNull(lbRule.probe());
+            Assertions.assertEquals(tcpProbe.name(), lbRule.probe().name());
 
             lbRule = resource.loadBalancingRules().get("lbrule2");
-            Assert.assertNotNull(lbRule);
-            Assert.assertEquals(22, lbRule.frontendPort());
-            Assert.assertNotNull(lbRule.frontend());
-            Assert.assertTrue("httpprobe".equalsIgnoreCase(lbRule.probe().name()));
-            Assert.assertEquals(TransportProtocol.UDP, lbRule.protocol());
-            Assert.assertNotNull(lbRule.backend());
-            Assert.assertTrue("backend2".equalsIgnoreCase(lbRule.backend().name()));
+            Assertions.assertNotNull(lbRule);
+            Assertions.assertEquals(22, lbRule.frontendPort());
+            Assertions.assertNotNull(lbRule.frontend());
+            Assertions.assertTrue("httpprobe".equalsIgnoreCase(lbRule.probe().name()));
+            Assertions.assertEquals(TransportProtocol.UDP, lbRule.protocol());
+            Assertions.assertNotNull(lbRule.backend());
+            Assertions.assertTrue("backend2".equalsIgnoreCase(lbRule.backend().name()));
 
             return resource;
         }
@@ -740,41 +740,41 @@ public class TestLoadBalancer {
                     .create();
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.privateFrontends().size());
-            Assert.assertEquals(0, lb.publicFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.privateFrontends().size());
+            Assertions.assertEquals(0, lb.publicFrontends().size());
             LoadBalancerFrontend frontend = lb.frontends().values().iterator().next();
-            Assert.assertEquals(1, frontend.loadBalancingRules().size());
-            Assert.assertFalse(frontend.isPublic());
-            Assert.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
+            Assertions.assertEquals(1, frontend.loadBalancingRules().size());
+            Assertions.assertFalse(frontend.isPublic());
+            Assertions.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
             LoadBalancerPrivateFrontend privateFrontend = (LoadBalancerPrivateFrontend) frontend;
-            Assert.assertTrue(network.id().equalsIgnoreCase(privateFrontend.networkId()));
-            Assert.assertNotNull(privateFrontend.privateIPAddress());
-            Assert.assertTrue("subnet1".equalsIgnoreCase(privateFrontend.subnetName()));
-            Assert.assertEquals(IPAllocationMethod.DYNAMIC, privateFrontend.privateIPAllocationMethod());
+            Assertions.assertTrue(network.id().equalsIgnoreCase(privateFrontend.networkId()));
+            Assertions.assertNotNull(privateFrontend.privateIPAddress());
+            Assertions.assertTrue("subnet1".equalsIgnoreCase(privateFrontend.subnetName()));
+            Assertions.assertEquals(IPAllocationMethod.DYNAMIC, privateFrontend.privateIPAllocationMethod());
 
             // Verify TCP probes
-            Assert.assertEquals(0, lb.tcpProbes().size());
+            Assertions.assertEquals(0, lb.tcpProbes().size());
 
             // Verify rules
-            Assert.assertEquals(1, lb.loadBalancingRules().size());
+            Assertions.assertEquals(1, lb.loadBalancingRules().size());
             LoadBalancingRule lbrule = lb.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbrule);
-            Assert.assertNotNull(lbrule.frontend());
-            Assert.assertEquals(80, lbrule.backendPort());
-            Assert.assertEquals(80, lbrule.frontendPort());
-            Assert.assertNull(lbrule.probe());
-            Assert.assertEquals(TransportProtocol.TCP, lbrule.protocol());
-            Assert.assertNotNull(lbrule.backend());
+            Assertions.assertNotNull(lbrule);
+            Assertions.assertNotNull(lbrule.frontend());
+            Assertions.assertEquals(80, lbrule.backendPort());
+            Assertions.assertEquals(80, lbrule.frontendPort());
+            Assertions.assertNull(lbrule.probe());
+            Assertions.assertEquals(TransportProtocol.TCP, lbrule.protocol());
+            Assertions.assertNotNull(lbrule.backend());
 
             // Verify backends
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertEquals(1, lb.backends().size());
             LoadBalancerBackend backend = lb.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
+            Assertions.assertNotNull(backend);
 
-            Assert.assertEquals(2, backend.backendNicIPConfigurationNames().size());
+            Assertions.assertEquals(2, backend.backendNicIPConfigurationNames().size());
             for (VirtualMachine vm : existingVMs) {
-                Assert.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
+                Assertions.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
             }
 
             return lb;
@@ -783,9 +783,9 @@ public class TestLoadBalancer {
         @Override
         public LoadBalancer updateResource(LoadBalancer resource) throws Exception {
             LoadBalancerBackend backend = resource.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
+            Assertions.assertNotNull(backend);
             LoadBalancingRule lbRule = resource.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbRule);
+            Assertions.assertNotNull(lbRule);
             resource =  resource.update()
                     .updatePrivateFrontend(lbRule.frontend().name())
                         .withExistingSubnet(this.network, "subnet2")
@@ -815,57 +815,57 @@ public class TestLoadBalancer {
                     .withTag("tag1", "value1")
                     .withTag("tag2", "value2")
                     .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify frontends
-            Assert.assertEquals(1, resource.frontends().size());
-            Assert.assertEquals(1,  resource.privateFrontends().size());
-            Assert.assertEquals(0, resource.publicFrontends().size());
+            Assertions.assertEquals(1, resource.frontends().size());
+            Assertions.assertEquals(1,  resource.privateFrontends().size());
+            Assertions.assertEquals(0, resource.publicFrontends().size());
             LoadBalancerFrontend frontend = resource.frontends().get(lbRule.frontend().name());
-            Assert.assertNotNull(frontend);
-            Assert.assertFalse(frontend.isPublic());
+            Assertions.assertNotNull(frontend);
+            Assertions.assertFalse(frontend.isPublic());
             LoadBalancerPrivateFrontend privateFrontend = (LoadBalancerPrivateFrontend) frontend;
-            Assert.assertTrue("subnet2".equalsIgnoreCase(privateFrontend.subnetName()));
-            Assert.assertEquals(IPAllocationMethod.STATIC, privateFrontend.privateIPAllocationMethod());
-            Assert.assertTrue("10.0.0.13".equalsIgnoreCase(privateFrontend.privateIPAddress()));
-            Assert.assertEquals(2, privateFrontend.loadBalancingRules().size());
+            Assertions.assertTrue("subnet2".equalsIgnoreCase(privateFrontend.subnetName()));
+            Assertions.assertEquals(IPAllocationMethod.STATIC, privateFrontend.privateIPAllocationMethod());
+            Assertions.assertTrue("10.0.0.13".equalsIgnoreCase(privateFrontend.privateIPAddress()));
+            Assertions.assertEquals(2, privateFrontend.loadBalancingRules().size());
 
             // Verify probes
-            Assert.assertEquals(1, resource.tcpProbes().size());
+            Assertions.assertEquals(1, resource.tcpProbes().size());
             LoadBalancerTcpProbe tcpProbe = resource.tcpProbes().get("tcpprobe");
-            Assert.assertNotNull(tcpProbe);
-            Assert.assertEquals(22,  tcpProbe.port());
-            Assert.assertTrue(tcpProbe.loadBalancingRules().containsKey("lbrule1"));
+            Assertions.assertNotNull(tcpProbe);
+            Assertions.assertEquals(22,  tcpProbe.port());
+            Assertions.assertTrue(tcpProbe.loadBalancingRules().containsKey("lbrule1"));
 
             LoadBalancerHttpProbe httpProbe = resource.httpProbes().get("httpprobe");
-            Assert.assertNotNull(httpProbe);
-            Assert.assertEquals(3, httpProbe.numberOfProbes());
-            Assert.assertTrue("/foo".equalsIgnoreCase(httpProbe.requestPath()));
-            Assert.assertTrue(httpProbe.loadBalancingRules().containsKey("lbrule2"));
+            Assertions.assertNotNull(httpProbe);
+            Assertions.assertEquals(3, httpProbe.numberOfProbes());
+            Assertions.assertTrue("/foo".equalsIgnoreCase(httpProbe.requestPath()));
+            Assertions.assertTrue(httpProbe.loadBalancingRules().containsKey("lbrule2"));
 
             // Verify backends
-            Assert.assertEquals(1, resource.backends().size());
-            Assert.assertTrue(resource.backends().containsKey("backend2"));
-            Assert.assertTrue(!resource.backends().containsKey(backend.name()));
+            Assertions.assertEquals(1, resource.backends().size());
+            Assertions.assertTrue(resource.backends().containsKey("backend2"));
+            Assertions.assertTrue(!resource.backends().containsKey(backend.name()));
 
             // Verify load balancing rules
             lbRule = resource.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbRule);
-            Assert.assertNull(lbRule.backend());
-            Assert.assertEquals(8080, lbRule.backendPort());
-            Assert.assertNotNull(lbRule.frontend());
-            Assert.assertEquals(11,  lbRule.idleTimeoutInMinutes());
-            Assert.assertNotNull(lbRule.probe());
-            Assert.assertEquals(tcpProbe.name(), lbRule.probe().name());
+            Assertions.assertNotNull(lbRule);
+            Assertions.assertNull(lbRule.backend());
+            Assertions.assertEquals(8080, lbRule.backendPort());
+            Assertions.assertNotNull(lbRule.frontend());
+            Assertions.assertEquals(11,  lbRule.idleTimeoutInMinutes());
+            Assertions.assertNotNull(lbRule.probe());
+            Assertions.assertEquals(tcpProbe.name(), lbRule.probe().name());
 
             lbRule = resource.loadBalancingRules().get("lbrule2");
-            Assert.assertNotNull(lbRule);
-            Assert.assertEquals(22, lbRule.frontendPort());
-            Assert.assertNotNull(lbRule.frontend());
-            Assert.assertTrue("httpprobe".equalsIgnoreCase(lbRule.probe().name()));
-            Assert.assertEquals(TransportProtocol.UDP, lbRule.protocol());
-            Assert.assertNotNull(lbRule.backend());
-            Assert.assertTrue("backend2".equalsIgnoreCase(lbRule.backend().name()));
+            Assertions.assertNotNull(lbRule);
+            Assertions.assertEquals(22, lbRule.frontendPort());
+            Assertions.assertNotNull(lbRule.frontend());
+            Assertions.assertTrue("httpprobe".equalsIgnoreCase(lbRule.probe().name()));
+            Assertions.assertEquals(TransportProtocol.UDP, lbRule.protocol());
+            Assertions.assertNotNull(lbRule.backend());
+            Assertions.assertTrue("backend2".equalsIgnoreCase(lbRule.backend().name()));
 
             return resource;
         }
@@ -921,45 +921,45 @@ public class TestLoadBalancer {
                     .create();
 
             // Verify frontends
-            Assert.assertEquals(1, lb.frontends().size());
-            Assert.assertEquals(1, lb.privateFrontends().size());
-            Assert.assertEquals(0, lb.publicFrontends().size());
+            Assertions.assertEquals(1, lb.frontends().size());
+            Assertions.assertEquals(1, lb.privateFrontends().size());
+            Assertions.assertEquals(0, lb.publicFrontends().size());
             LoadBalancerFrontend frontend = lb.frontends().values().iterator().next();
-            Assert.assertEquals(1, frontend.loadBalancingRules().size());
-            Assert.assertFalse(frontend.isPublic());
-            Assert.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
+            Assertions.assertEquals(1, frontend.loadBalancingRules().size());
+            Assertions.assertFalse(frontend.isPublic());
+            Assertions.assertTrue("lbrule1".equalsIgnoreCase(frontend.loadBalancingRules().values().iterator().next().name()));
             LoadBalancerPrivateFrontend privateFrontend = (LoadBalancerPrivateFrontend) frontend;
-            Assert.assertTrue(network.id().equalsIgnoreCase(privateFrontend.networkId()));
-            Assert.assertNotNull(privateFrontend.privateIPAddress());
-            Assert.assertTrue("subnet1".equalsIgnoreCase(privateFrontend.subnetName()));
-            Assert.assertEquals(IPAllocationMethod.DYNAMIC, privateFrontend.privateIPAllocationMethod());
+            Assertions.assertTrue(network.id().equalsIgnoreCase(privateFrontend.networkId()));
+            Assertions.assertNotNull(privateFrontend.privateIPAddress());
+            Assertions.assertTrue("subnet1".equalsIgnoreCase(privateFrontend.subnetName()));
+            Assertions.assertEquals(IPAllocationMethod.DYNAMIC, privateFrontend.privateIPAllocationMethod());
             // Verify frontend zone
-            Assert.assertNotNull(privateFrontend.availabilityZones());
-            Assert.assertFalse(privateFrontend.availabilityZones().isEmpty());
-            Assert.assertTrue(privateFrontend.availabilityZones().contains(AvailabilityZoneId.ZONE_1));
+            Assertions.assertNotNull(privateFrontend.availabilityZones());
+            Assertions.assertFalse(privateFrontend.availabilityZones().isEmpty());
+            Assertions.assertTrue(privateFrontend.availabilityZones().contains(AvailabilityZoneId.ZONE_1));
 
             // Verify TCP probes
-            Assert.assertEquals(0, lb.tcpProbes().size());
+            Assertions.assertEquals(0, lb.tcpProbes().size());
 
             // Verify rules
-            Assert.assertEquals(1, lb.loadBalancingRules().size());
+            Assertions.assertEquals(1, lb.loadBalancingRules().size());
             LoadBalancingRule lbrule = lb.loadBalancingRules().get("lbrule1");
-            Assert.assertNotNull(lbrule);
-            Assert.assertNotNull(lbrule.frontend());
-            Assert.assertEquals(80, lbrule.backendPort());
-            Assert.assertEquals(80, lbrule.frontendPort());
-            Assert.assertNull(lbrule.probe());
-            Assert.assertEquals(TransportProtocol.TCP, lbrule.protocol());
-            Assert.assertNotNull(lbrule.backend());
+            Assertions.assertNotNull(lbrule);
+            Assertions.assertNotNull(lbrule.frontend());
+            Assertions.assertEquals(80, lbrule.backendPort());
+            Assertions.assertEquals(80, lbrule.frontendPort());
+            Assertions.assertNull(lbrule.probe());
+            Assertions.assertEquals(TransportProtocol.TCP, lbrule.protocol());
+            Assertions.assertNotNull(lbrule.backend());
 
             // Verify backends
-            Assert.assertEquals(1, lb.backends().size());
+            Assertions.assertEquals(1, lb.backends().size());
             LoadBalancerBackend backend = lb.backends().values().iterator().next();
-            Assert.assertNotNull(backend);
+            Assertions.assertNotNull(backend);
 
-            Assert.assertEquals(2, backend.backendNicIPConfigurationNames().size());
+            Assertions.assertEquals(2, backend.backendNicIPConfigurationNames().size());
             for (VirtualMachine vm : existingVMs) {
-                Assert.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
+                Assertions.assertTrue(backend.backendNicIPConfigurationNames().containsKey(vm.primaryNetworkInterfaceId()));
             }
 
             return lb;

--- a/azure/src/test/java/com/microsoft/azure/management/TestLocalNetworkGateway.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestLocalNetworkGateway.java
@@ -9,7 +9,7 @@ import com.microsoft.azure.management.network.LocalNetworkGateway;
 import com.microsoft.azure.management.network.LocalNetworkGateways;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests Local Network Gateway.
@@ -36,9 +36,9 @@ public class TestLocalNetworkGateway extends TestTemplate<LocalNetworkGateway, L
                 .withAddressSpace("192.168.3.0/24")
                 .withAddressSpace("192.168.4.0/27")
                 .create();
-        Assert.assertEquals("40.71.184.214", gateway.ipAddress());
-        Assert.assertEquals(2, gateway.addressSpaces().size());
-        Assert.assertTrue(gateway.addressSpaces().contains("192.168.4.0/27"));
+        Assertions.assertEquals("40.71.184.214", gateway.ipAddress());
+        Assertions.assertEquals(2, gateway.addressSpaces().size());
+        Assertions.assertTrue(gateway.addressSpaces().contains("192.168.4.0/27"));
         return gateway;
     }
 
@@ -50,16 +50,16 @@ public class TestLocalNetworkGateway extends TestTemplate<LocalNetworkGateway, L
                 .withTag("tag2", "value2")
                 .withoutTag("tag1")
                 .apply();
-        Assert.assertFalse(gateway.addressSpaces().contains("192.168.3.0/24"));
-        Assert.assertEquals("40.71.184.216", gateway.ipAddress());
-        Assert.assertTrue(gateway.tags().containsKey("tag2"));
-        Assert.assertTrue(!gateway.tags().containsKey("tag1"));
+        Assertions.assertFalse(gateway.addressSpaces().contains("192.168.3.0/24"));
+        Assertions.assertEquals("40.71.184.216", gateway.ipAddress());
+        Assertions.assertTrue(gateway.tags().containsKey("tag2"));
+        Assertions.assertTrue(!gateway.tags().containsKey("tag1"));
         gateway.updateTags()
                 .withoutTag("tag2")
                 .withTag("tag3", "value3")
                 .applyTags();
-        Assert.assertFalse(gateway.tags().containsKey("tag2"));
-        Assert.assertEquals("value3", gateway.tags().get("tag3"));
+        Assertions.assertFalse(gateway.tags().containsKey("tag2"));
+        Assertions.assertEquals("value3", gateway.tags().get("tag3"));
         return gateway;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestNSG.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestNSG.java
@@ -20,7 +20,7 @@ import com.azure.management.resources.fluentcore.utils.Utils;
 
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.Observable;
 import rx.Subscriber;
 
@@ -96,15 +96,15 @@ public class TestNSG extends TestTemplate<NetworkSecurityGroup, NetworkSecurityG
         nsg.refresh();
 
         // Verify
-        Assert.assertTrue(nsg.region().equals(region));
-        Assert.assertTrue(nsg.securityRules().size() == 2);
+        Assertions.assertTrue(nsg.region().equals(region));
+        Assertions.assertTrue(nsg.securityRules().size() == 2);
 
         // Confirm NIC association
-        Assert.assertEquals(1, nsg.networkInterfaceIds().size());
-        Assert.assertTrue(nsg.networkInterfaceIds().contains(nic.id()));
+        Assertions.assertEquals(1, nsg.networkInterfaceIds().size());
+        Assertions.assertTrue(nsg.networkInterfaceIds().contains(nic.id()));
 
-        Assert.assertEquals(1, nsg.securityRules().get("rule2").sourceApplicationSecurityGroupIds().size());
-        Assert.assertEquals(asg.id(), nsg.securityRules().get("rule2").sourceApplicationSecurityGroupIds().iterator().next());
+        Assertions.assertEquals(1, nsg.securityRules().get("rule2").sourceApplicationSecurityGroupIds().size());
+        Assertions.assertEquals(asg.id(), nsg.securityRules().get("rule2").sourceApplicationSecurityGroupIds().iterator().next());
 
         return nsg;
     }
@@ -132,20 +132,20 @@ public class TestNSG extends TestTemplate<NetworkSecurityGroup, NetworkSecurityG
                     .withDescription("bar!!!")
                     .parent()
                 .apply();
-        Assert.assertTrue(resource.tags().containsKey("tag1"));
-        Assert.assertTrue(resource.securityRules().get("rule2").sourceApplicationSecurityGroupIds().isEmpty());
-        Assert.assertNull(resource.securityRules().get("rule2").sourceAddressPrefix());
-        Assert.assertEquals(2, resource.securityRules().get("rule2").sourceAddressPrefixes().size());
-        Assert.assertTrue(resource.securityRules().get("rule2").sourceAddressPrefixes().contains("100.1.0.0/29"));
-        Assert.assertEquals(1, resource.securityRules().get("rule2").sourcePortRanges().size());
-        Assert.assertEquals("88-90", resource.securityRules().get("rule2").sourcePortRanges().get(0));
+        Assertions.assertTrue(resource.tags().containsKey("tag1"));
+        Assertions.assertTrue(resource.securityRules().get("rule2").sourceApplicationSecurityGroupIds().isEmpty());
+        Assertions.assertNull(resource.securityRules().get("rule2").sourceAddressPrefix());
+        Assertions.assertEquals(2, resource.securityRules().get("rule2").sourceAddressPrefixes().size());
+        Assertions.assertTrue(resource.securityRules().get("rule2").sourceAddressPrefixes().contains("100.1.0.0/29"));
+        Assertions.assertEquals(1, resource.securityRules().get("rule2").sourcePortRanges().size());
+        Assertions.assertEquals("88-90", resource.securityRules().get("rule2").sourcePortRanges().get(0));
 
         resource.updateTags()
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .applyTags();
-        Assert.assertEquals("value3", resource.tags().get("tag3"));
-        Assert.assertFalse(resource.tags().containsKey("tag1"));
+        Assertions.assertEquals("value3", resource.tags().get("tag3"));
+        Assertions.assertFalse(resource.tags().containsKey("tag1"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestNetwork.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestNetwork.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.microsoft.azure.management.network.ServiceEndpointType;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.network.NetworkPeeringGatewayUse;
 import com.microsoft.azure.management.network.Network;
@@ -60,28 +60,28 @@ public class TestNetwork {
                     .create();
 
             // Verify address spaces
-            Assert.assertEquals(2, network.addressSpaces().size());
-            Assert.assertTrue(network.addressSpaces().contains("10.1.0.0/28"));
+            Assertions.assertEquals(2, network.addressSpaces().size());
+            Assertions.assertTrue(network.addressSpaces().contains("10.1.0.0/28"));
 
             // Verify subnets
-            Assert.assertEquals(2, network.subnets().size());
+            Assertions.assertEquals(2, network.subnets().size());
             Subnet subnet = network.subnets().get("subnetA");
-            Assert.assertEquals("10.0.0.0/29", subnet.addressPrefix());
+            Assertions.assertEquals("10.0.0.0/29", subnet.addressPrefix());
 
             subnet = network.subnets().get("subnetB");
-            Assert.assertEquals("10.0.0.8/29", subnet.addressPrefix());
-            Assert.assertTrue(nsg.id().equalsIgnoreCase(subnet.networkSecurityGroupId()));
+            Assertions.assertEquals("10.0.0.8/29", subnet.addressPrefix());
+            Assertions.assertTrue(nsg.id().equalsIgnoreCase(subnet.networkSecurityGroupId()));
 
             // Verify NSG
             List<Subnet> subnets = nsg.refresh().listAssociatedSubnets();
-            Assert.assertEquals(1, subnets.size());
+            Assertions.assertEquals(1, subnets.size());
             subnet = subnets.get(0);
-            Assert.assertTrue(subnet.name().equalsIgnoreCase("subnetB"));
-            Assert.assertTrue(subnet.parent().name().equalsIgnoreCase(newName));
-            Assert.assertNotNull(subnet.networkSecurityGroupId());
+            Assertions.assertTrue(subnet.name().equalsIgnoreCase("subnetB"));
+            Assertions.assertTrue(subnet.parent().name().equalsIgnoreCase(newName));
+            Assertions.assertNotNull(subnet.networkSecurityGroupId());
             NetworkSecurityGroup nsg2 = subnet.getNetworkSecurityGroup();
-            Assert.assertNotNull(nsg2);
-            Assert.assertTrue(nsg2.id().equalsIgnoreCase(nsg.id()));
+            Assertions.assertNotNull(nsg2);
+            Assertions.assertTrue(nsg2.id().equalsIgnoreCase(nsg.id()));
 
             return network;
         }
@@ -109,30 +109,30 @@ public class TestNetwork {
                         .withExistingNetworkSecurityGroup(nsg)
                         .attach()
                     .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify address spaces
-            Assert.assertEquals(2, resource.addressSpaces().size());
-            Assert.assertFalse(resource.addressSpaces().contains("10.1.0.0/28"));
+            Assertions.assertEquals(2, resource.addressSpaces().size());
+            Assertions.assertFalse(resource.addressSpaces().contains("10.1.0.0/28"));
 
             // Verify subnets
-            Assert.assertEquals(3, resource.subnets().size());
-            Assert.assertFalse(resource.subnets().containsKey("subnetA"));
+            Assertions.assertEquals(3, resource.subnets().size());
+            Assertions.assertFalse(resource.subnets().containsKey("subnetA"));
 
             Subnet subnet = resource.subnets().get("subnetB");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.8/29", subnet.addressPrefix());
-            Assert.assertNull(subnet.networkSecurityGroupId());
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.8/29", subnet.addressPrefix());
+            Assertions.assertNull(subnet.networkSecurityGroupId());
 
             subnet = resource.subnets().get("subnetC");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.0/29", subnet.addressPrefix());
-            Assert.assertNull(subnet.networkSecurityGroupId());
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.0/29", subnet.addressPrefix());
+            Assertions.assertNull(subnet.networkSecurityGroupId());
 
             subnet = resource.subnets().get("subnetD");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.16/29", subnet.addressPrefix());
-            Assert.assertTrue(nsg.id().equalsIgnoreCase(subnet.networkSecurityGroupId()));
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.16/29", subnet.addressPrefix());
+            Assertions.assertTrue(nsg.id().equalsIgnoreCase(subnet.networkSecurityGroupId()));
 
             return resource;
         }
@@ -168,19 +168,19 @@ public class TestNetwork {
                     .create();
 
             // Verify address spaces
-            Assert.assertEquals(1, network.addressSpaces().size());
-            Assert.assertTrue(network.addressSpaces().contains("10.0.0.0/28"));
+            Assertions.assertEquals(1, network.addressSpaces().size());
+            Assertions.assertTrue(network.addressSpaces().contains("10.0.0.0/28"));
 
             // Verify subnets
-            Assert.assertEquals(2, network.subnets().size());
+            Assertions.assertEquals(2, network.subnets().size());
             Subnet subnet = network.subnets().get("subnetA");
-            Assert.assertEquals("10.0.0.0/29", subnet.addressPrefix());
+            Assertions.assertEquals("10.0.0.0/29", subnet.addressPrefix());
 
             subnet = network.subnets().get("subnetB");
-            Assert.assertEquals("10.0.0.8/29", subnet.addressPrefix());
-            Assert.assertNotNull(subnet.servicesWithAccess());
-            Assert.assertTrue(subnet.servicesWithAccess().containsKey(ServiceEndpointType.MICROSOFT_STORAGE));
-            Assert.assertTrue(subnet.servicesWithAccess().get(ServiceEndpointType.MICROSOFT_STORAGE).size() > 0);
+            Assertions.assertEquals("10.0.0.8/29", subnet.addressPrefix());
+            Assertions.assertNotNull(subnet.servicesWithAccess());
+            Assertions.assertTrue(subnet.servicesWithAccess().containsKey(ServiceEndpointType.MICROSOFT_STORAGE));
+            Assertions.assertTrue(subnet.servicesWithAccess().get(ServiceEndpointType.MICROSOFT_STORAGE).size() > 0);
             return network;
         }
 
@@ -203,31 +203,31 @@ public class TestNetwork {
                         .attach()
                     .apply();
 
-            Assert.assertTrue(resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
             // Verify address spaces
-            Assert.assertEquals(2, resource.addressSpaces().size());
-            Assert.assertFalse(resource.addressSpaces().contains("10.1.0.0/28"));
+            Assertions.assertEquals(2, resource.addressSpaces().size());
+            Assertions.assertFalse(resource.addressSpaces().contains("10.1.0.0/28"));
 
             // Verify subnets
-            Assert.assertEquals(3, resource.subnets().size());
-            Assert.assertFalse(resource.subnets().containsKey("subnetA"));
+            Assertions.assertEquals(3, resource.subnets().size());
+            Assertions.assertFalse(resource.subnets().containsKey("subnetA"));
 
             Subnet subnet = resource.subnets().get("subnetB");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.8/29", subnet.addressPrefix());
-            Assert.assertNotNull(subnet.servicesWithAccess());
-            Assert.assertTrue(subnet.servicesWithAccess().isEmpty());
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.8/29", subnet.addressPrefix());
+            Assertions.assertNotNull(subnet.servicesWithAccess());
+            Assertions.assertTrue(subnet.servicesWithAccess().isEmpty());
 
             subnet = resource.subnets().get("subnetC");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.0/29", subnet.addressPrefix());
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.0/29", subnet.addressPrefix());
 
             subnet = resource.subnets().get("subnetD");
-            Assert.assertNotNull(subnet);
-            Assert.assertEquals("141.25.0.16/29", subnet.addressPrefix());
-            Assert.assertNotNull(subnet.servicesWithAccess());
-            Assert.assertTrue(subnet.servicesWithAccess().containsKey(ServiceEndpointType.MICROSOFT_STORAGE));
+            Assertions.assertNotNull(subnet);
+            Assertions.assertEquals("141.25.0.16/29", subnet.addressPrefix());
+            Assertions.assertNotNull(subnet.servicesWithAccess());
+            Assertions.assertTrue(subnet.servicesWithAccess().containsKey(ServiceEndpointType.MICROSOFT_STORAGE));
 
             return resource;
         }
@@ -266,8 +266,8 @@ public class TestNetwork {
             CreatedResources<Network> createdNetworks = networks.create(Arrays.asList(remoteNetworkDefinition, localNetworkDefinition));
             Network localNetwork = createdNetworks.get(localNetworkDefinition.key());
             Network remoteNetwork = createdNetworks.get(remoteNetworkDefinition.key());
-            Assert.assertNotNull(localNetwork);
-            Assert.assertNotNull(remoteNetwork);
+            Assertions.assertNotNull(localNetwork);
+            Assertions.assertNotNull(remoteNetwork);
 
             // Create peering
             NetworkPeering localPeering = localNetwork.peerings().define("peer0")
@@ -280,28 +280,28 @@ public class TestNetwork {
                 .create();
 
             // Verify local peering
-            Assert.assertNotNull(localNetwork.peerings());
-            Assert.assertEquals(1,  localNetwork.peerings().list().size());
-            Assert.assertEquals(1, localPeering.remoteAddressSpaces().size());
-            Assert.assertEquals("10.1.0.0/27", localPeering.remoteAddressSpaces().get(0));
+            Assertions.assertNotNull(localNetwork.peerings());
+            Assertions.assertEquals(1,  localNetwork.peerings().list().size());
+            Assertions.assertEquals(1, localPeering.remoteAddressSpaces().size());
+            Assertions.assertEquals("10.1.0.0/27", localPeering.remoteAddressSpaces().get(0));
             localPeering = localNetwork.peerings().list().get(0);
-            Assert.assertNotNull(localPeering);
-            Assert.assertTrue(localPeering.name().equalsIgnoreCase("peer0"));
-            Assert.assertEquals(VirtualNetworkPeeringState.CONNECTED, localPeering.state());
-            Assert.assertTrue(localPeering.isTrafficForwardingFromRemoteNetworkAllowed());
-            Assert.assertFalse(localPeering.checkAccessBetweenNetworks());
-            Assert.assertEquals(NetworkPeeringGatewayUse.BY_REMOTE_NETWORK, localPeering.gatewayUse());
+            Assertions.assertNotNull(localPeering);
+            Assertions.assertTrue(localPeering.name().equalsIgnoreCase("peer0"));
+            Assertions.assertEquals(VirtualNetworkPeeringState.CONNECTED, localPeering.state());
+            Assertions.assertTrue(localPeering.isTrafficForwardingFromRemoteNetworkAllowed());
+            Assertions.assertFalse(localPeering.checkAccessBetweenNetworks());
+            Assertions.assertEquals(NetworkPeeringGatewayUse.BY_REMOTE_NETWORK, localPeering.gatewayUse());
 
             // Verify remote peering
-            Assert.assertNotNull(remoteNetwork.peerings());
-            Assert.assertEquals(1, remoteNetwork.peerings().list().size());
+            Assertions.assertNotNull(remoteNetwork.peerings());
+            Assertions.assertEquals(1, remoteNetwork.peerings().list().size());
             NetworkPeering remotePeering = localPeering.getRemotePeering();
-            Assert.assertNotNull(remotePeering);
-            Assert.assertTrue(remotePeering.remoteNetworkId().equalsIgnoreCase(localNetwork.id()));
-            Assert.assertEquals(VirtualNetworkPeeringState.CONNECTED, remotePeering.state());
-            Assert.assertTrue(remotePeering.isTrafficForwardingFromRemoteNetworkAllowed());
-            Assert.assertFalse(remotePeering.checkAccessBetweenNetworks());
-            Assert.assertEquals(NetworkPeeringGatewayUse.NONE, remotePeering.gatewayUse());
+            Assertions.assertNotNull(remotePeering);
+            Assertions.assertTrue(remotePeering.remoteNetworkId().equalsIgnoreCase(localNetwork.id()));
+            Assertions.assertEquals(VirtualNetworkPeeringState.CONNECTED, remotePeering.state());
+            Assertions.assertTrue(remotePeering.isTrafficForwardingFromRemoteNetworkAllowed());
+            Assertions.assertFalse(remotePeering.checkAccessBetweenNetworks());
+            Assertions.assertEquals(NetworkPeeringGatewayUse.NONE, remotePeering.gatewayUse());
 
             return localNetwork;
         }
@@ -312,14 +312,14 @@ public class TestNetwork {
 
             // Verify remote IP invisibility to local network before peering
             Network remoteNetwork = localPeering.getRemoteNetwork();
-            Assert.assertNotNull(remoteNetwork);
+            Assertions.assertNotNull(remoteNetwork);
             Subnet remoteSubnet = remoteNetwork.subnets().get("subnet3");
-            Assert.assertNotNull(remoteSubnet);
+            Assertions.assertNotNull(remoteSubnet);
             Set<String> remoteAvailableIPs = remoteSubnet.listAvailablePrivateIPAddresses();
-            Assert.assertNotNull(remoteAvailableIPs);
-            Assert.assertFalse(remoteAvailableIPs.isEmpty());
+            Assertions.assertNotNull(remoteAvailableIPs);
+            Assertions.assertFalse(remoteAvailableIPs.isEmpty());
             String remoteTestIP = remoteAvailableIPs.iterator().next();
-            Assert.assertFalse(resource.isPrivateIPAddressAvailable(remoteTestIP));
+            Assertions.assertFalse(resource.isPrivateIPAddressAvailable(remoteTestIP));
 
             localPeering.update()
                 .withoutTrafficForwardingFromEitherNetwork()
@@ -328,23 +328,23 @@ public class TestNetwork {
                 .apply();
 
             // Verify local peering changes
-            Assert.assertFalse(localPeering.isTrafficForwardingFromRemoteNetworkAllowed());
-            Assert.assertTrue(localPeering.checkAccessBetweenNetworks());
-            Assert.assertEquals(NetworkPeeringGatewayUse.NONE, localPeering.gatewayUse());
+            Assertions.assertFalse(localPeering.isTrafficForwardingFromRemoteNetworkAllowed());
+            Assertions.assertTrue(localPeering.checkAccessBetweenNetworks());
+            Assertions.assertEquals(NetworkPeeringGatewayUse.NONE, localPeering.gatewayUse());
 
             // Verify remote peering changes
             NetworkPeering remotePeering = localPeering.getRemotePeering();
-            Assert.assertNotNull(remotePeering);
-            Assert.assertFalse(remotePeering.isTrafficForwardingFromRemoteNetworkAllowed());
-            Assert.assertTrue(remotePeering.checkAccessBetweenNetworks());
-            Assert.assertEquals(NetworkPeeringGatewayUse.NONE, remotePeering.gatewayUse());
+            Assertions.assertNotNull(remotePeering);
+            Assertions.assertFalse(remotePeering.isTrafficForwardingFromRemoteNetworkAllowed());
+            Assertions.assertTrue(remotePeering.checkAccessBetweenNetworks());
+            Assertions.assertEquals(NetworkPeeringGatewayUse.NONE, remotePeering.gatewayUse());
 
             // Delete the peering
             resource.peerings().deleteById(remotePeering.id());
 
             // Verify deletion
-            Assert.assertEquals(0, resource.peerings().list().size());
-            Assert.assertEquals(0, remoteNetwork.peerings().list().size());
+            Assertions.assertEquals(0, resource.peerings().list().size());
+            Assertions.assertEquals(0, remoteNetwork.peerings().list().size());
 
             return resource;
         }
@@ -372,9 +372,9 @@ public class TestNetwork {
                     .withNewDdosProtectionPlan()
                     .withVmProtection()
                     .create();
-            Assert.assertTrue(network.isDdosProtectionEnabled());
-            Assert.assertNotNull(network.ddosProtectionPlanId());
-            Assert.assertTrue(network.isVmProtectionEnabled());
+            Assertions.assertTrue(network.isDdosProtectionEnabled());
+            Assertions.assertNotNull(network.ddosProtectionPlanId());
+            Assertions.assertTrue(network.isVmProtectionEnabled());
 
             return network;
         }
@@ -385,9 +385,9 @@ public class TestNetwork {
                     .withoutDdosProtectionPlan()
                     .withoutVmProtection()
                     .apply();
-            Assert.assertFalse(network.isDdosProtectionEnabled());
-            Assert.assertNull(network.ddosProtectionPlanId());
-            Assert.assertFalse(network.isVmProtectionEnabled());
+            Assertions.assertFalse(network.isDdosProtectionEnabled());
+            Assertions.assertNull(network.ddosProtectionPlanId());
+            Assertions.assertFalse(network.isVmProtectionEnabled());
             return network;
         }
 
@@ -413,7 +413,7 @@ public class TestNetwork {
                     .withNewResourceGroup(groupName)
                     .withTag("tag1", "value1")
                     .create();
-            Assert.assertEquals("value1", network.tags().get("tag1"));
+            Assertions.assertEquals("value1", network.tags().get("tag1"));
             return network;
         }
 
@@ -423,8 +423,8 @@ public class TestNetwork {
                     .withoutTag("tag1")
                     .withTag("tag2", "value2")
                     .applyTags();
-            Assert.assertFalse(network.tags().containsKey("tag1"));
-            Assert.assertEquals("value2", network.tags().get("tag2"));
+            Assertions.assertFalse(network.tags().containsKey("tag1"));
+            Assertions.assertEquals("value2", network.tags().get("tag2"));
             return network;
         }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestNetworkInterface.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestNetworkInterface.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.management;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.network.LoadBalancerBackend;
 import com.microsoft.azure.management.network.LoadBalancerInboundNatRule;
@@ -47,20 +47,20 @@ public class TestNetworkInterface extends TestTemplate<NetworkInterface, Network
                 .create();
 
         // Verify NIC settings
-        Assert.assertTrue(nic.isAcceleratedNetworkingEnabled());
-        Assert.assertTrue(nic.isIPForwardingEnabled());
+        Assertions.assertTrue(nic.isAcceleratedNetworkingEnabled());
+        Assertions.assertTrue(nic.isIPForwardingEnabled());
 
         // Verify IP configs
         NicIPConfiguration ipConfig = nic.primaryIPConfiguration();
-        Assert.assertNotNull(ipConfig);
+        Assertions.assertNotNull(ipConfig);
         network = ipConfig.getNetwork();
-        Assert.assertNotNull(network);
+        Assertions.assertNotNull(network);
         Subnet subnet = network.subnets().get(ipConfig.subnetName());
-        Assert.assertNotNull(subnet);
-        Assert.assertEquals(1, subnet.networkInterfaceIPConfigurationCount());
+        Assertions.assertNotNull(subnet);
+        Assertions.assertEquals(1, subnet.networkInterfaceIPConfigurationCount());
         Collection<NicIPConfiguration> ipConfigs = subnet.listNetworkInterfaceIPConfigurations();
-        Assert.assertNotNull(ipConfigs);
-        Assert.assertEquals(1, ipConfigs.size());
+        Assertions.assertNotNull(ipConfigs);
+        Assertions.assertEquals(1, ipConfigs.size());
         NicIPConfiguration ipConfig2 = null;
         for (NicIPConfiguration i : ipConfigs) {
             if (i.name().equalsIgnoreCase(ipConfig.name())) {
@@ -68,8 +68,8 @@ public class TestNetworkInterface extends TestTemplate<NetworkInterface, Network
                 break;
             }
         }
-        Assert.assertNotNull(ipConfig2);
-        Assert.assertTrue(ipConfig.name().equalsIgnoreCase(ipConfig2.name()));
+        Assertions.assertNotNull(ipConfig2);
+        Assertions.assertTrue(ipConfig.name().equalsIgnoreCase(ipConfig2.name()));
 
         return nic;
     }
@@ -89,23 +89,23 @@ public class TestNetworkInterface extends TestTemplate<NetworkInterface, Network
                 .apply();
 
         // Verifications
-        Assert.assertFalse(resource.isAcceleratedNetworkingEnabled());
-        Assert.assertFalse(resource.isIPForwardingEnabled());
+        Assertions.assertFalse(resource.isAcceleratedNetworkingEnabled());
+        Assertions.assertFalse(resource.isIPForwardingEnabled());
         NicIPConfiguration primaryIpConfig = resource.primaryIPConfiguration();
-        Assert.assertNotNull(primaryIpConfig);
-        Assert.assertTrue(primaryIpConfig.isPrimary());
-        Assert.assertTrue("subnet2".equalsIgnoreCase(primaryIpConfig.subnetName()));
-        Assert.assertNull(primaryIpConfig.publicIPAddressId());
-        Assert.assertTrue(resource.tags().containsKey("tag1"));
+        Assertions.assertNotNull(primaryIpConfig);
+        Assertions.assertTrue(primaryIpConfig.isPrimary());
+        Assertions.assertTrue("subnet2".equalsIgnoreCase(primaryIpConfig.subnetName()));
+        Assertions.assertNull(primaryIpConfig.publicIPAddressId());
+        Assertions.assertTrue(resource.tags().containsKey("tag1"));
 
-        Assert.assertEquals(1,  resource.ipConfigurations().size());
+        Assertions.assertEquals(1,  resource.ipConfigurations().size());
 
         resource.updateTags()
                 .withoutTag("tag1")
                 .withTag("tag3", "value3")
                 .applyTags();
-        Assert.assertFalse(resource.tags().containsKey("tag1"));
-        Assert.assertEquals("value3", resource.tags().get("tag3"));
+        Assertions.assertFalse(resource.tags().containsKey("tag1"));
+        Assertions.assertEquals("value3", resource.tags().get("tag3"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestNetworkWatcher.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestNetworkWatcher.java
@@ -15,7 +15,7 @@ import com.azure.management.resources.fluentcore.model.CreatedResources;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azure.management.storage.StorageAccounts;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.azure.management.resources.fluentcore.arm.Region;
 
@@ -65,15 +65,15 @@ public class TestNetworkWatcher extends TestTemplate<NetworkWatcher, NetworkWatc
                 .withoutTag("tag1")
                 .apply();
         resource.refresh();
-        Assert.assertTrue(resource.tags().containsKey("tag2"));
-        Assert.assertFalse(resource.tags().containsKey("tag1"));
+        Assertions.assertTrue(resource.tags().containsKey("tag2"));
+        Assertions.assertFalse(resource.tags().containsKey("tag1"));
 
         resource.updateTags()
                 .withTag("tag3", "value3")
                 .withoutTag("tag2")
                 .applyTags();
-        Assert.assertTrue(resource.tags().containsKey("tag3"));
-        Assert.assertFalse(resource.tags().containsKey("tag2"));
+        Assertions.assertTrue(resource.tags().containsKey("tag3"));
+        Assertions.assertFalse(resource.tags().containsKey("tag2"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestPublicIPAddress.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestPublicIPAddress.java
@@ -5,7 +5,7 @@
  */
 package com.microsoft.azure.management;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.network.LoadBalancer;
 import com.microsoft.azure.management.network.NetworkInterface;
@@ -44,16 +44,16 @@ public class TestPublicIPAddress extends TestTemplate<PublicIPAddress, PublicIPA
                 .withTag("tag1", "value1")
                 .withTag("tag2", "value2")
                 .apply();
-        Assert.assertTrue(resource.leafDomainLabel().equalsIgnoreCase(updatedDnsName));
-        Assert.assertTrue(resource.idleTimeoutInMinutes() == updatedIdleTimeout);
-        Assert.assertEquals("value2", resource.tags().get("tag2"));
+        Assertions.assertTrue(resource.leafDomainLabel().equalsIgnoreCase(updatedDnsName));
+        Assertions.assertTrue(resource.idleTimeoutInMinutes() == updatedIdleTimeout);
+        Assertions.assertEquals("value2", resource.tags().get("tag2"));
 
         resource.updateTags()
                 .withoutTag("tag1")
                 .withTag("tag3", "value3")
                 .applyTags();
-        Assert.assertFalse(resource.tags().containsKey("tag1"));
-        Assert.assertEquals("value3", resource.tags().get("tag3"));
+        Assertions.assertFalse(resource.tags().containsKey("tag1"));
+        Assertions.assertEquals("value3", resource.tags().get("tag3"));
         return resource;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestRedis.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestRedis.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.redis.RedisCaches;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.model.Indexable;
 import com.azure.management.resources.fluentcore.utils.Utils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.Observable;
 import rx.functions.Action1;
 
@@ -40,7 +40,7 @@ public class TestRedis extends TestTemplate<RedisCache, RedisCaches>  {
 
         redisCaches[0] = future.get();
 
-        Assert.assertEquals(redisCaches[0].name(), redisName);
+        Assertions.assertEquals(redisCaches[0].name(), redisName);
 
         return redisCaches[0];
     }
@@ -51,7 +51,7 @@ public class TestRedis extends TestTemplate<RedisCache, RedisCaches>  {
                 .withPremiumSku(2)
                 .apply();
 
-        Assert.assertEquals(true, resource.isPremium());
+        Assertions.assertEquals(true, resource.isPremium());
 
         return resource;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestResourceStreaming.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestResourceStreaming.java
@@ -18,7 +18,7 @@ import com.azure.management.resources.fluentcore.model.Indexable;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azure.management.storage.StorageAccounts;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.functions.Func1;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,7 +68,7 @@ public class TestResourceStreaming extends TestTemplate<VirtualMachine, VirtualM
                     }
                 }).toBlocking().last();
 
-        Assert.assertTrue(resourceCount.get() == 7);
+        Assertions.assertTrue(resourceCount.get() == 7);
         return virtualMachine;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestRouteTables.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestRouteTables.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.management;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.microsoft.azure.management.network.Route;
 import com.microsoft.azure.management.network.RouteNextHopType;
@@ -56,19 +56,19 @@ public class TestRouteTables {
                     .withDisableBgpRoutePropagation()
                     .create();
 
-            Assert.assertTrue(routeTable.routes().containsKey(ROUTE1_NAME));
+            Assertions.assertTrue(routeTable.routes().containsKey(ROUTE1_NAME));
             Route route1 = routeTable.routes().get(ROUTE1_NAME);
-            Assert.assertTrue(route1.destinationAddressPrefix().equalsIgnoreCase(route1AddressPrefix));
-            Assert.assertTrue(route1.nextHopIPAddress().equalsIgnoreCase(VIRTUAL_APPLIANCE_IP));
-            Assert.assertTrue(route1.nextHopType().equals(RouteNextHopType.VIRTUAL_APPLIANCE));
+            Assertions.assertTrue(route1.destinationAddressPrefix().equalsIgnoreCase(route1AddressPrefix));
+            Assertions.assertTrue(route1.nextHopIPAddress().equalsIgnoreCase(VIRTUAL_APPLIANCE_IP));
+            Assertions.assertTrue(route1.nextHopType().equals(RouteNextHopType.VIRTUAL_APPLIANCE));
 
-            Assert.assertTrue(routeTable.routes().containsKey(ROUTE2_NAME));
+            Assertions.assertTrue(routeTable.routes().containsKey(ROUTE2_NAME));
             Route route2 = routeTable.routes().get(ROUTE2_NAME);
-            Assert.assertTrue(route2.destinationAddressPrefix().equalsIgnoreCase(route2AddressPrefix));
-            Assert.assertTrue(route2.nextHopIPAddress() == null);
-            Assert.assertTrue(route2.nextHopType().equals(hopType));
+            Assertions.assertTrue(route2.destinationAddressPrefix().equalsIgnoreCase(route2AddressPrefix));
+            Assertions.assertTrue(route2.nextHopIPAddress() == null);
+            Assertions.assertTrue(route2.nextHopType().equals(hopType));
 
-            Assert.assertTrue(routeTable.isBgpRoutePropagationDisabled());
+            Assertions.assertTrue(routeTable.isBgpRoutePropagationDisabled());
 
             // Create a subnet that references the route table
             routeTables.manager().networks().define("net" + this.testId)
@@ -82,8 +82,8 @@ public class TestRouteTables {
                 .create();
 
             List<Subnet> subnets = routeTable.refresh().listAssociatedSubnets();
-            Assert.assertTrue(subnets.size() == 1);
-            Assert.assertTrue(subnets.get(0).routeTableId().equalsIgnoreCase(routeTable.id()));
+            Assertions.assertTrue(subnets.size() == 1);
+            Assertions.assertTrue(subnets.get(0).routeTableId().equalsIgnoreCase(routeTable.id()));
             return routeTable;
         }
 
@@ -105,12 +105,12 @@ public class TestRouteTables {
                     .withEnableBgpRoutePropagation()
                     .apply();
 
-            Assert.assertTrue(routeTable.tags().containsKey("tag1"));
-            Assert.assertTrue(routeTable.tags().containsKey("tag2"));
-            Assert.assertTrue(!routeTable.routes().containsKey(ROUTE1_NAME));
-            Assert.assertTrue(routeTable.routes().containsKey(ROUTE2_NAME));
-            Assert.assertTrue(routeTable.routes().containsKey(ROUTE_ADDED_NAME));
-            Assert.assertFalse(routeTable.isBgpRoutePropagationDisabled());
+            Assertions.assertTrue(routeTable.tags().containsKey("tag1"));
+            Assertions.assertTrue(routeTable.tags().containsKey("tag2"));
+            Assertions.assertTrue(!routeTable.routes().containsKey(ROUTE1_NAME));
+            Assertions.assertTrue(routeTable.routes().containsKey(ROUTE2_NAME));
+            Assertions.assertTrue(routeTable.routes().containsKey(ROUTE_ADDED_NAME));
+            Assertions.assertFalse(routeTable.isBgpRoutePropagationDisabled());
 
             routeTable.manager().networks().getByResourceGroup(routeTable.resourceGroupName(), "net" + this.testId).update()
                 .updateSubnet("subnet1")
@@ -119,14 +119,14 @@ public class TestRouteTables {
                 .apply();
 
             List<Subnet> subnets = routeTable.refresh().listAssociatedSubnets();
-            Assert.assertTrue(subnets.size() == 0);
+            Assertions.assertTrue(subnets.size() == 0);
 
             routeTable.updateTags()
                     .withoutTag("tag1")
                     .withTag("tag3", "value3")
                     .applyTags();
-            Assert.assertFalse(routeTable.tags().containsKey("tag1"));
-            Assert.assertEquals("value3", routeTable.tags().get("tag3"));
+            Assertions.assertFalse(routeTable.tags().containsKey("tag1"));
+            Assertions.assertEquals("value3", routeTable.tags().get("tag3"));
             return routeTable;
         }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestSearchService.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestSearchService.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.management;
 
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.microsoft.azure.management.search.*;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
@@ -23,7 +23,7 @@ public class TestSearchService {
             final String newName = "ssrv" + this.testId;
             String rgName = "rgSearch" + this.testId;
 
-            Assert.assertTrue(searchServices.checkNameAvailability(newName).isAvailable());
+            Assertions.assertTrue(searchServices.checkNameAvailability(newName).isAvailable());
 
             SearchService searchService = searchServices.define(newName)
                 .withRegion(Region.US_WEST)
@@ -31,18 +31,18 @@ public class TestSearchService {
                 .withSku(SkuName.STANDARD)
                 .create();
 
-            Assert.assertEquals(SkuName.STANDARD, searchService.sku().name());
-            Assert.assertEquals(1, searchService.replicaCount());
-            Assert.assertEquals(1, searchService.partitionCount());
+            Assertions.assertEquals(SkuName.STANDARD, searchService.sku().name());
+            Assertions.assertEquals(1, searchService.replicaCount());
+            Assertions.assertEquals(1, searchService.partitionCount());
 
             AdminKeys adminKeys = searchService.getAdminKeys();
-            Assert.assertNotNull(adminKeys);
-            Assert.assertNotNull(adminKeys.primaryKey());
-            Assert.assertNotNull(adminKeys.secondaryKey());
+            Assertions.assertNotNull(adminKeys);
+            Assertions.assertNotNull(adminKeys.primaryKey());
+            Assertions.assertNotNull(adminKeys.secondaryKey());
 
             List<QueryKey> queryKeys = searchService.listQueryKeys();
-            Assert.assertNotNull(queryKeys);
-            Assert.assertEquals(1, queryKeys.size());
+            Assertions.assertNotNull(queryKeys);
+            Assertions.assertEquals(1, queryKeys.size());
 
             return searchService;
         }
@@ -58,11 +58,11 @@ public class TestSearchService {
                 .withReplicaCount(1)
                 .withPartitionCount(1)
                 .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
-            Assert.assertEquals(1, resource.replicaCount());
-            Assert.assertEquals(1, resource.partitionCount());
-            Assert.assertEquals(2, resource.listQueryKeys().size());
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertEquals(1, resource.replicaCount());
+            Assertions.assertEquals(1, resource.partitionCount());
+            Assertions.assertEquals(2, resource.listQueryKeys().size());
 
             String adminKeyPrimary = resource.getAdminKeys().primaryKey();
             String adminKeySecondary = resource.getAdminKeys().secondaryKey();
@@ -70,9 +70,9 @@ public class TestSearchService {
             resource.deleteQueryKey(resource.listQueryKeys().get(1).key());
             resource.regenerateAdminKeys(AdminKeyKind.PRIMARY);
             resource.regenerateAdminKeys(AdminKeyKind.SECONDARY);
-            Assert.assertEquals(1, resource.listQueryKeys().size());
-            Assert.assertNotEquals(adminKeyPrimary, resource.getAdminKeys().primaryKey());
-            Assert.assertNotEquals(adminKeySecondary, resource.getAdminKeys().secondaryKey());
+            Assertions.assertEquals(1, resource.listQueryKeys().size());
+            Assertions.assertNotEquals(adminKeyPrimary, resource.getAdminKeys().primaryKey());
+            Assertions.assertNotEquals(adminKeySecondary, resource.getAdminKeys().secondaryKey());
 
             return resource;
         }
@@ -98,9 +98,9 @@ public class TestSearchService {
                 .withFreeSku()
                 .create();
 
-            Assert.assertEquals(SkuName.FREE, searchService.sku().name());
-            Assert.assertEquals(1, searchService.replicaCount());
-            Assert.assertEquals(1, searchService.partitionCount());
+            Assertions.assertEquals(SkuName.FREE, searchService.sku().name());
+            Assertions.assertEquals(1, searchService.replicaCount());
+            Assertions.assertEquals(1, searchService.partitionCount());
 
             return searchService;
         }
@@ -112,8 +112,8 @@ public class TestSearchService {
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
             return resource;
         }
 
@@ -139,9 +139,9 @@ public class TestSearchService {
                 .withReplicaCount(1)
                 .create();
 
-            Assert.assertEquals(SkuName.BASIC, searchService.sku().name());
-            Assert.assertEquals(1, searchService.replicaCount());
-            Assert.assertEquals(1, searchService.partitionCount());
+            Assertions.assertEquals(SkuName.BASIC, searchService.sku().name());
+            Assertions.assertEquals(1, searchService.replicaCount());
+            Assertions.assertEquals(1, searchService.partitionCount());
 
             return searchService;
         }
@@ -153,8 +153,8 @@ public class TestSearchService {
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
             return resource;
         }
 
@@ -181,9 +181,9 @@ public class TestSearchService {
                 .withReplicaCount(1)
                 .create();
 
-            Assert.assertEquals(SkuName.STANDARD, searchService.sku().name());
-            Assert.assertEquals(1, searchService.replicaCount());
-            Assert.assertEquals(2, searchService.partitionCount());
+            Assertions.assertEquals(SkuName.STANDARD, searchService.sku().name());
+            Assertions.assertEquals(1, searchService.replicaCount());
+            Assertions.assertEquals(2, searchService.partitionCount());
 
             return searchService;
         }
@@ -197,11 +197,11 @@ public class TestSearchService {
                 .withTag("tag3", "value3")
                 .withoutTag("tag1")
                 .apply();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
-            Assert.assertEquals(SkuName.STANDARD, resource.sku().name());
-            Assert.assertEquals(1, resource.replicaCount());
-            Assert.assertEquals(1, resource.partitionCount());
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertEquals(SkuName.STANDARD, resource.sku().name());
+            Assertions.assertEquals(1, resource.replicaCount());
+            Assertions.assertEquals(1, resource.partitionCount());
 
             return resource;
         }

--- a/azure/src/test/java/com/microsoft/azure/management/TestSql.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestSql.java
@@ -13,7 +13,7 @@ import com.azure.management.resources.fluentcore.utils.Utils;
 import com.microsoft.azure.management.sql.ElasticPoolEdition;
 import com.microsoft.azure.management.sql.SqlServer;
 import com.microsoft.azure.management.sql.SqlServers;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.Observable;
 import rx.functions.Action1;
 
@@ -44,13 +44,13 @@ public class TestSql extends TestTemplate<SqlServer, SqlServers>  {
 
         sqlServers[0] = future.get();
 
-        Assert.assertNotNull(sqlServers[0].inner());
+        Assertions.assertNotNull(sqlServers[0].inner());
 
-        Assert.assertNotNull(sqlServers[0].inner());
+        Assertions.assertNotNull(sqlServers[0].inner());
         // Including master database
-        Assert.assertEquals(sqlServers[0].databases().list().size(), 3);
-        Assert.assertEquals(sqlServers[0].elasticPools().list().size(), 1);
-        Assert.assertEquals(sqlServers[0].firewallRules().list().size(), 2);
+        Assertions.assertEquals(sqlServers[0].databases().list().size(), 3);
+        Assertions.assertEquals(sqlServers[0].elasticPools().list().size(), 1);
+        Assertions.assertEquals(sqlServers[0].firewallRules().list().size(), 2);
 
         return sqlServers[0];
     }
@@ -63,11 +63,11 @@ public class TestSql extends TestTemplate<SqlServer, SqlServers>  {
                 .withoutElasticPool("elasticPool1")
                 .apply();
 
-        Assert.assertNotNull(sqlServer.inner());
+        Assertions.assertNotNull(sqlServer.inner());
         // Just master database
-        Assert.assertEquals(1, sqlServer.databases().list().size());
-        Assert.assertEquals(0, sqlServer.elasticPools().list().size());
-        Assert.assertEquals(2, sqlServer.firewallRules().list().size());
+        Assertions.assertEquals(1, sqlServer.databases().list().size());
+        Assertions.assertEquals(0, sqlServer.elasticPools().list().size());
+        Assertions.assertEquals(2, sqlServer.firewallRules().list().size());
 
         return sqlServer;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestTemplate.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestTemplate.java
@@ -17,7 +17,7 @@ import com.azure.management.resources.fluentcore.collection.SupportsDeletingById
 import com.azure.management.resources.fluentcore.collection.SupportsListing;
 import com.azure.management.resources.fluentcore.model.HasInner;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 
@@ -84,7 +84,7 @@ public abstract class TestTemplate<
     public ResourceT verifyGetting() throws CloudException, IOException {
         ResourceT resourceByGroup = this.collection.getByResourceGroup(this.resource.resourceGroupName(), this.resource.name());
         ResourceT resourceById = this.collection.getById(resourceByGroup.id());
-        Assert.assertTrue(resourceById.id().equalsIgnoreCase(resourceByGroup.id()));
+        Assertions.assertTrue(resourceById.id().equalsIgnoreCase(resourceByGroup.id()));
         return resourceById;
     }
 
@@ -128,7 +128,7 @@ public abstract class TestTemplate<
 
         // Verify getting
         this.resource = verifyGetting();
-        Assert.assertTrue(this.resource != null);
+        Assertions.assertTrue(this.resource != null);
         System.out.println("\n------------\nRetrieved resource:\n");
         print(this.resource);
 
@@ -137,7 +137,7 @@ public abstract class TestTemplate<
         // Verify update
         try {
             this.resource = updateResource(this.resource);
-            Assert.assertTrue(this.resource != null);
+            Assertions.assertTrue(this.resource != null);
             System.out.println("\n------------\nUpdated resource:\n");
             message = "Print failed";
             print(this.resource);
@@ -155,8 +155,8 @@ public abstract class TestTemplate<
             e.printStackTrace();
             failedDelete = true;
         }
-        Assert.assertFalse(message, failedUpdate);
-        Assert.assertFalse(message,  failedDelete);
+        Assertions.assertFalse(message, failedUpdate);
+        Assertions.assertFalse(message,  failedDelete);
     }
 
     /**
@@ -182,7 +182,7 @@ public abstract class TestTemplate<
 
         // Verify getting
         this.resource = verifyGetting();
-        Assert.assertTrue(this.resource != null);
+        Assertions.assertTrue(this.resource != null);
         System.out.println("\n------------\nRetrieved resource:\n");
         print(this.resource);
 
@@ -191,7 +191,7 @@ public abstract class TestTemplate<
         // Verify update
         try {
             this.resource = updateResource(this.resource);
-            Assert.assertTrue(this.resource != null);
+            Assertions.assertTrue(this.resource != null);
             System.out.println("\n------------\nUpdated resource:\n");
             message = "Print failed";
             print(this.resource);
@@ -209,7 +209,7 @@ public abstract class TestTemplate<
             e.printStackTrace();
             failedDelete = true;
         }
-        Assert.assertFalse(message, failedUpdate);
-        Assert.assertFalse(message,  failedDelete);
+        Assertions.assertFalse(message, failedUpdate);
+        Assertions.assertFalse(message,  failedDelete);
     }
 }

--- a/azure/src/test/java/com/microsoft/azure/management/TestTemplate.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestTemplate.java
@@ -155,8 +155,8 @@ public abstract class TestTemplate<
             e.printStackTrace();
             failedDelete = true;
         }
-        Assertions.assertFalse(message, failedUpdate);
-        Assertions.assertFalse(message,  failedDelete);
+        Assertions.assertFalse(failedUpdate, message);
+        Assertions.assertFalse(failedDelete, message);
     }
 
     /**
@@ -209,7 +209,7 @@ public abstract class TestTemplate<
             e.printStackTrace();
             failedDelete = true;
         }
-        Assertions.assertFalse(message, failedUpdate);
-        Assertions.assertFalse(message,  failedDelete);
+        Assertions.assertFalse(failedUpdate, message);
+        Assertions.assertFalse(failedDelete, message);
     }
 }

--- a/azure/src/test/java/com/microsoft/azure/management/TestTrafficManager.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestTrafficManager.java
@@ -18,7 +18,7 @@ import com.microsoft.azure.management.trafficmanager.TrafficManagerExternalEndpo
 import com.microsoft.azure.management.trafficmanager.TrafficManagerNestedProfileEndpoint;
 import com.microsoft.azure.management.trafficmanager.TrafficManagerProfile;
 import com.microsoft.azure.management.trafficmanager.TrafficManagerProfiles;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.Map;
 
@@ -75,15 +75,15 @@ public class TestTrafficManager extends TestTemplate<TrafficManagerProfile, Traf
                 .withTimeToLive(500)
                 .create();
 
-        Assert.assertTrue(nestedProfile.isEnabled());
-        Assert.assertNotNull(nestedProfile.monitorStatus());
-        Assert.assertEquals(nestedProfile.monitoringPort(), 443);
-        Assert.assertEquals(nestedProfile.monitoringPath(), "/");
-        Assert.assertEquals(nestedProfile.azureEndpoints().size(), 0);
-        Assert.assertEquals(nestedProfile.nestedProfileEndpoints().size(), 0);
-        Assert.assertEquals(nestedProfile.externalEndpoints().size(), 1);
-        Assert.assertEquals(nestedProfile.fqdn(), nestedTmProfileDnsLabel + ".trafficmanager.net");
-        Assert.assertEquals(nestedProfile.timeToLive(), 500);
+        Assertions.assertTrue(nestedProfile.isEnabled());
+        Assertions.assertNotNull(nestedProfile.monitorStatus());
+        Assertions.assertEquals(nestedProfile.monitoringPort(), 443);
+        Assertions.assertEquals(nestedProfile.monitoringPath(), "/");
+        Assertions.assertEquals(nestedProfile.azureEndpoints().size(), 0);
+        Assertions.assertEquals(nestedProfile.nestedProfileEndpoints().size(), 0);
+        Assertions.assertEquals(nestedProfile.externalEndpoints().size(), 1);
+        Assertions.assertEquals(nestedProfile.fqdn(), nestedTmProfileDnsLabel + ".trafficmanager.net");
+        Assertions.assertEquals(nestedProfile.timeToLive(), 500);
 
         // Creates a public ip to be used as an Azure endpoint
         //
@@ -93,7 +93,7 @@ public class TestTrafficManager extends TestTemplate<TrafficManagerProfile, Traf
                 .withLeafDomainLabel(pipDnsLabel)
                 .create();
 
-        Assert.assertNotNull(publicIPAddress.fqdn());
+        Assertions.assertNotNull(publicIPAddress.fqdn());
         // Creates a TM profile
         //
 
@@ -106,31 +106,31 @@ public class TestTrafficManager extends TestTemplate<TrafficManagerProfile, Traf
                                     .attach()
                                 .apply();
 
-        Assert.assertEquals(1, updatedProfile.azureEndpoints().size());
-        Assert.assertTrue(updatedProfile.azureEndpoints().containsKey(azureEndpointName));
-        Assert.assertEquals(1, updatedProfile.externalEndpoints().size());
-        Assert.assertTrue(updatedProfile.externalEndpoints().containsKey(externalEndpointName21));
+        Assertions.assertEquals(1, updatedProfile.azureEndpoints().size());
+        Assertions.assertTrue(updatedProfile.azureEndpoints().containsKey(azureEndpointName));
+        Assertions.assertEquals(1, updatedProfile.externalEndpoints().size());
+        Assertions.assertTrue(updatedProfile.externalEndpoints().containsKey(externalEndpointName21));
 
         TrafficManagerProfile updatedProfileFromGet = profiles.getById(updatedProfile.id());
 
-        Assert.assertEquals(1, updatedProfileFromGet.azureEndpoints().size());
-        Assert.assertTrue(updatedProfileFromGet.azureEndpoints().containsKey(azureEndpointName));
-        Assert.assertEquals(1, updatedProfileFromGet.externalEndpoints().size());
-        Assert.assertTrue(updatedProfileFromGet.externalEndpoints().containsKey(externalEndpointName21));
+        Assertions.assertEquals(1, updatedProfileFromGet.azureEndpoints().size());
+        Assertions.assertTrue(updatedProfileFromGet.azureEndpoints().containsKey(azureEndpointName));
+        Assertions.assertEquals(1, updatedProfileFromGet.externalEndpoints().size());
+        Assertions.assertTrue(updatedProfileFromGet.externalEndpoints().containsKey(externalEndpointName21));
 
         nestedProfile.update()
                 .withoutEndpoint(azureEndpointName)
                 .apply();
 
-        Assert.assertEquals(0, nestedProfile.azureEndpoints().size());
-        Assert.assertEquals(1, nestedProfile.externalEndpoints().size());
-        Assert.assertTrue(nestedProfile.externalEndpoints().containsKey(externalEndpointName21));
+        Assertions.assertEquals(0, nestedProfile.azureEndpoints().size());
+        Assertions.assertEquals(1, nestedProfile.externalEndpoints().size());
+        Assertions.assertTrue(nestedProfile.externalEndpoints().containsKey(externalEndpointName21));
 
         updatedProfileFromGet = profiles.getById(updatedProfile.id());
-        Assert.assertEquals(0, updatedProfileFromGet.azureEndpoints().size());
-        Assert.assertEquals(nestedProfile.azureEndpoints().size(), updatedProfileFromGet.azureEndpoints().size());
-        Assert.assertEquals(1, updatedProfileFromGet.externalEndpoints().size());
-        Assert.assertTrue(updatedProfileFromGet.externalEndpoints().containsKey(externalEndpointName21));
+        Assertions.assertEquals(0, updatedProfileFromGet.azureEndpoints().size());
+        Assertions.assertEquals(nestedProfile.azureEndpoints().size(), updatedProfileFromGet.azureEndpoints().size());
+        Assertions.assertEquals(1, updatedProfileFromGet.externalEndpoints().size());
+        Assertions.assertTrue(updatedProfileFromGet.externalEndpoints().containsKey(externalEndpointName21));
         // end of bugfix
 
         TrafficManagerProfile profile = profiles.define(tmProfileName)
@@ -163,66 +163,66 @@ public class TestTrafficManager extends TestTemplate<TrafficManagerProfile, Traf
                 .withHttpMonitoring()
                 .create();
 
-        Assert.assertTrue(profile.isEnabled());
-        Assert.assertNotNull(profile.monitorStatus());
-        Assert.assertEquals(profile.monitoringPort(), 80);
-        Assert.assertEquals(profile.monitoringPath(), "/");
-        Assert.assertEquals(profile.azureEndpoints().size(), 1);
-        Assert.assertEquals(profile.nestedProfileEndpoints().size(), 1);
-        Assert.assertEquals(profile.externalEndpoints().size(), 2);
-        Assert.assertEquals(profile.fqdn(), tmProfileDnsLabel + ".trafficmanager.net");
-        Assert.assertEquals(profile.timeToLive(), 300); // Default
+        Assertions.assertTrue(profile.isEnabled());
+        Assertions.assertNotNull(profile.monitorStatus());
+        Assertions.assertEquals(profile.monitoringPort(), 80);
+        Assertions.assertEquals(profile.monitoringPath(), "/");
+        Assertions.assertEquals(profile.azureEndpoints().size(), 1);
+        Assertions.assertEquals(profile.nestedProfileEndpoints().size(), 1);
+        Assertions.assertEquals(profile.externalEndpoints().size(), 2);
+        Assertions.assertEquals(profile.fqdn(), tmProfileDnsLabel + ".trafficmanager.net");
+        Assertions.assertEquals(profile.timeToLive(), 300); // Default
 
         profile = profile.refresh();
-        Assert.assertEquals(profile.azureEndpoints().size(), 1);
-        Assert.assertEquals(profile.nestedProfileEndpoints().size(), 1);
-        Assert.assertEquals(profile.externalEndpoints().size(), 2);
+        Assertions.assertEquals(profile.azureEndpoints().size(), 1);
+        Assertions.assertEquals(profile.nestedProfileEndpoints().size(), 1);
+        Assertions.assertEquals(profile.externalEndpoints().size(), 2);
 
         int c = 0;
         for (TrafficManagerExternalEndpoint endpoint : profile.externalEndpoints().values()) {
-            Assert.assertEquals(endpoint.endpointType(), EndpointType.EXTERNAL);
+            Assertions.assertEquals(endpoint.endpointType(), EndpointType.EXTERNAL);
             if (endpoint.name().equalsIgnoreCase(externalEndpointName21)) {
-                Assert.assertEquals(endpoint.routingPriority(), 1);
-                Assert.assertEquals(endpoint.fqdn(), externalFqdn21);
-                Assert.assertNotNull(endpoint.monitorStatus());
-                Assert.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST);
+                Assertions.assertEquals(endpoint.routingPriority(), 1);
+                Assertions.assertEquals(endpoint.fqdn(), externalFqdn21);
+                Assertions.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST);
                 c++;
             } else if (endpoint.name().equalsIgnoreCase(externalEndpointName22)) {
-                Assert.assertEquals(endpoint.routingPriority(), 2);
-                Assert.assertEquals(endpoint.fqdn(), externalFqdn22);
-                Assert.assertNotNull(endpoint.monitorStatus());
-                Assert.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST2);
+                Assertions.assertEquals(endpoint.routingPriority(), 2);
+                Assertions.assertEquals(endpoint.fqdn(), externalFqdn22);
+                Assertions.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST2);
                 c++;
             }
         }
-        Assert.assertEquals(c, 2);
+        Assertions.assertEquals(c, 2);
 
         c = 0;
         for (TrafficManagerAzureEndpoint endpoint : profile.azureEndpoints().values()) {
-            Assert.assertEquals(endpoint.endpointType(), EndpointType.AZURE);
+            Assertions.assertEquals(endpoint.endpointType(), EndpointType.AZURE);
             if (endpoint.name().equalsIgnoreCase(azureEndpointName)) {
-                Assert.assertEquals(endpoint.routingPriority(), 3);
-                Assert.assertNotNull(endpoint.monitorStatus());
-                Assert.assertEquals(endpoint.targetAzureResourceId(), publicIPAddress.id());
-                Assert.assertEquals(endpoint.targetResourceType(), TargetAzureResourceType.PUBLICIP);
+                Assertions.assertEquals(endpoint.routingPriority(), 3);
+                Assertions.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.targetAzureResourceId(), publicIPAddress.id());
+                Assertions.assertEquals(endpoint.targetResourceType(), TargetAzureResourceType.PUBLICIP);
                 c++;
             }
         }
-        Assert.assertEquals(c, 1);
+        Assertions.assertEquals(c, 1);
 
         c = 0;
         for (TrafficManagerNestedProfileEndpoint endpoint : profile.nestedProfileEndpoints().values()) {
-            Assert.assertEquals(endpoint.endpointType(), EndpointType.NESTED_PROFILE);
+            Assertions.assertEquals(endpoint.endpointType(), EndpointType.NESTED_PROFILE);
             if (endpoint.name().equalsIgnoreCase(nestedProfileEndpointName)) {
-                Assert.assertEquals(endpoint.routingPriority(), 4);
-                Assert.assertNotNull(endpoint.monitorStatus());
-                Assert.assertEquals(endpoint.minimumChildEndpointCount(), 1);
-                Assert.assertEquals(endpoint.nestedProfileId(), nestedProfile.id());
-                Assert.assertEquals(endpoint.sourceTrafficLocation(), Region.INDIA_CENTRAL);
+                Assertions.assertEquals(endpoint.routingPriority(), 4);
+                Assertions.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.minimumChildEndpointCount(), 1);
+                Assertions.assertEquals(endpoint.nestedProfileId(), nestedProfile.id());
+                Assertions.assertEquals(endpoint.sourceTrafficLocation(), Region.INDIA_CENTRAL);
                 c++;
             }
         }
-        Assert.assertEquals(c, 1);
+        Assertions.assertEquals(c, 1);
         return profile;
     }
 
@@ -249,45 +249,45 @@ public class TestTrafficManager extends TestTemplate<TrafficManagerProfile, Traf
                     .attach()
                 .apply();
 
-        Assert.assertEquals(profile.monitoringPort(), 8080);
-        Assert.assertEquals(profile.monitoringPath(), "/");
-        Assert.assertEquals(profile.azureEndpoints().size(), 1);
-        Assert.assertEquals(profile.nestedProfileEndpoints().size(), 1);
-        Assert.assertEquals(profile.externalEndpoints().size(), 2);
-        Assert.assertEquals(profile.timeToLive(), 600);
+        Assertions.assertEquals(profile.monitoringPort(), 8080);
+        Assertions.assertEquals(profile.monitoringPath(), "/");
+        Assertions.assertEquals(profile.azureEndpoints().size(), 1);
+        Assertions.assertEquals(profile.nestedProfileEndpoints().size(), 1);
+        Assertions.assertEquals(profile.externalEndpoints().size(), 2);
+        Assertions.assertEquals(profile.timeToLive(), 600);
 
         int c = 0;
         for (TrafficManagerExternalEndpoint endpoint : profile.externalEndpoints().values()) {
-            Assert.assertEquals(endpoint.endpointType(), EndpointType.EXTERNAL);
+            Assertions.assertEquals(endpoint.endpointType(), EndpointType.EXTERNAL);
              if (endpoint.name().equalsIgnoreCase(externalEndpointName22)) {
-                Assert.assertEquals(endpoint.routingPriority(), 2);
-                Assert.assertEquals(endpoint.fqdn(), externalFqdn22);
-                Assert.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST2);
-                Assert.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.routingPriority(), 2);
+                Assertions.assertEquals(endpoint.fqdn(), externalFqdn22);
+                Assertions.assertEquals(endpoint.sourceTrafficLocation(), Region.US_EAST2);
+                Assertions.assertNotNull(endpoint.monitorStatus());
                 c++;
             } else if (endpoint.name().equalsIgnoreCase(externalEndpointName23)) {
-                Assert.assertEquals(endpoint.routingPriority(), 6);
-                Assert.assertEquals(endpoint.fqdn(), externalFqdn23);
-                Assert.assertNotNull(endpoint.monitorStatus());
-                Assert.assertEquals(endpoint.sourceTrafficLocation(), Region.US_CENTRAL);
+                Assertions.assertEquals(endpoint.routingPriority(), 6);
+                Assertions.assertEquals(endpoint.fqdn(), externalFqdn23);
+                Assertions.assertNotNull(endpoint.monitorStatus());
+                Assertions.assertEquals(endpoint.sourceTrafficLocation(), Region.US_CENTRAL);
                 c++;
             } else {
                 c++;
             }
         }
-        Assert.assertEquals(c, 2);
+        Assertions.assertEquals(c, 2);
 
         c = 0;
         for (TrafficManagerAzureEndpoint endpoint : profile.azureEndpoints().values()) {
-            Assert.assertEquals(endpoint.endpointType(), EndpointType.AZURE);
+            Assertions.assertEquals(endpoint.endpointType(), EndpointType.AZURE);
             if (endpoint.name().equalsIgnoreCase(azureEndpointName)) {
-                Assert.assertEquals(endpoint.routingPriority(), 5);
-                Assert.assertEquals(endpoint.routingWeight(), 2);
-                Assert.assertEquals(endpoint.targetResourceType(), TargetAzureResourceType.PUBLICIP);
+                Assertions.assertEquals(endpoint.routingPriority(), 5);
+                Assertions.assertEquals(endpoint.routingWeight(), 2);
+                Assertions.assertEquals(endpoint.targetResourceType(), TargetAzureResourceType.PUBLICIP);
                 c++;
             }
         }
-        Assert.assertEquals(c, 1);
+        Assertions.assertEquals(c, 1);
         return profile;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachine.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachine.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.azure.management;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.azure.management.compute.Disk;
@@ -50,13 +50,13 @@ public class TestVirtualMachine extends TestTemplate<VirtualMachine, VirtualMach
                 });
         vms[0] = future.get();
 
-        Assert.assertEquals(1, vms[0].dataDisks().size());
+        Assertions.assertEquals(1, vms[0].dataDisks().size());
         VirtualMachineDataDisk dataDisk = vms[0].dataDisks().values().iterator().next();
-        Assert.assertEquals(150, dataDisk.size());
-        Assert.assertEquals(128, vms[0].osDiskSize());
+        Assertions.assertEquals(150, dataDisk.size());
+        Assertions.assertEquals(128, vms[0].osDiskSize());
         Disk osDisk = virtualMachines.manager().disks().getById(vms[0].osDiskId());
-        Assert.assertNotNull(osDisk);
-        Assert.assertEquals(128, osDisk.sizeInGB());
+        Assertions.assertNotNull(osDisk);
+        Assertions.assertEquals(128, osDisk.sizeInGB());
 
         return vms[0];
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineCustomData.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineCustomData.java
@@ -19,7 +19,7 @@ import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -66,7 +66,7 @@ public class TestVirtualMachineCustomData extends TestTemplate<VirtualMachine, V
                 .create();
 
         pip.refresh();
-        Assert.assertTrue(pip.hasAssignedNetworkInterface());
+        Assertions.assertTrue(pip.hasAssignedNetworkInterface());
 
         if (TestBase.isRecordMode()) {
             JSch jsch = new JSch();
@@ -89,10 +89,10 @@ public class TestVirtualMachineCustomData extends TestTemplate<VirtualMachine, V
 
                 String msg;
                 while ((msg = in.readLine()) != null) {
-                    Assert.assertFalse(msg.startsWith("The program 'pwgen' is currently not installed"));
+                    Assertions.assertFalse(msg.startsWith("The program 'pwgen' is currently not installed"));
                 }
             } catch (Exception e) {
-                Assert.fail("SSH connection failed" + e.getMessage());
+                Assertions.fail("SSH connection failed" + e.getMessage());
             } finally {
                 if (channel != null) {
                     channel.disconnect();

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineDataDisk.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineDataDisk.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.management.compute.VirtualMachines;
 import com.microsoft.azure.management.compute.CachingTypes;
 import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestVirtualMachineDataDisk extends TestTemplate<VirtualMachine, VirtualMachines> {
     @Override
@@ -37,8 +37,8 @@ public class TestVirtualMachineDataDisk extends TestTemplate<VirtualMachine, Vir
                 .withSize(VirtualMachineSizeTypes.STANDARD_A8)
                 .create();
 
-        Assert.assertTrue(virtualMachine.size().equals(VirtualMachineSizeTypes.STANDARD_A8));
-        Assert.assertTrue(virtualMachine.unmanagedDataDisks().size() == 2);
+        Assertions.assertTrue(virtualMachine.size().equals(VirtualMachineSizeTypes.STANDARD_A8));
+        Assertions.assertTrue(virtualMachine.unmanagedDataDisks().size() == 2);
         VirtualMachineUnmanagedDataDisk disk2 = null;
         for (VirtualMachineUnmanagedDataDisk dataDisk : virtualMachine.unmanagedDataDisks().values()) {
             if (dataDisk.name().equalsIgnoreCase("disk2")) {
@@ -46,9 +46,9 @@ public class TestVirtualMachineDataDisk extends TestTemplate<VirtualMachine, Vir
                 break;
             }
         }
-        Assert.assertNotNull(disk2);
-        Assert.assertTrue(disk2.cachingType() == CachingTypes.READ_ONLY);
-        Assert.assertTrue(disk2.size() == 20);
+        Assertions.assertNotNull(disk2);
+        Assertions.assertTrue(disk2.cachingType() == CachingTypes.READ_ONLY);
+        Assertions.assertTrue(disk2.size() == 20);
         return virtualMachine;
     }
 
@@ -61,7 +61,7 @@ public class TestVirtualMachineDataDisk extends TestTemplate<VirtualMachine, Vir
                     .withLun(2)
                     .attach()
                 .apply();
-        Assert.assertTrue(virtualMachine.unmanagedDataDisks().size() == 2);
+        Assertions.assertTrue(virtualMachine.unmanagedDataDisks().size() == 2);
         VirtualMachineUnmanagedDataDisk disk3 = null;
         for (VirtualMachineUnmanagedDataDisk dataDisk : virtualMachine.unmanagedDataDisks().values()) {
             if (dataDisk.name().equalsIgnoreCase("disk3")) {
@@ -69,9 +69,9 @@ public class TestVirtualMachineDataDisk extends TestTemplate<VirtualMachine, Vir
                 break;
             }
         }
-        Assert.assertNotNull(disk3);
-        Assert.assertTrue(disk3.cachingType() == CachingTypes.READ_WRITE);
-        Assert.assertTrue(disk3.size() == 10);
+        Assertions.assertNotNull(disk3);
+        Assertions.assertTrue(disk3.cachingType() == CachingTypes.READ_WRITE);
+        Assertions.assertTrue(disk3.size() == 10);
         return virtualMachine;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineInAvailabilitySet.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineInAvailabilitySet.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
 import com.microsoft.azure.management.compute.VirtualMachines;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestVirtualMachineInAvailabilitySet extends TestTemplate<VirtualMachine, VirtualMachines> {
     @Override
@@ -35,9 +35,9 @@ public class TestVirtualMachineInAvailabilitySet extends TestTemplate<VirtualMac
                 .withNewAvailabilitySet(newAvailSetName)
                 .create();
 
-        Assert.assertNotNull(vm.availabilitySetId());
-        Assert.assertNotNull(vm.computerName());
-        Assert.assertTrue(vm.computerName().equalsIgnoreCase("myvm123"));
+        Assertions.assertNotNull(vm.availabilitySetId());
+        Assertions.assertNotNull(vm.computerName());
+        Assertions.assertTrue(vm.computerName().equalsIgnoreCase("myvm123"));
         return vm;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineNics.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineNics.java
@@ -18,7 +18,7 @@ import com.azure.management.resources.ResourceGroup;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.model.Creatable;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestVirtualMachineNics extends TestTemplate<VirtualMachine, VirtualMachines> {
     private final NetworkManager networkManager;
@@ -80,12 +80,12 @@ public class TestVirtualMachineNics extends TestTemplate<VirtualMachine, Virtual
                 .withNewSecondaryNetworkInterface(secondaryNetworkInterfaceCreatable2)
                 .create();
 
-        Assert.assertTrue(virtualMachine.networkInterfaceIds().size() == 3);
+        Assertions.assertTrue(virtualMachine.networkInterfaceIds().size() == 3);
         NetworkInterface primaryNetworkInterface = virtualMachine.getPrimaryNetworkInterface();
-        Assert.assertEquals(primaryNetworkInterface.primaryPrivateIP(), "10.0.0.4");
+        Assertions.assertEquals(primaryNetworkInterface.primaryPrivateIP(), "10.0.0.4");
 
         PublicIPAddress primaryPublicIPAddress = primaryNetworkInterface.primaryIPConfiguration().getPublicIPAddress();
-        Assert.assertTrue(primaryPublicIPAddress.fqdn().startsWith(primaryPipName));
+        Assertions.assertTrue(primaryPublicIPAddress.fqdn().startsWith(primaryPipName));
         return virtualMachine;
     }
 
@@ -98,7 +98,7 @@ public class TestVirtualMachineNics extends TestTemplate<VirtualMachine, Virtual
                 .withoutSecondaryNetworkInterface(secondaryNicName)
                 .apply();
 
-        Assert.assertTrue(virtualMachine.networkInterfaceIds().size() == 2);
+        Assertions.assertTrue(virtualMachine.networkInterfaceIds().size() == 2);
         return virtualMachine;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineSizes.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineSizes.java
@@ -11,7 +11,7 @@ import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.compute.VirtualMachines;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class TestVirtualMachineSizes extends TestTemplate<VirtualMachine, Virtua
     @Override
     public VirtualMachine createResource(VirtualMachines virtualMachines) throws Exception {
         List<VirtualMachineSize> availableSizes = virtualMachines.sizes().listByRegion(Region.US_EAST);
-        Assert.assertTrue(availableSizes.size() > 0);
+        Assertions.assertTrue(availableSizes.size() > 0);
         System.out.println("VM Sizes: " + availableSizes);
         final String vmName = "vm" + this.testId;
         VirtualMachine vm = virtualMachines.define(vmName)
@@ -34,14 +34,14 @@ public class TestVirtualMachineSizes extends TestTemplate<VirtualMachine, Virtua
                 .withSize(availableSizes.get(0).name()) // Use the first size
                 .create();
 
-        Assert.assertTrue(vm.size().toString().equalsIgnoreCase(availableSizes.get(0).name()));
+        Assertions.assertTrue(vm.size().toString().equalsIgnoreCase(availableSizes.get(0).name()));
         return vm;
     }
 
     @Override
     public VirtualMachine updateResource(VirtualMachine virtualMachine) throws Exception {
         List<VirtualMachineSize> resizableSizes = virtualMachine.availableSizes();
-        Assert.assertTrue(resizableSizes.size() > 1);
+        Assertions.assertTrue(resizableSizes.size() > 1);
         VirtualMachineSize newSize = null;
         for (VirtualMachineSize resizableSize : resizableSizes) {
             if (!resizableSize.name().equalsIgnoreCase(virtualMachine.size().toString())) {
@@ -49,12 +49,12 @@ public class TestVirtualMachineSizes extends TestTemplate<VirtualMachine, Virtua
                 break;
             }
         }
-        Assert.assertNotNull(newSize);
+        Assertions.assertNotNull(newSize);
         virtualMachine = virtualMachine.update()
                 .withSize(newSize.name())
                 .apply();
 
-        Assert.assertTrue(virtualMachine.size().toString().equalsIgnoreCase(newSize.name()));
+        Assertions.assertTrue(virtualMachine.size().toString().equalsIgnoreCase(newSize.name()));
         return virtualMachine;
     }
 

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineSsh.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualMachineSsh.java
@@ -16,7 +16,7 @@ import com.microsoft.azure.management.network.PublicIPAddresses;
 import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
 import com.azure.management.resources.core.TestBase;
 import com.azure.management.resources.fluentcore.arm.Region;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class TestVirtualMachineSsh extends TestTemplate<VirtualMachine, VirtualMachines> {
     final PublicIPAddresses pips;
@@ -49,7 +49,7 @@ public class TestVirtualMachineSsh extends TestTemplate<VirtualMachine, VirtualM
                 .create();
 
         pip.refresh();
-        Assert.assertTrue(pip.hasAssignedNetworkInterface());
+        Assertions.assertTrue(pip.hasAssignedNetworkInterface());
 
         JSch jsch= new JSch();
         Session session = null;
@@ -63,15 +63,15 @@ public class TestVirtualMachineSsh extends TestTemplate<VirtualMachine, VirtualM
                 session.setConfig(config);
                 session.connect();
             } catch (Exception e) {
-                Assert.fail("SSH connection failed" + e.getMessage());
+                Assertions.fail("SSH connection failed" + e.getMessage());
             } finally {
                 if (session != null) {
                     session.disconnect();
                 }
             }
 
-            Assert.assertNotNull(vm.inner().osProfile().linuxConfiguration().ssh());
-            Assert.assertTrue(vm.inner().osProfile().linuxConfiguration().ssh().publicKeys().size() > 0);
+            Assertions.assertNotNull(vm.inner().osProfile().linuxConfiguration().ssh());
+            Assertions.assertTrue(vm.inner().osProfile().linuxConfiguration().ssh().publicKeys().size() > 0);
         }
         return vm;
     }

--- a/azure/src/test/java/com/microsoft/azure/management/TestVirtualNetworkGateway.java
+++ b/azure/src/test/java/com/microsoft/azure/management/TestVirtualNetworkGateway.java
@@ -15,7 +15,7 @@ import com.microsoft.azure.management.network.VirtualNetworkGateways;
 import com.microsoft.azure.management.network.implementation.NetworkManager;
 import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -82,8 +82,8 @@ public class TestVirtualNetworkGateway {
                     .withoutTag("tag1")
                     .apply();
             resource.refresh();
-            Assert.assertTrue(resource.tags().containsKey("tag2"));
-            Assert.assertTrue(!resource.tags().containsKey("tag1"));
+            Assertions.assertTrue(resource.tags().containsKey("tag2"));
+            Assertions.assertTrue(!resource.tags().containsKey("tag1"));
 
             Map<String, String> tagsMap = new HashMap<>();
             tagsMap.put("tag3", "value3");
@@ -91,8 +91,8 @@ public class TestVirtualNetworkGateway {
             resource.updateTags()
                     .withTags(tagsMap)
                     .applyTags();
-            Assert.assertEquals(2, resource.tags().size());
-            Assert.assertEquals("value4", resource.tags().get("tag4"));
+            Assertions.assertEquals(2, resource.tags().size());
+            Assertions.assertEquals("value4", resource.tags().get("tag4"));
             return resource;
         }
     }
@@ -139,23 +139,23 @@ public class TestVirtualNetworkGateway {
                     .withTag("tag1", "value1")
                     .create();
 
-            Assert.assertEquals(1, vngw.ipConfigurations().size());
+            Assertions.assertEquals(1, vngw.ipConfigurations().size());
             Subnet subnet = vngw.ipConfigurations().iterator().next().getSubnet();
-            Assert.assertEquals("10.0.0.0/27", subnet.addressPrefix());
-            Assert.assertTrue(vngw.isBgpEnabled());
-            Assert.assertEquals("10.12.255.30", vngw.bgpSettings().bgpPeeringAddress());
+            Assertions.assertEquals("10.0.0.0/27", subnet.addressPrefix());
+            Assertions.assertTrue(vngw.isBgpEnabled());
+            Assertions.assertEquals("10.12.255.30", vngw.bgpSettings().bgpPeeringAddress());
 
-            Assert.assertEquals("40.71.184.214", lngw.ipAddress());
-            Assert.assertEquals(1, lngw.addressSpaces().size());
-            Assert.assertEquals("192.168.3.0/24", lngw.addressSpaces().iterator().next());
-            Assert.assertNotNull(lngw.bgpSettings());
-            Assert.assertEquals("10.51.255.254", lngw.bgpSettings().bgpPeeringAddress());
+            Assertions.assertEquals("40.71.184.214", lngw.ipAddress());
+            Assertions.assertEquals(1, lngw.addressSpaces().size());
+            Assertions.assertEquals("192.168.3.0/24", lngw.addressSpaces().iterator().next());
+            Assertions.assertNotNull(lngw.bgpSettings());
+            Assertions.assertEquals("10.51.255.254", lngw.bgpSettings().bgpPeeringAddress());
 
             List<VirtualNetworkGatewayConnection> connections = vngw.listConnections();
-            Assert.assertEquals(1, connections.size());
-            Assert.assertEquals(vngw.id(), connections.get(0).virtualNetworkGateway1Id());
-            Assert.assertEquals(lngw.id(), connections.get(0).localNetworkGateway2Id());
-            Assert.assertEquals("value1", connection.tags().get("tag1"));
+            Assertions.assertEquals(1, connections.size());
+            Assertions.assertEquals(vngw.id(), connections.get(0).virtualNetworkGateway1Id());
+            Assertions.assertEquals(lngw.id(), connections.get(0).localNetworkGateway2Id());
+            Assertions.assertEquals("value1", connection.tags().get("tag1"));
 
             return vngw;
         }
@@ -163,22 +163,22 @@ public class TestVirtualNetworkGateway {
         @Override
         public VirtualNetworkGateway updateResource(VirtualNetworkGateway resource) throws Exception {
             VirtualNetworkGatewayConnection connection = resource.connections().getByName(CONNECTION_NAME);
-            Assert.assertFalse(connection.isBgpEnabled());
+            Assertions.assertFalse(connection.isBgpEnabled());
             connection.update()
                     .withBgp()
                     .apply();
-            Assert.assertTrue(connection.isBgpEnabled());
+            Assertions.assertTrue(connection.isBgpEnabled());
 
             resource.connections().deleteByName(CONNECTION_NAME);
             List<VirtualNetworkGatewayConnection> connections = resource.listConnections();
-            Assert.assertEquals(0, connections.size());
+            Assertions.assertEquals(0, connections.size());
 
             resource.updateTags()
                     .withTag("tag3", "value3")
                     .withoutTag("tag1")
                     .applyTags();
-            Assert.assertEquals("value3", resource.tags().get("tag3"));
-            Assert.assertFalse(resource.tags().containsKey("tag1"));
+            Assertions.assertEquals("value3", resource.tags().get("tag3"));
+            Assertions.assertFalse(resource.tags().containsKey("tag1"));
 
             return resource;
         }
@@ -244,9 +244,9 @@ public class TestVirtualNetworkGateway {
                     .withSharedKey("MySecretKey")
                     .create();
             List<VirtualNetworkGatewayConnection> connections = vngw1.listConnections();
-            Assert.assertEquals(1, connections.size());
-            Assert.assertEquals(vngw1.id(), connections.get(0).virtualNetworkGateway1Id());
-            Assert.assertEquals(vngw2.id(), connections.get(0).virtualNetworkGateway2Id());
+            Assertions.assertEquals(1, connections.size());
+            Assertions.assertEquals(vngw1.id(), connections.get(0).virtualNetworkGateway1Id());
+            Assertions.assertEquals(vngw2.id(), connections.get(0).virtualNetworkGateway2Id());
             return vngw1;
         }
 
@@ -254,7 +254,7 @@ public class TestVirtualNetworkGateway {
         public VirtualNetworkGateway updateResource(VirtualNetworkGateway resource) throws Exception {
             resource.connections().deleteByName(CONNECTION_NAME);
             List<VirtualNetworkGatewayConnection> connections = resource.listConnections();
-            Assert.assertEquals(0, connections.size());
+            Assertions.assertEquals(0, connections.size());
             return resource;
         }
     }
@@ -303,10 +303,10 @@ public class TestVirtualNetworkGateway {
                         .attach()
                     .apply();
 
-            Assert.assertNotNull(vngw1.vpnClientConfiguration());
-            Assert.assertEquals("172.16.201.0/24", vngw1.vpnClientConfiguration().vpnClientAddressPool().addressPrefixes().get(0));
-            Assert.assertEquals(1, vngw1.vpnClientConfiguration().vpnClientRootCertificates().size());
-            Assert.assertEquals(CERTIFICATE_NAME, vngw1.vpnClientConfiguration().vpnClientRootCertificates().get(0).name());
+            Assertions.assertNotNull(vngw1.vpnClientConfiguration());
+            Assertions.assertEquals("172.16.201.0/24", vngw1.vpnClientConfiguration().vpnClientAddressPool().addressPrefixes().get(0));
+            Assertions.assertEquals(1, vngw1.vpnClientConfiguration().vpnClientRootCertificates().size());
+            Assertions.assertEquals(CERTIFICATE_NAME, vngw1.vpnClientConfiguration().vpnClientRootCertificates().get(0).name());
             String profile = vngw1.generateVpnProfile();
             System.out.println(profile);
             return vngw1;
@@ -318,13 +318,13 @@ public class TestVirtualNetworkGateway {
                     .withRevokedCertificate(CERTIFICATE_NAME, "bdf834528f0fff6eaae4c154e06b54322769276c")
                     .parent()
                     .apply();
-            Assert.assertEquals(CERTIFICATE_NAME, vngw1.vpnClientConfiguration().vpnClientRevokedCertificates().get(0).name());
+            Assertions.assertEquals(CERTIFICATE_NAME, vngw1.vpnClientConfiguration().vpnClientRevokedCertificates().get(0).name());
 
             vngw1.update().updatePointToSiteConfiguration()
                     .withoutAzureCertificate(CERTIFICATE_NAME)
                     .parent()
                     .apply();
-            Assert.assertEquals(0, vngw1.vpnClientConfiguration().vpnClientRootCertificates().size());
+            Assertions.assertEquals(0, vngw1.vpnClientConfiguration().vpnClientRootCertificates().size());
             return vngw1;
         }
     }

--- a/azure/src/test/java/com/microsoft/azure/management/VirtualNetworkGatewayTests.java
+++ b/azure/src/test/java/com/microsoft/azure/management/VirtualNetworkGatewayTests.java
@@ -15,9 +15,9 @@ import com.azure.management.resources.fluentcore.arm.Region;
 import com.azure.management.resources.fluentcore.utils.SdkContext;
 import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.rest.RestClient;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class VirtualNetworkGatewayTests extends TestBase {
     private Azure azure;
@@ -33,7 +33,7 @@ public class VirtualNetworkGatewayTests extends TestBase {
     }
 
     @Test
-    @Ignore("Service has bug that cause 'InternalServerError' - record this once service is fixed")
+    @Disabled("Service has bug that cause 'InternalServerError' - record this once service is fixed")
     //
 
     public void testNetworkWatcherTroubleshooting() throws Exception {
@@ -79,7 +79,7 @@ public class VirtualNetworkGatewayTests extends TestBase {
                 .withStorageAccount(storageAccount.id())
                 .withStoragePath(storageAccount.endPoints().primary().blob() + "results")
                 .execute();
-        Assert.assertEquals("UnHealthy", troubleshooting.code());
+        Assertions.assertEquals("UnHealthy", troubleshooting.code());
 
         // Create corresponding connection on second gateway to make it work
         vngw2.connections()
@@ -94,7 +94,7 @@ public class VirtualNetworkGatewayTests extends TestBase {
                 .withStorageAccount(storageAccount.id())
                 .withStoragePath(storageAccount.endPoints().primary().blob() + "results")
                 .execute();
-        Assert.assertEquals("Healthy", troubleshooting.code());
+        Assertions.assertEquals("Healthy", troubleshooting.code());
 
         azure.resourceGroups().deleteByName(resourceGroup);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
                 <version>4.1.0</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13-rc-2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.6.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Api changed: https://junit.org/junit5/docs/5.4.0-RC2/user-guide/index.html#migrating-from-junit4-tips
Concurrency: 32 threads per module, could be changed in properties

After I run record, it seems the providers.getByName will return null