### PR TITLE
Fix for update Azure Active Directory account password

### DIFF
--- a/azure-mgmt-graph-rbac/src/main/java/com/microsoft/azure/management/graphrbac/implementation/ActiveDirectoryUserImpl.java
+++ b/azure-mgmt-graph-rbac/src/main/java/com/microsoft/azure/management/graphrbac/implementation/ActiveDirectoryUserImpl.java
@@ -101,6 +101,7 @@ class ActiveDirectoryUserImpl
     @Override
     public ActiveDirectoryUserImpl withPassword(String password) {
         createParameters.withPasswordProfile(new PasswordProfile().withPassword(password));
+        updateParameters.withPasswordProfile(new PasswordProfile().withPassword(password));
         return this;
     }
 
@@ -163,6 +164,7 @@ class ActiveDirectoryUserImpl
     @Override
     public ActiveDirectoryUserImpl withPromptToChangePasswordOnLogin(boolean promptToChangePasswordOnLogin) {
         createParameters.passwordProfile().withForceChangePasswordNextLogin(promptToChangePasswordOnLogin);
+        updateParameters.passwordProfile().withForceChangePasswordNextLogin(promptToChangePasswordOnLogin);
         return this;
     }
 


### PR DESCRIPTION
I tried to update an AAD user password using the following code
```
ActiveDirectoryUser user = activeDirectoryUser.update()
              .withPassword(new String(password, StandardCharsets.UTF_8))
              .withPromptToChangePasswordOnLogin(false)
              .withAccountEnabled(true)
              .apply();
```
and the password was not updated.

It seems that the PATCH request to Microsoft Graph API used to update the user password is missing the password field. 

This was the request body

`{"accountEnabled":true,"displayName":"florin-test Service Account"}`

This is the new request body

`{"accountEnabled":true,"displayName":"florin-test Service Account","passwordProfile":{"password":"new-pass","forceChangePasswordNextLogin":false}}`

I also have an Azure Ticket: **120031822000981**