### PR TITLE
fix security

### DIFF
--- a/azure-mgmt-cosmosdb/pom.xml
+++ b/azure-mgmt-cosmosdb/pom.xml
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.microsoft.azure</groupId>
@@ -142,7 +142,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.24</version>
+                        <version>8.29</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.4</version>
+        <version>2.9.10</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.4</version>
+        <version>2.9.10.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.10</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <dependencies>
           <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -196,7 +196,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.24</version>
+            <version>8.29</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
Bump jackson-databind from 2.9.4 to 2.9.10.3  dependencies
Bump checkstyle from 8.24 to 8.29 in /azure-mgmt-cosmosdb  dependencies
