### PR TITLE
feat: deprecate getAccessProfile api

### DIFF
--- a/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
+++ b/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
@@ -168,7 +168,7 @@ public class KubernetesClustersImpl extends
                 public byte[] call(CredentialResultsInner credentialInner) {
                     if (credentialInner == null
                             || credentialInner.kubeconfigs() == null
-                            || credentialInner.kubeconfigs().size() == 0) {
+                            || credentialInner.kubeconfigs().isEmpty()) {
                         return new byte[0];
                     } else {
                         return credentialInner.kubeconfigs().get(0).value();
@@ -191,7 +191,7 @@ public class KubernetesClustersImpl extends
                 public byte[] call(CredentialResultsInner credentialInner) {
                     if (credentialInner == null
                         || credentialInner.kubeconfigs() == null
-                        || credentialInner.kubeconfigs().size() == 0) {
+                        || credentialInner.kubeconfigs().isEmpty()) {
                         return new byte[0];
                     } else {
                         return credentialInner.kubeconfigs().get(0).value();

--- a/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
+++ b/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.management.containerservice.implementation;
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.apigeneration.LangDefinition;
 import com.microsoft.azure.management.containerservice.KubernetesCluster;
-import com.microsoft.azure.management.containerservice.KubernetesClusterAccessProfileRole;
 import com.microsoft.azure.management.containerservice.KubernetesClusters;
 import com.microsoft.azure.management.containerservice.OrchestratorVersionProfile;
 import com.microsoft.azure.management.resources.ResourceGroup;

--- a/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
+++ b/azure-mgmt-containerservice/src/main/java/com/microsoft/azure/management/containerservice/implementation/KubernetesClustersImpl.java
@@ -157,25 +157,22 @@ public class KubernetesClustersImpl extends
 
     @Override
     public byte[] getAdminKubeConfigContent(String resourceGroupName, String kubernetesClusterName) {
-        ManagedClusterAccessProfileInner profileInner = this.manager().inner().managedClusters().getAccessProfile(resourceGroupName, kubernetesClusterName, KubernetesClusterAccessProfileRole.ADMIN.toString());
-        if (profileInner == null) {
-            return new byte[0];
-        } else {
-            return profileInner.kubeConfig();
-        }
+        return this.getAdminKubeConfigContentAsync(resourceGroupName, kubernetesClusterName).toBlocking().last();
     }
 
     @Override
     public Observable<byte[]> getAdminKubeConfigContentAsync(String resourceGroupName, String kubernetesClusterName) {
         return this.manager().inner().managedClusters()
-            .getAccessProfileAsync(resourceGroupName, kubernetesClusterName, KubernetesClusterAccessProfileRole.ADMIN.toString())
-            .map(new Func1<ManagedClusterAccessProfileInner, byte[]>() {
+            .listClusterAdminCredentialsAsync(resourceGroupName, kubernetesClusterName)
+            .map(new Func1<CredentialResultsInner, byte[]>() {
                 @Override
-                public byte[] call(ManagedClusterAccessProfileInner profileInner) {
-                    if (profileInner == null) {
+                public byte[] call(CredentialResultsInner credentialInner) {
+                    if (credentialInner == null
+                            || credentialInner.kubeconfigs() == null
+                            || credentialInner.kubeconfigs().size() == 0) {
                         return new byte[0];
                     } else {
-                        return profileInner.kubeConfig();
+                        return credentialInner.kubeconfigs().get(0).value();
                     }
                 }
             });
@@ -183,25 +180,22 @@ public class KubernetesClustersImpl extends
 
     @Override
     public byte[] getUserKubeConfigContent(String resourceGroupName, String kubernetesClusterName) {
-        ManagedClusterAccessProfileInner profileInner = this.manager().inner().managedClusters().getAccessProfile(resourceGroupName, kubernetesClusterName, KubernetesClusterAccessProfileRole.USER.toString());
-        if (profileInner == null) {
-            return new byte[0];
-        } else {
-            return profileInner.kubeConfig();
-        }
+        return this.getUserKubeConfigContentAsync(resourceGroupName, kubernetesClusterName).toBlocking().last();
     }
 
     @Override
     public Observable<byte[]> getUserKubeConfigContentAsync(String resourceGroupName, String kubernetesClusterName) {
         return this.manager().inner().managedClusters()
-            .getAccessProfileAsync(resourceGroupName, kubernetesClusterName, KubernetesClusterAccessProfileRole.USER.toString())
-            .map(new Func1<ManagedClusterAccessProfileInner, byte[]>() {
+            .listClusterUserCredentialsAsync(resourceGroupName, kubernetesClusterName)
+            .map(new Func1<CredentialResultsInner, byte[]>() {
                 @Override
-                public byte[] call(ManagedClusterAccessProfileInner profileInner) {
-                    if (profileInner == null) {
+                public byte[] call(CredentialResultsInner credentialInner) {
+                    if (credentialInner == null
+                        || credentialInner.kubeconfigs() == null
+                        || credentialInner.kubeconfigs().size() == 0) {
                         return new byte[0];
                     } else {
-                        return profileInner.kubeConfig();
+                        return credentialInner.kubeconfigs().get(0).value();
                     }
                 }
             });

--- a/azure-mgmt-containerservice/src/test/resources/session-records/canCRUDKubernetesCluster.json
+++ b/azure-mgmt-containerservice/src/test/resources/session-records/canCRUDKubernetesCluster.json
@@ -1,13 +1,13 @@
 {
   "networkCallRecords" : [ {
     "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ResourceManagementClient, 2019-08-01)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:40:49 GMT",
+      "date" : "Thu, 26 Mar 2020 02:07:06 GMT",
       "content-length" : "309",
       "expires" : "-1",
       "x-ms-ratelimit-remaining-subscription-writes" : "1199",
@@ -15,24 +15,25 @@
       "StatusCode" : "201",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "3147eb50-9576-4713-b391-e737da0610f8",
+      "x-ms-correlation-request-id" : "369702c6-ccec-4c95-ba1e-f37fd747bc46",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024050Z:3147eb50-9576-4713-b391-e737da0610f8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020707Z:369702c6-ccec-4c95-ba1e-f37fd747bc46",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3147eb50-9576-4713-b391-e737da0610f8",
-      "Body" : "{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376\",\"name\":\"javaacsrg20376\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-18T02:40:45.434Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}}"
+      "x-ms-request-id" : "369702c6-ccec-4c95-ba1e-f37fd747bc46",
+      "Body" : "{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971\",\"name\":\"javaacsrg49971\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-26T02:07:02.615Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}}"
     }
   }, {
     "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:41:01 GMT",
-      "content-length" : "1782",
+      "date" : "Thu, 26 Mar 2020 02:07:16 GMT",
+      "content-length" : "1783",
       "server" : "nginx",
       "expires" : "-1",
       "x-ms-ratelimit-remaining-subscription-writes" : "1198",
@@ -40,23 +41,24 @@
       "StatusCode" : "201",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "81a08444-99c6-4ec2-8aff-eb2eb65e4fdc",
+      "x-ms-correlation-request-id" : "f2d730b5-6a77-4186-9ec2-b43aa515d352",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024102Z:81a08444-99c6-4ec2-8aff-eb2eb65e4fdc",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020717Z:f2d730b5-6a77-4186-9ec2-b43aa515d352",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3468ba62-add3-492e-b750-769240232253",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4\",\n  \"location\": \"centralus\",\n  \"name\": \"aks42786938f4\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"mp1dns89446c\",\n   \"fqdn\": \"mp1dns89446c-42e6cecd.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap014819f\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg20376_aks42786938f4_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
-      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31"
+      "x-ms-request-id" : "db7d97ec-1fa1-4a73-990a-50f8780c66e1",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\n  \"location\": \"centralus\",\n  \"name\": \"aks66843282e2\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"mp1dns94511d\",\n   \"fqdn\": \"mp1dns94511d-3d22ae46.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap0470064\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg49971_aks66843282e2_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 10\n  }\n }",
+      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:41:01 GMT",
+      "date" : "Thu, 26 Mar 2020 02:07:17 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -67,22 +69,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c00f80ea-8a17-47f7-97f1-46f1f5fdc982",
+      "x-ms-correlation-request-id" : "b2ec903a-6530-4674-9a19-bdf516ee589e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024102Z:c00f80ea-8a17-47f7-97f1-46f1f5fdc982",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020718Z:b2ec903a-6530-4674-9a19-bdf516ee589e",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f7b3cc42-b1bd-4591-af12-8871d878abb7",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "bfb650c8-e032-40ff-a008-887ea377a394",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:41:33 GMT",
+      "date" : "Thu, 26 Mar 2020 02:07:48 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -93,22 +96,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e8dbaa3f-2e5c-489f-990b-0f1982393897",
+      "x-ms-correlation-request-id" : "5b7e3f33-981a-440e-8afa-ac209d4082b6",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024133Z:e8dbaa3f-2e5c-489f-990b-0f1982393897",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020748Z:5b7e3f33-981a-440e-8afa-ac209d4082b6",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "df7e519b-3520-4a09-b4f0-8ce0ee3f630a",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "ebb525b7-3706-466c-966e-4faadb07f9c1",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:42:03 GMT",
+      "date" : "Thu, 26 Mar 2020 02:08:18 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -119,22 +123,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "01358dbb-216a-474d-9574-d694c3e2242c",
+      "x-ms-correlation-request-id" : "1ee517eb-b55c-497a-a44f-a401df5a1e7e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024203Z:01358dbb-216a-474d-9574-d694c3e2242c",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020818Z:1ee517eb-b55c-497a-a44f-a401df5a1e7e",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5eb51519-1faa-4623-af99-3f324f8f612b",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "1c8ad467-698c-41f9-9a07-7c3e330cd727",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:42:33 GMT",
+      "date" : "Thu, 26 Mar 2020 02:08:49 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -145,22 +150,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "65f7d42a-218a-4558-9ebb-086335f6a0ab",
+      "x-ms-correlation-request-id" : "3ed89865-e534-484e-83d6-b2eb12ab2294",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024234Z:65f7d42a-218a-4558-9ebb-086335f6a0ab",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020849Z:3ed89865-e534-484e-83d6-b2eb12ab2294",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7eda6358-0217-406c-9f75-655a8eaa475e",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "be7bca33-bf68-48e3-a320-3ea098ca65e1",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:43:05 GMT",
+      "date" : "Thu, 26 Mar 2020 02:09:19 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -171,22 +177,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "f9ea5d22-75c2-4ba8-80f9-f7721db307cc",
+      "x-ms-correlation-request-id" : "955ad7d7-0b17-4d35-bad3-e247e266e322",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024305Z:f9ea5d22-75c2-4ba8-80f9-f7721db307cc",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020919Z:955ad7d7-0b17-4d35-bad3-e247e266e322",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5ceb724d-ed40-4967-8b8e-dfeb17074fde",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "92458e80-d7fd-4458-9e1e-9c60761e85ab",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:43:35 GMT",
+      "date" : "Thu, 26 Mar 2020 02:09:50 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -197,22 +204,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0c474048-09e3-4da7-aeb1-e4706b602600",
+      "x-ms-correlation-request-id" : "06dc9153-57ad-4b60-ad04-9a1974f7a5d1",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024335Z:0c474048-09e3-4da7-aeb1-e4706b602600",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T020950Z:06dc9153-57ad-4b60-ad04-9a1974f7a5d1",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8b444bcd-30c3-4bb6-b751-da78e005a90d",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "02276dc7-e0c6-4d5d-9475-f62acf0b138d",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:44:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:10:20 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -223,22 +231,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6aa6950a-0abd-43ae-b0ff-f8e248962710",
+      "x-ms-correlation-request-id" : "ffd48c3c-ba34-46e3-bc82-34c9f3180eb8",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024406Z:6aa6950a-0abd-43ae-b0ff-f8e248962710",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021020Z:ffd48c3c-ba34-46e3-bc82-34c9f3180eb8",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "275b69ff-2e0c-4f43-83c8-a5615511d91b",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "59d2d98d-6902-4fe4-9cdf-163c4ee518a9",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:44:36 GMT",
+      "date" : "Thu, 26 Mar 2020 02:10:50 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -249,22 +258,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d63245f3-5493-4826-8471-435adbc79811",
+      "x-ms-correlation-request-id" : "f3e95edd-9a89-4255-88c5-8776c275ec9b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024437Z:d63245f3-5493-4826-8471-435adbc79811",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021051Z:f3e95edd-9a89-4255-88c5-8776c275ec9b",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3bbf055e-7d59-4cef-8cae-0848c13184f0",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "b05bc5c2-0150-4e00-a979-4bea6016776e",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:45:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:11:21 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -275,22 +285,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "520b3e54-ca3e-44a0-8a7b-1eca6207f6d5",
+      "x-ms-correlation-request-id" : "f80399b4-740c-4389-bc13-6a4f8dc9e797",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024507Z:520b3e54-ca3e-44a0-8a7b-1eca6207f6d5",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021121Z:f80399b4-740c-4389-bc13-6a4f8dc9e797",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ba7b4bd8-f6c8-4908-9212-5c387ec5252f",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "ba621aa1-52bf-479f-998c-dea4e96cba2d",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:45:37 GMT",
+      "date" : "Thu, 26 Mar 2020 02:11:51 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -301,22 +312,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5cc54745-4d81-4c94-b0b4-3e57459acd98",
+      "x-ms-correlation-request-id" : "aef99289-7201-4dad-9e33-bc1442313dba",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024537Z:5cc54745-4d81-4c94-b0b4-3e57459acd98",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021152Z:aef99289-7201-4dad-9e33-bc1442313dba",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ce3df0d2-4686-4982-8970-42747c1ad926",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "4f9049d2-ca0a-48d9-b626-835fbc7e7859",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:46:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:12:21 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -327,24 +339,25 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "26d50e71-a8e8-4eee-9b7d-af1ae26a738c",
+      "x-ms-correlation-request-id" : "eb6ff992-68c4-46c2-b8e1-c670fc529840",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024608Z:26d50e71-a8e8-4eee-9b7d-af1ae26a738c",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021222Z:eb6ff992-68c4-46c2-b8e1-c670fc529840",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8e8ae23f-e4f2-4e4c-95d0-c9400b1433d0",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "35833e00-d4fd-4732-8637-fe5b2b78c728",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/db7d97ec-1fa1-4a73-990a-50f8780c66e1?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:46:38 GMT",
+      "date" : "Thu, 26 Mar 2020 02:12:53 GMT",
       "server" : "nginx",
-      "content-length" : "126",
+      "content-length" : "170",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -353,24 +366,25 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "da9b4715-20ba-4bd7-8c26-3fdcb04bcdd4",
+      "x-ms-correlation-request-id" : "2b9f21d7-2a7a-4b61-91a3-199a1d0ea6fe",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024639Z:da9b4715-20ba-4bd7-8c26-3fdcb04bcdd4",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021253Z:2b9f21d7-2a7a-4b61-91a3-199a1d0ea6fe",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e2a2cfe2-c986-4e86-8fe1-60f51486b457",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\"\n }"
+      "x-ms-request-id" : "e4dbb82e-3997-47a9-89b2-3e2ccb6e43de",
+      "Body" : "{\n  \"name\": \"ec977ddb-a11f-734a-990a-50f8780c66e1\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2020-03-26T02:07:15.5738587Z\",\n  \"endTime\": \"2020-03-26T02:12:39.5302614Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/3468ba62-add3-492e-b750-769240232253?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:12:54 GMT",
       "server" : "nginx",
-      "content-length" : "170",
+      "content-length" : "1785",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -379,51 +393,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "83682c2c-b3a9-4165-9c51-d3b1c940cc73",
+      "x-ms-correlation-request-id" : "04d554c3-7848-415d-8922-9bef26b99311",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024709Z:83682c2c-b3a9-4165-9c51-d3b1c940cc73",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021254Z:04d554c3-7848-415d-8922-9bef26b99311",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "100b1883-2c4e-4e10-a76c-96b06ded38bb",
-      "Body" : "{\n  \"name\": \"62ba6834-d3ad-2e49-b750-769240232253\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2019-10-18T02:41:00.6211097Z\",\n  \"endTime\": \"2019-10-18T02:47:01.4521668Z\"\n }"
-    }
-  }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
-    },
-    "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:10 GMT",
-      "server" : "nginx",
-      "content-length" : "1784",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11986",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0add4f02-68ed-4619-a146-5d940460270b",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024711Z:0add4f02-68ed-4619-a146-5d940460270b",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "fee96694-08f7-43b7-b053-8291d2cb53b1",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4\",\n  \"location\": \"centralus\",\n  \"name\": \"aks42786938f4\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"mp1dns89446c\",\n   \"fqdn\": \"mp1dns89446c-42e6cecd.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap014819f\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg20376_aks42786938f4_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+      "x-ms-request-id" : "4fa242b5-d11d-4184-adde-f81191d8e3ef",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\n  \"location\": \"centralus\",\n  \"name\": \"aks66843282e2\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"mp1dns94511d\",\n   \"fqdn\": \"mp1dns94511d-3d22ae46.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap0470064\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg49971_aks66843282e2_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 10\n  }\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterAdmin/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2/listClusterAdminCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:12:54 GMT",
       "server" : "nginx",
-      "content-length" : "13170",
+      "content-length" : "12893",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -432,25 +421,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2ffe8f9d-4cbe-43e2-854f-228690e66912",
+      "x-ms-correlation-request-id" : "7d71143c-ced5-4cfd-9b5e-75c653c47b4c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024711Z:2ffe8f9d-4cbe-43e2-854f-228690e66912",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021255Z:7d71143c-ced5-4cfd-9b5e-75c653c47b4c",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "68187c4b-7f75-49ba-8135-a4b864cde8cc",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterAdmin\",\n  \"location\": \"centralus\",\n  \"name\": \"clusterAdmin\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVVsRWFqZFlhbVIyYWpaTVJXcEdlVVIxVldGbWNEUjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJyZUUxRVJUUk5SRWw2VFZSQk1sZG9ZMDVPUkd0NFRVUkZkMDFFU1RCTlZFRXlWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFRWS0NtSkhNa2d3Y1RoWk56aExhSE5CUldadU5WSklWVFpGYkd0R1VGcE1VR1Z1TjNCbFlUZE9VRXBYVjJoRVJIQnhNV2M0ZG1RNVVrWjZkMVpFVGpScVJVc0tUMVZaUW1kUmNEaDNTa2xEVVV4d01VcFBlSFpZU0RacVIyTjBSalptSzJZdlMxUlpaRGs0ZURCTU5UVlljSGcyVlRkV01taHBWaTlxVDBWbE0xazFjUXAxYW5WaE0wZEVjRkU1Wm1GRlZVOW1TbEJ5UjFGc2VFdE9SbWsyT0ZCM2NXOXVkM0JvT1M5UWQwUkZaMkpuVjNZeFZtdE9RWGxtYUcxdGQwczJjbUpJQ2t0SGVXcFhObVk0ZFdkcVNHVlBWVm8zUXpKUVRWa3pZa05PZDNaalRuSklUa0ZyUlRSaVVsVkZabkpzYlZsQmQxTjNaWE0yVEdwNE5UZHVXSGg2V2tjS1lrdHJRbTFZZWk5MVUwNXRhM0pOT0dodVUyMVJNR1IwYTAxa2FsSjBaSGN5TUdOM1FrbEtTMkoxT1VZM016TXZhbmxyY2psUU9HNWpieTlsYVRKb1p3bzVNRXR3UzJWTFp6TlBRVVZPU0daNWVXRmxjMk5ITVhNMFZFTk9VV3RQTlU1SmJtZHRTMkZSUzBOU1pXcHBXWEIyVVdjMlVXOTVhR3RVU3psMmRuWndDbEZ3VTAxTGRqSmtUVE5USzJNNGIwSllPVEphVVdnNU1sbGFNVWN6VlVKU05FdHphMkprTUhkUlpIUTBkbUZITVZwTmF6RTBjV3hTVjBJclVGSllXRWtLVVRGT1Nrc3ZXbEpCYTFvMGVXWnBVMk5XYkVkMldYaG1lVTk2TnpaT0wyeGpiSE5PUW1VNE9XVnNaV3RyUXpSSWMwOURkSGRPVTBsMk4wdFZibXc0ZFFwMVVYaG5lVGQxVW1odmRGUjFRWE5IYjNWc1ZWRlBWa3RDV0VwemR6TlNWbXhzYVVsa2MydGtlRUp2Y2tkeWJHWmxTMEZoVVV4eFRtOXdhbEpCVjAwMUNrUm9NVFIzTWpNeGJXTmFOVUpETld4TldWbFhjREpSY2pScFlXcHpkMjlsZGpCd1N6ZE5iMVZVYVd4NWNqVkJjMEoyWlhsUlpHTktkSEZTWlhkdFdsSUtNa3BwUjFKNk1YaFZNak5ET0ZCMWRscEJla1ZDVG5aT09GQktlamxqYWpRclRFdG1SbEpxVUVGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlEweEpWamxyQ2pVdmMyaDZOVkkyTDI1Q2MzUTBMM05XVVZBdlUwRmhRVVpTSzFkbGVERm9jMHhNZURGQ1VVVklOSGR3TTJSQ1QwMHhVVWRRYTFaVlZESnJVVVV5TTNnS1JrTm9iVnBGWTBoRVpscFBOeXRLUkd4bGFsbHJORk53Um5ScVoxbDBNV2xGUW1Kd01EYzBSRE5wZDBsMVMzUkJSRTlHVWxKa1YzSnpVR2d2VGxKWWFncEtiM2hLUWxoV0wzUXdNbGxFV1VwcFZHTlFiVVZ3YmxObFRtaE9aSEp0VVRjelYyNXVjVFpsVTFScVZHVkdaemxFTUc1VlVFbFNNbnBUTTJkNE5tVjNDa2d5ZURocVZFZGpSbGQ0YXpoWmNYbFlTRlpwU1RKM1dWUjFMMnBoYWxnMVUwUkliVEV6TDJ0a1lWVnBPV2h1TW1STlkyOWhSRkZqWW1oUU0zVXZZV29LUmpWUmFEQjRkbkZWWjFSeFYyNHphVkIxTlZaclF6ZHVXRTA1U1RKM1FuVTNWbWxUZVU4MGJVeFpNazFKTURSUVp6WnVOa0ZWYW5STlYwMDJVRXBVVHdwRUsxbzVaRVF5ZEZscEx6VjJjbWxpWVVoaVpUQnRjVzR6UTJGWVdsaDFWM001TVVwRllUUXhXVVJwZVZkQ1drdFJUM2xaWlU5aFluTTVSeXM0UTNkQkNtRnRLMjkwWlZadGFqZDFiRWxLSzFKbVJVVnJjekpSY1hCSlpFSk1ZVVJyZVRsNE1YVjBLM0JIWkcxclNtTXpZbnB2T1ROcVRVMVVPV3RJTDJnNVEwa0thaTl0Tm1sYWRYQlBXVUprVW5CRGR6UkJLelpCY2poUVZsb3pibnB3WkM5eU5GaHFjMXBHWldnM1dYcEZTa2xWU2pNM1NVdHROM1ZMTkhab2RFMXNPQW8wZW1SdU5GZHhOemh6VEhocFZrbHdUQzl2ZW5oQ0t5dFFURUpXT1RaNGNrVllkV1Z4YTFkeVQzTnZjRXR6V1VGSmJURnRkVTF5VURKRU9HTlJSbFJhQ214elJXVldTMDlvU2pOUk5HTmxNMmg1VTJOTWMzUlFLMDlxVERGdGJXcFVjbHBVT0RoQk9HbDFVRVJQV1d4TFIyaE1jR3hMWVhSVFdubGhXWFJKTjFBS05TdFFiMkpIV2xwbUsxUlhhRUprTVd3d1dqWXJTRzlXVGs5MU1HTmpZVkJ6UkRnemEyYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zODk0NDZjLTQyZTZjZWNkLmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczQyNzg2OTM4ZjQKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczQyNzg2OTM4ZjQKICAgIHVzZXI6IGNsdXN0ZXJBZG1pbl9qYXZhYWNzcmcyMDM3Nl9ha3M0Mjc4NjkzOGY0CiAgbmFtZTogYWtzNDI3ODY5MzhmNApjdXJyZW50LWNvbnRleHQ6IGFrczQyNzg2OTM4ZjQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyQWRtaW5famF2YWFjc3JnMjAzNzZfYWtzNDI3ODY5MzhmNAogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZWRU5EUVhWWFowRjNTVUpCWjBsU1FVeDFOV1J3SzJ4M1pXTklhWFl2TXprNVoxRnpNbk4zUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVhjS1JGUkZURTFCYTBkQk1WVkZRWGhOUTFreVJYZElhR05PVFZScmVFMUVSVFJOUkVsNlRWUkJNbGRvWTA1TmFrVjRUVVJGTTAxRVNUQk5WRUV5VjJwQmR3cE5VbU4zUmxGWlJGWlJVVXRGZHpWNlpWaE9NRnBYTURaaVYwWjZaRWRXZVdONlJWWk5RazFIUVRGVlJVRjRUVTFpVjBaNlpFZFdlVmt5ZUhCYVZ6VXdDazFKU1VOSmFrRk9RbWRyY1docmFVYzVkekJDUVZGRlJrRkJUME5CWnpoQlRVbEpRME5uUzBOQlowVkJNREpUVW5GQllXNDJhM0p4Y1hwbFMwSk5NVE1LTHpkdlpVWnljVFZ0UjBsYWJtcERiWEJLU3pVdk1rVTFkMFZ3VUZKRU9VcEpaRzFFWTAxVlZ6QTROWE40WWpCVWFITk9XbmRtZGtseFQwNTBZVTA1WXdwWVRrODBUMUUyWTFKdVluTnZZVGN3TkdJMGJsRlJNSGRSTmxCT1RFWnFRbFZuVEZsdE1tRktSMkZKV1haall6ZFdZMjV0ZUdGVlRrSm9TSGM1ZFhoR0NscDJWVzV2ZURsUE9UbHViVXMyZVRGVVJVdHhUR05xUXpSaFoyMHdaRlFyVjBKSllVVklaVW8wUlRkMGRIUnRTRlJ0YTI1WFVHTkdWbkZ2ZHpneGVWb0tWbWN4WTBwblVWTjJWVUZoUWtSSFFUQXZibFZXUTNCQldUYzNNR0ZqVDJ4R1YzbGxTaTl1V0ZGVWNuWmFaRkZKZFhSaFVIWXlRbk4yTTNkcFZHcERkZ3BKVDI5aWVuaEVhVUpqVTNwNGVYaEhaVVZRVGxKeWJUWXpkRUpRU25wVlkwSTVORWR5Vm1kb2VXWkhaV3BYTlVsT1NEUnpiakZQTkNzeGQwb3ZjRXN2Q2xWMlkwVnJRelJqTDFwNFIwaEhNVXBVVUc0eFRFbFlOMDkyTkhKc2NEUjZLMWsyV0U4NFZVdE5RMnQyUjI1MGJrWkZOVTlLWVdkMlpYcDVVRm96ZFRnS1ltNVJXRVZTUmpKSVRsWk9UMEp1ZW0xUk5IQkVPR0k1UWxCV2Iwb3hkek5WVmxVd1lraE9WekF5ZDJKck5IRlNaRWhIU0ZaVWFqSkdaVzV4WmpaUU1ncEhPUzl2VW10RVN6ZDFlSEZKYm5VNFlYVXlSSE14V1hrMmFGQTJTbmg2WlRSellpc3lWbFpsVWtSU2RUTlhaakExWVZabE5sbGFaMlZqVGxaTmFITmpDbmMzVkZacWJYUTJWWFJCVkdSQlZFMU9TRGRaVlhWT01VUktNRFpTVjNaSVQwVllWamRhY0c1Rk5HSkxkVWwxVEhoa2VXSlliVmsyT0haR1pISmFlR01LWkVSSVkzcEJZbW96TDBzNWJHazNiRFp4ZHpOcVYwdG9WbEpESzFKVVFteFdMMnRpY2tSTlRUaEROVXBLVG1veWRVaGlRbkpxYlU5VmNFTjNUM1Y0WlFwa2JTdFhkR2hTTkVaT1kxVkVlbWwwU1d0bFNVcGpPRU5CZDBWQlFXRk5NVTFFVFhkRVoxbEVWbEl3VUVGUlNDOUNRVkZFUVdkWFowMUNUVWRCTVZWa0NrcFJVVTFOUVc5SFEwTnpSMEZSVlVaQ2QwMURUVUYzUjBFeFZXUkZkMFZDTDNkUlEwMUJRWGRFVVZsS1MyOWFTV2gyWTA1QlVVVk1RbEZCUkdkblNVSUtRVWwxU25wNWRtb3hSbE5GUmpoQlFrRjVVak5zYlhST00yNWlaV3cxUkVkaWFrRkhNR1ZNVldGUVJWUk5NbEp4SzI1TllsVXpaV3BNUVVWVGEwbDNOd3BxTW5sdFIzVk1TMlZzVUdsMlVsVklkMjlpYTFka2JqQXhLM1JCYjJ4UFJsRmtWRzFWUjBOSU5qQlNiWE5OU0RSSlYwWkVOV3BzTm1kcmRUUmxSbG8yQ2tNelEzUm5RaTh5U1VwQ1N5dE9hRGx1ZG1WblZYcEhaVzV4U2pCeUsxTXpTM0Y2VjNWQllUTk1NbTFVZFhJMWQyNUliRFZQWVd0NlMzWlRkVkV6Y25FS2J6QnNRVVIwUVhoeFlXdHNUVGhqUjJwRGVURkxhMk15WnprMlNVMHhNMlJRTDFvM2IwTjNZMFYyYzNCT2JIaG9aM0J3ZVc5bmFVRjRXVXRJU0d4RGJncFZaRkp6VkVKR2NXSm9WRTR2WkcwNGFqVXJka3RDVUdOM2NrSkJlSGhrVjBsdk5IVTJiVTFEYTBGeFQzUnlhV3RzT1ZWR1dtRkxlVEZTYlVaemJXeFZDbkoyU2treVJtVTJNVXhYYUhKNmVWbEpjbWd5V0VaV1NGZFJNbTlSUTNvM04xSlFiM0ZXZUhsMlpGSnNlbkZMWVRsQlNGSjNjbmQwVVVReE5UQlBhVXNLUkM5a1NXMUJaa3RVUlRGaU0xUmxUMUprTWtaeU56SjRjMEZtSzFrNVdsbEJhMnh0TlU5a1ltdG5VVXhhYkhObVlVMUxhbm95YzI1a1FXdFVaV0ZHTlFwVWFsQkRhMjFVUVZKTmEzVnhiM1JhUjBWcllVcHRhaThyVWxFM04wcHVTRFl6WTFOb1VtSndjbGxCVEd0MGVHdzBjbEZtTHpCV2IzUnZibmhQVFhGd0NqbHZORWhCSzNORGQxRnpPR1pSU0VwWlZUVlJWVlFyTkRkTU1XbHJTSHBaZWpWNGJHUjFXR2gyTkhSRU5sSnpjREIzWjNaTFRtSm5lRkk1V2paMVpXd0tabk5zYlZrMGNVeDNUbWhxUkRGT1VYZDRUbEpxWlZjclpuZHpUVU01VWtSSlNqQk5NVmxPZUc5alkyOUdOR3hLVUhkeWRtSTRNeXRoVEcxVllqYzVSUW8yVlZGMmJqbE1SV2RRVUd4VVRVaDVjM2N5VjFkTGIxbHRNMWRUUjJkdE16WlpPR2xCYzFaalVHZDZaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJNREpUVW5GQllXNDJhM0p4Y1hwbFMwSk5NVE12TjI5bFJuSnhOVzFIU1ZwdWFrTnRjRXBMTlM4eVJUVjNSWEJRQ2xKRU9VcEpaRzFFWTAxVlZ6QTROWE40WWpCVWFITk9XbmRtZGtseFQwNTBZVTA1WTFoT1R6UlBVVFpqVW01aWMyOWhOekEwWWpSdVVWRXdkMUUyVUU0S1RFWnFRbFZuVEZsdE1tRktSMkZKV1haall6ZFdZMjV0ZUdGVlRrSm9TSGM1ZFhoR1duWlZibTk0T1U4NU9XNXRTelo1TVZSRlMzRk1ZMnBETkdGbmJRb3daRlFyVjBKSllVVklaVW8wUlRkMGRIUnRTRlJ0YTI1WFVHTkdWbkZ2ZHpneGVWcFdaekZqU21kUlUzWlZRV0ZDUkVkQk1DOXVWVlpEY0VGWk56Y3dDbUZqVDJ4R1YzbGxTaTl1V0ZGVWNuWmFaRkZKZFhSaFVIWXlRbk4yTTNkcFZHcERka2xQYjJKNmVFUnBRbU5UZW5oNWVFZGxSVkJPVW5KdE5qTjBRbEFLU25wVlkwSTVORWR5Vm1kb2VXWkhaV3BYTlVsT1NEUnpiakZQTkNzeGQwb3ZjRXN2VlhaalJXdEROR012V25oSFNFY3hTbFJRYmpGTVNWZzNUM1kwY2dwc2NEUjZLMWsyV0U4NFZVdE5RMnQyUjI1MGJrWkZOVTlLWVdkMlpYcDVVRm96ZFRoaWJsRllSVkpHTWtoT1ZrNVBRbTU2YlZFMGNFUTRZamxDVUZadkNrb3hkek5WVmxVd1lraE9WekF5ZDJKck5IRlNaRWhIU0ZaVWFqSkdaVzV4WmpaUU1rYzVMMjlTYTBSTE4zVjRjVWx1ZFRoaGRUSkVjekZaZVRab1VEWUtTbmg2WlRSellpc3lWbFpsVWtSU2RUTlhaakExWVZabE5sbGFaMlZqVGxaTmFITmpkemRVVm1wdGREWlZkRUZVWkVGVVRVNUlOMWxWZFU0eFJFb3dOZ3BTVjNaSVQwVllWamRhY0c1Rk5HSkxkVWwxVEhoa2VXSlliVmsyT0haR1pISmFlR05rUkVoamVrRmlhak12U3psc2FUZHNObkYzTTJwWFMyaFdVa01yQ2xKVVFteFdMMnRpY2tSTlRUaEROVXBLVG1veWRVaGlRbkpxYlU5VmNFTjNUM1Y0WldSdEsxZDBhRkkwUms1alZVUjZhWFJKYTJWSlNtTTRRMEYzUlVFS1FWRkxRMEZuUlVGNGEwdzJaMVppVFhkbFpFWjBVazh2T1UxVmIyMU5XR05XYjBWSFpFczNPVk1yY0doUlRsVkZZMVZ4YTNWWU5UUllXUzlzWWxWUWRRcEVVMUZ6VW5KaVEwOWhjMlF4ZWxRNGVDOTZNM00zTm5BM1RGVmxPRlZxTkRkVWNWRjNNVE5wYW1KdWFtNXdNbFJtTWxZMVRVNWpLMHBUZFZKR1VGQnhDbG80VjBKTVNFNXNUbEZxV1RBMWMzSlFOQ3RRWVZoUlIxSm1RbEJJTUUxeGVUaHJabUpWU1VkeFJYVjRUbXBqU1VkVGVrUTJjRk5yTlVGUllVVkZkbG9LSzJwMlJFdHZaV05XTDFGdkwxSmxUMlZrWjJ0UU5sbGlhSGRSUVVwRU9HWm1LMEYxUjNsVk1YZFdNRlZqVEhST2MzbHdNV1phWlc4NFJrVTBWV0ZIZGdweE9YRmtWVzFoVDBKVWEyRm1ka2RvYmtkSk5WaEdXakppYkUxdGVsZzBSVmQxTmtGeVpIaFJjVXR6VkRWT1VHbG5WVlJOZVZKRmFWTTJiRFpCY2pkM0NrVkZRWEZaU21GdGJVRnpiekpYVEVaUmVVWnZlWGRqUm5OTFpUbHRPRTVRTlVKalZGTTBlbGRMVTBWM1dUWnpUMVl6TkVveGNsSlRSakJvTTBnNVdEUUtPVWhvVWpBMlRHbHFNSEpGTUZONmRFcFFRMUo2U2xwc1kxWjNSek5KTUVoSFFVeDFkVmxIUnpaS1ltRkdSR050V0dGaVpsUk1kRnBvWVVWQk1YRlZNZ3B4T1VaMWNHeGpkVFY0T1VGU2MyNXRZVFpPTkdGTWRYVnlia0U1YlZsV1pGaHJaVVl5TTFvMVpYUjRWM1EyWTJsd2RYaExjMUZ0WjI5NE9ITlBUWEZZQ213clZVZGtXSFpaWWtaUGVETXhlQ3RMYWpOcFptUkNjM2RQVFVrMmRsUlVkazlpVVhkd1p5dHNPV1JIVkhCd2NqTkllRFJyWm1SemRuQjJiamRqTUd3S05ESkVlV0pEYjJsRU9YZEJhRVU0YTJkTmQzZGxha1ZyYmpKSFprTnFhMnR6YUdkblNHaG1hVTR6YlRGck0yMHJlbFZCYUVacFV5dHhOWGhJVkdsSVRnb3phRnBMVFRWWGNrMWtiMmRuVnl0MVRUWlJSbXhwVHpGWFlsaEthVUpDV0ZwdlZVb3dXVGc1VDA5T2RtMXlZalJQUjBWRFoyZEZRa0ZRV21jemRYWnBDbXB6Vm1wUksyUm1WSFZDVUhnekwyc3JkRmxLWVU0d1JIZG9ZVGg2UkdSVU0wbHNaa28zWVRjMFEwUnpPVGRrU25jM1QydzFXR0YyTTBWNmNVcG9SbUVLUm14c1pFaFlPRWQxYWpCMU5HRktaMlJKVmtaUmNUSlFWVWxKU21wMmRISTJhRUk0T0VveFV6SlFNWFZ5UVRGVk5Vc3pkU3N4U1dKMlIwVkhabXN6UkFweWVYcDBWVGxTUjJoVFVXbFRUMEozTnpZM1puTjVlVnBMVGs5cFZGWlJlVU5aTjBaSFVsSTJkU3RHYWxwRmNrNVJWWFZuZWpOMGJFNUNVRm95VDBwaENuRk5aa00xV1ZKMlJrc3pPREF3U1dObFpXcHVRVzk1UWtwckswTlJXR0ZFWVdORVNFdGpTRGc1VTFoNU9HZGlMemxWUmpSMmNUUTNOMWx1UXpWVmVXRUtNbEpQVlRkVksxWlFSRTVCT1hrMFkzVkJOekF3Y25wc1JHaGhXV2hTZUU1VE1FdG5VRkZSV0ZjMWRXWmtOM0ZMYjJ0S1QyVmlSVVE1YlhkU1RFaHFUd3A1WjNrelIxWlNja0o2UzNoMUsydERaMmRGUWtGT2RXdzNORlZsWjJ0UFZFaFBOR2hYVmtvNVJqZDZPSFl2Tldoc2FqTlFSazQyZVhRMllYTTFLMUpUQ2lzNWJUaEJWbTFRVVVrNGRtYzJUMjkwYUcxVGNGTlZPR05NTld0bWFYQjJPVk51YmxaaU5rVkdMMG9yTWtacE5GY3Zja1p4UzJSVmJrSjZRa1p4YjFjS09GVXdabWd3SzNkd1pqbExUbWw0Y1c5TEwzVkJaVTgyVEVvMmFtTm5ja0ZqY2s4dmNuUTFjbTVJTlVSdFpEUnVVMVJqT0cxMmIyUnBZMk51WlVoNVFncG9iRFZWWjJjd05tWmhRMk13TTNSRlpHVkpabWRxTlhkVU5XWlpRamhHWWxCc1J6Vm1SbU5tY1Vab1VXSk1hSGxFYlRkMFdtOTNSSGxhUkdkdFpuZ3pDa0pIZFhRMmRVUTRhMnRFU25Wd016TkZjelF2VVRNMFpHVkVhVlYxUVc1VmVHUm1PVW94VEN0eE4zWmlMMlZ4Y2taV2VWTXpUVk5rTWpoa1JqQkNObFlLZDJWSk9XbElVVlZMWXpoV1kwWm5lVlJYVTA5VUsxTmhhRzF3TkRkVlNrNUJRVk5ZY2xkSkswZFFZME5uWjBWQ1FVNXNaelpQTmxseGVqQjFPSFpsVHdwWFRYRkRkVlpPTTFaWVZrcFJhRTVYZDBsV1RrOUxWazFSV2xkWGRHcFNPVWRUWjFSNlFrRlZZbWt6ZDBoclFWVnpOM1pPUkRVNVduRTRVbGMyY2tweUNqTnBRV3BaUVV4cVRsbDBjMkUwVFRCdmJWUktVMFJWSzNCdWNUZHpXbEYwVWpkU04xWkRVa1JHWVhvNE5GSk5NVEEwVTB4MFVqWndiVGhLTkRsMlEyY0tPRGxJU1hscFNEQnZlRlJaTTBnMWNEa3JTMkZJWWpRcmF6YzBOakp2UkN0T1VYbE5jRU14TTFsaVpqTm1NMmwzT1hwNldXaFpjRnBWVUdSSVZucG1PQXA0Wmsxdk1HTkNVRE5oVVVoU2JrWjJaR0o2VEVGVVZYVm9lakJIZGtOdmFrcExla0kyU21OVFpVaExNblJSTmtoWk0wdGlNbUpKTkVsWVZYTm1hVVZ6Q2xjM2QyaEJjbGhXYzNaUVNGRk1VbGhMU2tnMVMyVkRjSFJrUW05RWN6SjNVMmw0U21rNWNYcG1TM2RwUkhrMlIyWTBTV3AxVDJkNVJUUlZZV1UyWmtjS09ITm1aMng0YTBOblowVkJVekF2V0VVMVlrWmFXRkZuZGtWdE1DOWpTMnRxUVd4Q2NqTkJOR1Z3VEhobVpscGlXVUYyZWt0MVpVWk5WQzh3VjI5bWVRcDNLMWQyZUd0TVNIaFlZbmh3ZUZoV1RtOU1kMlUwTms1NWEwNXRjeTg1U1RCeU0wcFpiMjg0UWpNd1ZXVmxUbG8zT0ZsS1FtMU1PV000Y3pKemR6RklDbkpaVURsc1ZHTjFValJTWkVrek9HNVpNMFkxV0dSU2EzWTVjMlZyTW1KclluRnhlRXhIYm1WQlpFZEhPV1pIUVRFd1pHbFhXbHA2ZDNjMVNURlZOVlFLTW5Wc1N6Tm1ORFJUVlUxNVptdFJNa1pyVG1SVVYwRkRkWHBVVmxCSE5DOVpOa05ZTVhCd1RUbHdNM2g0YkhCaFJqVklZbGR4VWxsWlN6bDFWa3A0YkFwaVZUazVOMFZJVjAxa0syaFFZa2hRUldRNU1GSjJTM055TkZVcmIxbGtkWHBQWml0YVUwMXhTRTlpUTFOaGQzbDFiRE50YjFWWlMwSTBLeTl3VFZaNENraEhPRzFoVTJNclVVSmtTSEkwVDBsVFUwOVVabTFOTW1WV2VXdGtORmxDVDNkTFEwRlJRV0UwWlZOb0wxWTNZMjVKY0VOSFkyeERTazVCTW1seGFITUtNSEJ5TlRkMVozWmpPQ3RIVEU1NldTOWtPV1pVVmt0V2NqTkZkMVJyWkhsaGQybFROelp5ZEdKb2NrVXZkMGh3V1dkVWNHRTJkamQ1VGxCaUsyeElhd3B3VXpaQmRUWlRWMUJyYkVKa2JpOTJlRE5zTWxjM2MzTkZaVFozSzB0emNVNXRSR2N6Uld4U2IwZGhLMUF4YW01WGRHVlZkVGRPTW5oWVRsUndhWHBEQ21wcFpYQXZWbWRWU1dKaFl6TjVNM1ZoTkV4QlVFaDBia3BYVFRJMWEwazJlbE15VkZkRmFFb3hWbFpXUWpWQ2JqY3ZWRk5NY2tGQmFVRTNSSFJaVWt3S1ZXaDJhSGRLTldWQmVqQklTbXBMVlRkek9IcG9Neko1Y3poRFZFdElVQzlhUkRKbmJFdG9OeTh5UjBGbU1EQTBiM2R4YjNBeFJXOVNkV3QxZUhBM1VncExXWGxXZVdWQmNYSnJkMDFsYVc5aGJXODNNa041ZGs4MllWa3ZMMmRLWTJSelJGVklkVVZNVm5ab1NWaEVkSEV5WTAxTVNsSTJRMlJPV1U0S0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiBjVGZoWkgyWFFzZzkwUkJnTlVvMkVaWm9kQUFTcVNvWUlGdmZRZ3MxalcwNXMxS3Y5R1o3M3JjNHFkeUtRblprWUJyOVg4RTAzdkFmRWR1bnZEdGYxYUF3ODdaaWljNUFqc2hzd1owblI2dXRYWnIxSDlHVml6YXY1aUdYWDYxdgo=\"\n  }\n }"
+      "x-ms-request-id" : "3eab56dc-fd71-4bbe-aca4-4df112b84156",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterAdmin\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSU204NVJXMUtlRWx1YUVOQ1QxQXlkRzloZUdGSFZFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5WRlV6VFdwQ1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTlJHTjVUVVp2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSUkNsZDNkeXRJZVZGWVNVdFhSeXRuTjFWa05GUjNaRFpJYjB4c1NITlFTSGw1TTA5RE5tUkhjRzlhYkVSQ1MyMHpiemRWY3pWMlV5dHVRMEpMV1VnNE1EUUtlbEJQYWxkT2RraExVVWR5ZVRsd1pFcE9hVXhJY1ZGbWMwRkxZMjlRZUhsRlFqZDFka0pyTm00MmFreHBVakJYVldOV1NrOHlhVXBCTVVseVNqSTFiUXB0VUdWeWF6SllRMDFLVDBGWlQwTjBhM0ZLVkZsNFVFMXJLMVYzVkd0V1lrRm9WbUkwWWtKYWNtOURjMUJ6YVVSb09VdEJiV05EV0U1M1dYbHFZVWQxQ2xCSmFTdEVTMnBYU1RkdWJIcFZSWGxSVVVod2JrVk5UaTk1Vm5ab1QySlpiazk2WkZwNU5VbHdUSHB2VEhRdlJpOXViR3QzUmtkWlpubHNVVGQ0WlVVS2JEbDFZMUk1Y0RWNk9HUlRiRTlFUkZOc1kyTXdjWEJtVEZoV2JYcFpWbEpIYTNZeFMyeEdXalJxSzNSYVpGUlBSVklyTVN0aWNFTnlORUY0TlRGTFdRb3ZSbk5vVVVoUVEzTkpTVWMwUTNaTGQySlRZM1oyYjBSWk1rcEtSM1pVTWpOUU1Hd3hhblZHZFdsMGFpdEhSVkJXVVhONVNFZEZZMlZ4U2pNMkwxVnpDbFIyUXpkR1UybHVkbEZtTjI4NGMzYzRjMkpsT1dSblVsSkxPRFpCU0dkeFoyUnJNVEEyVkdKbVFWbzBkRnB5WVVOU1drOHlOWEpRU2pZd2FYZEhXVTRLYmtGM1dIQTFlakkxZVdOQk5FOUdXRk41WmxSbGJFbElha2xZYTNwQlZIWklNMWRaVFhnNVp6QnhVMVEyWmpsa09UbFdSRUptYVRJMllsWm1kemR6UkFwRFpuazVZakp0UjNkM2FrTnNRMVZsZEhwWmFtdHVNV05EWVZRd05URXpSMU5NVEV0WGRrRjFObVV2UTBaM2NEaDBRWG8yZUVwUmVVSm9TbVJxWlU5UkNrcHJiMlEyWjBoblpqZFhkakF5VTJGaVVFRkpWV2RyTWxWYU5rRmtORGt2YkZGbWFVUm1aMnhuVlVGMVVETXZhVmx6UzNkaFMxaHVkVU5NWWpSTlVGUUtkazVUYlZWWlJYZFlaemx2Y2twV1NqTXpNR05SVjNGRFFWRnNVbTUzTTBvd09WTkphWEJaV21oUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRkJhR0ZGQ2xsTFdua3hWVk0zTTNvcmNVWnFjbW92WlZSa1YzQm9SV1p1WVhsRVVIUkhUbnBtYkRsa1MwOU5SRXd6VlVkdWNFeEhNRTkwVXpOdFVXZHJZbmR3Y2lzS1dEWlpZbkZIWkZaSk5UTXpkVkZrTTJWV1NqSlRiVzFtUW5WeFNVOTBLMUpQTmpsUmJsbEJiMVIwUmt4eGNEVkRPVVpaU0Zvd2FHTndSamhvWWpCUWFncE1Sa0Z4ZG0xelozZ3JSRzk2WVhaME9UbDFkRVJVVEZwdlpIcEpWRVV3WVdSbUwwWkthSFkwZDFoT01sQTBRelpZWVZWQlFVbG9SblF4WTNGSE9UbEtDakZDTTNsVVNXVTVlVEJwUldaeU5XVXpTRFI1U2xOdWRVdzFMMVI0T0hOQ1QyNXZhMlJzZHprMlRtTmthWEJ5V2xSTmNrZFZhREZ5YUhKcmRsSllSMWNLVWpWaloxbGFWbXRoVm5WUFkxUmlWWGRPTkdvNVQyeFlMM2xTVms1eFIyWkxTREppUlhsNmRHdGFibEZCVjJkT2RrMVNkR3R6YW1odmRtWjZUSFV2YVFwMFZFNDFhakJhZEV0S2RYSTVlRVJ2U1RCMGJXMTBjM0kwTTJFelkyTnBLMnA0ZUVkMmJHTlVOVkp6VlUwNVdYQnRiMUJZYTJkM00xZEVWMUpSU3poV0NtdFJlbTlWYVdobFNXTnZlbmxpWVdwMFJXMTZZVVJxVVhkTlpXczVTa2t4YlhCWFUxRkpiSEF2TkRWMmQyZG9aR2MxY21jMk5tdDRSRlo1UTJaMlN5c0tOR3RoWjBJME9VTlpVbFZuWW1acWIxWmFjak5sUVV0bVlVbE1lVWxyUjIxMWMzbG9ZMGh3TUZGMFRUVlpSSEZhWWsxbk9XUmhOMHB3VFdjd04xSnZkQXBuWkM5NGVVSTNWV2QzUTAwMldteG1ZV1JuYzJrNWNtOVRTamhNU0hweFJVWnZVbEpFZEZSWVRuTmxNbHBtVlhNMVJtWTVla0p1Y0RCUGRqZFROV3M0Q205dVJHaEJWV2RIWjBaVlVpOVZUbGRYVmtnMlkycEZjbHBvVVRoMlIwZFhORzR6VGtsVU9VMTNXRkpqVURKNk1TdE9UbWczT1hsc2JFdElWM0ZYYm1vS1dGTm1TakpUTVRCV01qTmhXRGhDYnpGVVZXeEVXbnBNUjFCMlZGaFFRV3hEYTFNM1psUnZQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zOTQ1MTFkLTNkMjJhZTQ2LmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczY2ODQzMjgyZTIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczY2ODQzMjgyZTIKICAgIHVzZXI6IGNsdXN0ZXJBZG1pbl9qYXZhYWNzcmc0OTk3MV9ha3M2Njg0MzI4MmUyCiAgbmFtZTogYWtzNjY4NDMyODJlMgpjdXJyZW50LWNvbnRleHQ6IGFrczY2ODQzMjgyZTIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyQWRtaW5famF2YWFjc3JnNDk5NzFfYWtzNjY4NDMyODJlMgogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZSRU5EUVhWVFowRjNTVUpCWjBsUlIyTmhSWG94VVhSQ1IxaDBiRzVtZUVSemIyUTRha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRnpSa0ZFUVU0S1RWRnpkME5SV1VSV1VWRkVSWGRLYWxsVVFXVkdkekI1VFVSQmVrMXFXWGROVkZVelRXcENZVVozTUhsTmFrRjZUV3BaZDAxcVFUTk5ha0poVFVSQmVBcEdla0ZXUW1kT1ZrSkJiMVJFYms0MVl6TlNiR0pVY0hSWldFNHdXbGhLZWsxU1ZYZEZkMWxFVmxGUlJFVjNlSFJaV0U0d1dsaEthbUpIYkd4aWJsRjNDbWRuU1dsTlFUQkhRMU54UjFOSllqTkVVVVZDUVZGVlFVRTBTVU5FZDBGM1oyZEpTMEZ2U1VOQlVVUmxObTlQTjFWNk5rZEJSazlLUkZWNVUwZHpRMHNLVm1KbWRUaHNkV05LTkhZemVrUk5aalUwZFhSMFNtZDNPREJqWlhoNksyTjVRalY0THpKbk1ETjJVRk5TTmt0WVZWa3JaMHN3Ym0xaFZtRlRhbE5PU2dweFNTc3pkR3hSYUM5VVZXTk5TVWwwWVZCTVZrdzJSbk53U0N0Mkx6bGhXVmhrTjA1Vk9GZEJRbWxZVDNOUGEwTk1SME5zZVhCWGRVVkdjWGxvT1VwSENqazRObXRDVUhGd2FVcG9WMlpNVGxseVVWTTFTMDEyVDFaTlp6TTBUek55V2xFdmNrZEJiVmMyVEZNNFRuRjBjRWhGVFVsTVNXa3phVkIzTVVOd2FVa0taSGt3WTJsbE1YQXhLMDFwYW1wc2FrMW5Xa295VTI5ME0zUTVNVGxZY0dsSGJqUjJSMjU0VURkUlVWTXZTM2RIUTA5aU1HZGtSbEJ4Tm5saFJWbEdWZ3AzU3pkT2NrSm9iM2RzVlVoVWVXeEhWMnBTZG01NlVqVklielJVYjFJM1V6TmxPRVkzUzNaM1V6ZE5PVFE1VjJGTWNERlFNblptTkdsRmF5OUJPVEpzQ2sxU0swRTBWSEp6YmxoRlV6aE9SVWt2ZGpKTk5FcHFWRWxhT0haYVJtWlJMME54UTBjd2JVWnFUWFpRVEUxRlNsQTBZMU0xTkZVMFpGaGxVRlJyYUhBS2NIcE5aekZDSzJZd1QyOUVUMWhyV0VaQ2MxZFBLMncwUkhJNE5DdExTMWRsYVcxSE1FdFBlVmxOTWk5WFNuSmlXbGd2YmxWWWJYQTFVblJVU1ZCTlp3b3lPVXRhWkhWc1lubGxSMGhQVDBkaVJ6aG1XV1pFV0dKSU56Sk5NakJuVjNodllYRkNZeXMxZDJKelVFc3lNRlpwTkdVcmFXSXljbkp5U0RoVlMzUmFDbWw1VkdSck5rbDJTRFI2VFhad2RIQkpVbWgzUnprNE1saEtRVUZGYWxSemJ6Vmpha0U1TWxaRFRVcDRUR1oyUVhaSGF5ODVkbXd3TUVWNU1UVlRWSElLTlhSeFlXMWhXa1ZNZFV4eVRGWkRXRkZXYWtkbGNFSm5jVzFvSzI5dFVrSlNSRzQ1ZGxadGFFVndUMnhTTjFwbFMwaEtVakZwYWxWcVJtSXphbXBKU1FwcGJ6WmFjSGhMYldsNFFtczJNMkZIUVdSNFdXVjNTVVJCVVVGQ2IzcFZkMDE2UVU5Q1owNVdTRkU0UWtGbU9FVkNRVTFEUW1GQmQwVjNXVVJXVWpCc0NrSkJkM2REWjFsSlMzZFpRa0pSVlVoQmQwbDNSRUZaUkZaU01GUkJVVWd2UWtGSmQwRkVRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRUtlSEYzTlhGQ1JGVkJUbVpqYVRsMlZsTmlVaXR1VVRWd04wRm5abXg2VkRSbmVFVm1NR05VVDBSYVpsSlJLMnd5UmtvelRrWTFhalpZYzNoUlNIRkZRZ3BEWm13eldGVmhjSEV6UzB0dU1sRk9SMkZVWWxWRFJIbEZVRkJ5TVV4bmIzVjNlV3RqU210VFJtUk5RVU5oUmxoYWF6WTVhR3R2Wm1WSWEwWm5WRU14Q2pkU05YSjViSFpxZUVOSVdGQjZUVlUwSzNkc1FrTnNaRTFyYzFCeUszaFpTRFZSYkZOR1NGWkpkVGsxVERadU4yeE9PV2xKTDA1emNVOVRhMDVyVmtNS2FuZGxPRk5xUm5aWGFtaEVPWEl2UWtWQlpVMURPR05YU21wbmJWVk1Za0ZzT1hwaGVuUXhVREZJU0hKSVdsZFRUMnczTjJwNFREbHJOMGN6UW0xdFl3cG5LMVZaV0dodmEzaHVjWFpDTWxWeFdubHFXbGx5ZDFWcVFsZGpha3BKYmtGTE1IazJVSE5FVG14aGFITjFka1lyYURscFdVRlVPVlU0WW1aNWNYVm1DbmxKU0VSWlJWaDFTa2d5ZWxGQmVFcHllVmxPYldsaE5sbGpTVXd5T0haVVdXbEZWVkIxZHk5clEwWlNPVVY1UVc5c2VGSkpTM1pHYm1WS1pWcERUbk1LVFhOTVlrb3JWRFYzTkdNeVZreDJUREpZUzFWelkySmllbVUyTVVKUFJqSkVTbkJZU0dsRlEzVkRVVGxOUjFvMVoyMW9SbXRTYm0xUVZrdDVWelY0VndwT2QyZDZja2xSWmpGMmVuQnJaazlTWmxObVRFY3dUMnc1ZUhRdlNYaGtlbFYxUTA5cGN6azVjVTVpYmtKV2NuTjVTRUpMWVVGaFprOXJlSEJtYkc1NUNqaFpha2RYZDFJcmIzcEpOVkZxYkhBd2NWSm1SRGhtV2tWNlptUlphMkZvVnpJMlZFeFZNMHhhV2s5RmRYQkhka1Z4Wkc1aVMyeHNPVFl6YzFkMVRIZ0tZbHBpYjJSdUwyeHFURE00WWt0cVIyTXpWWEowUW5RM2JqQnVhRzE0SzBGeFptRm5TR1JFWlhKNE5UZE9ZalI2YXpOSlQwb3liMnd2TldSaWQzRTJjd3BuWjNWSWJIZEZWV1l5V21GUFEwTkRWWFl4VTNOSlJ6Rm1WR1V4TW14RWRVVjVUV0ZVUkVOM1UzUlpQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJNM1Z4UkhVeFRTdG9aMEpVYVZFeFRXdG9ja0ZwYkZjek4zWktZbTVEWlV3NU9IZDZTQ3RsVEhKaVUxbE5VRTVJQ2toell5OXVUV2RsWTJZNWIwNU9OM293YTJWcGJERkhVRzlEZEVvMWJXeFhhMjh3YWxOaGFWQjBOMXBWU1dZd01VaEVRME5NVjJwNU1WTXJhR0pMVWk4S2NpOHZWMjFHTTJWNlZsQkdaMEZaYkhweVJIQkJhWGhuY0dOeFZuSm9RbUZ6YjJaVFVuWm1UM0JCVkRaeFdXbFpWbTU1ZWxkTE1FVjFVMnBNZW14VVNRcE9LMFIwTmpKVlVEWjRaMHBzZFdrd2RrUmhjbUZTZUVSRFEzbEpkRFJxT0U1UmNWbHBTR04wU0VsdWRHRmtabXBKYnpRMVdYcEpSMU5rYTNGTVpEZG1DbVJtVmpaWmFIQXJUSGh3T0ZRck1FVkZkbmx6UW1kcWJUbEpTRkpVTm5WemJXaEhRbFpqUTNWNllYZFpZVTFLVmtJd09IQlNiRzh3WWpVNE1HVlNOazhLUlRaRlpUQjBNM1pDWlhseU9FVjFlbEJsVUZadGFUWmtWRGx5TXl0SmFFcFFkMUJrY0ZSRlptZFBSVFkzU2pGNFJYWkVVa05RTnpscVQwTlpNSGxIWmdwTU1sSllNRkIzY1dkb2RFcG9XWHBNZW5sNlFrTlVLMGhGZFdWR1QwaFdNMm93TlVsaFlXTjZTVTVSWm00NVJIRkJlbXcxUm5oUllrWnFkbkJsUVRZdkNrOVFhV2xzYm05d2FIUkRhbk50UkU1Mk1XbGhNakpXTHpVeFJqVnhaVlZpVlhsRWVrbE9kbE50V0dKd1Z6aHVhR2g2YW1odGVIWklNa2gzTVRKNEt6a0thazUwU1VaellVZHhaMWhRZFdOSE4wUjVkSFJHV1hWSWRtOXRPWEUyTm5ndlJrTnlWMWx6YXpOYVQybE1lQ3ROZWt3MlltRlRSVmxqUW5abVRteDVVUXBCUWtrd04wdFBXRWwzVUdSc1VXcERZMU16TjNkTWVIQlFMMkkxWkU1Q1RYUmxWV3MySzJKaGJYQnRiVkpETjJrMmVURlJiREJHV1hodWNWRlpTM0J2Q21aeFNtdFJWVkUxTDJJeFdtOVNTMVJ3VldVeVdHbG9lVlZrV1c4eFNYaFhPVFEwZVVOSmNVOXRZV05UY0c5elVWcFBkREpvWjBoalYwaHpRMEYzUlVFS1FWRkxRMEZuUW0xNUswc3ZjV1F5TVZWalZYb3JSM2RPU0VWVllVSm1iSGxQVmxaQ2NEUk5SMWhMV21VeWFHOTRiVzk0YzFadFR5OXlPR0ZJSzBWclFnbzNVRkZVU0ZwV01uSlJOSFpzWVRoVUx6WktkVzVNYTA1clFWSnlNMVV5V2xCSU1rUjRkelpOTVRGdVVYTjNjalJuUzFORFVUQkhWekptV1U5QldYWlVDbE5CVWxaNU15OHpNWFZGT0ROV1dXTlliRmN3UmxaeFpEVmpRakJrWVZwWVVVOTVUemRoZWtOb1dFd3pUelpLYml0SldYcDFhV3Q1YVRSc2NpdG5hbW9LVFhkNVNrTlFjaTl4U0RWWVZrYzRZeTg1ZURCT2NtMUlhRVZHWlM5UldsTnRUa0puT1U5MVRHSmxZazA1WVRaemN6TmhaQzlLT0hvclIxaGtaemRaV1FvMWNTOVpPRGhZYWswMU0yOXJiMXBsZW5SaVJsWk1aV1IyVDBSV2RVdDBhbk5UTnpSalJsWm9jalJIY2t4alNITnFOVUpXU1cxQlIyTldRMVJyVlVNckNtcExkV3htYlU1RU9GTk1OVzVRUm5sa09XNVBVa3B5ZVdOclpuUkllSHByU210YVUxWndNRXhZYjJ4VmFGQmhPVkEyZGl0dksyZ3hWMnc0T1dVM2NVWUtXbW8yTTNGMGRuWnRRV2gzTTNkelVHWndTVlkzVTIxUE4xWTNSMDVtTjJkSEwwUk5XVGd6UVZCaVEzZDZVa1pUVmpaSmMyTkRUV1JCT1ZWd1dVMU9UZ3A1TTI4ME1sazJTSFJ4Ym1aemFGRm9aMmwzZGtGWlRrNVFWV0ZoT1ZGT09EQk9MMjlvZGtkWVJISnlLelJSU214V1IyMWllbUZEV1dRMGNGRXpjRGRIQ2xsQ1VETkdNVWxQTVZVMVJsZzBNV2xDT0hWSlVVbEtWRmhxVGtWVVJqVkpkRE5STUVsNlEwNXNRMUlyWnpRdlJpOXVTa3g2Y2xSdFl5OXZaVnBCYlZVS2RpdDFaamt5VTFGWGVraGFZVGR3Y0c4MFkyRjRMMUV5VnpGVmFERlVlRXMxU1RoT1VXbFVjamgzTDBKWWMzTjFOeklyYUdwelN6UjJUelV2TlZaRlVBcHVUMHRaVnl0TGEwOUlaMm8wZVhCNFIydDViRkpxTlZGdGVrNWxMMGhYVld0c1NFOTBaWFk1WW1veFoyRkhiVkozVVV0RFFWRkZRVFJ1S3lzNFFYUXlDbUZhZUV0aVNsWTFTVUl2U25sSE5pOUpaM1l5VWtKR01tdHVVak5uZDNOT2MwRTBOazFIYkZGdmRHWnlSM2hwVkZWTk1EVXhWMXBtUjFKQ05qZEdVM0lLZDFaUlJtaEtaRlZvWnprNUsxcE5UVTl2TjNoU2VrcDFVMFZpYTJGMVR6Sk9Za1JXVEc5TGEwVkpNM0ZvT0dOQ09ETmFaMmMzZFZZMlN6Qk1WR3B2Y2dwVFlraENVSFZqTWxsUlYyaFNaamxpZUcxS1VVOUtVMlpzT1ZsSFFuRktjVzl3Vkd3eFJrbzRaell2VUZJNFRHUkpXa3BuT1ZKUGFtMWpjVkF4ZDNGTUNtcG1URGhNU2tKbFowNU1kWFJoUmtGbFFuTllUbTFDVVhwcGQxY3Zhelo1SzFOd05tcHRNRGh1VjJ0MWJtcGtWMEp1VjBSR2NrbDFaa2hNUVRZNFVta0tOV04zZGtNck9YTm1SR1ZhV0ROVWFqaDNNM0JaV1hoS1dIWlpkVXRGYmpaMWNuaHJZa3A1T1UxQ1VFNXhZM0l4VGs4MmF5c3hhelZWYVhGcWFuVkJNQXBUVFVOSUwxSnBWa1phUmswd1VVdERRVkZGUVNzdlRrNUtLMkpqT0ZsMVREQmpVbVVyWW13ME1XeElibWsxUjFkRGMxWjVjM1JTYjFZeVVrbE1VbEpsQ2xWUUswRkRSa0ZZTkVobmVEUlpaMGMyUms1TlNVOU9PV05XVkdWd1JtbHNZbWxEUzFRNVIyZGhjUzgwTm1SUFVsSjZTMlJ5ZGxWSVNrRnFWV05YVVVjS1FtUlBiVEJ4YzB0alMxQmlUbVoxYUZKcFozTjZNbTV4VG5kTGVYWlFlbkZaV0VGelRuQnpVSFV4UVZCWU5UaE9WbHBRWkRGeVpVTndhVzlrVUVVdmRnb3JNelIzYmpOWk1FdHFkRkp3U1dkT1JVUmphMGhZY21KRE9YQllTR2xuZFRBelVIWjJWaTlPVjBkd1kycEdZa2hPVEUxb1RGZFZRMWRxY0VSSlJEUlBDakptVDJReE0wVk9MMmx4TW14NWEyOWhTV2xsVVdWdk1tRkxRakJUY2psbFMwUnVlSFppUVV4WmVrRlZWV2hQVG1GYVR6QmlPVmwwUVRWWFkySmhkSGdLVG5JdlpUWmthMFZRYTJGYVVUaEtWRVZoZEhkYWNtaGhjVXNyY1Rkb1RIQTFMekU1U1ZsdmVtbDNTME5CVVVKVGFXNUZMM042TW5Nd1VYTkRUbEp4VndwRVZpdFJhbTFPVXl0bU56azBWWFJRY0dWbWFuUnZVaTlqZWk5aVdYQllSRTF0U2pSV2JWWm9TR1JyUlc1eVJISlNiV3N4WkUxdEszY3ljbUpZWm1GekNtZEVjazVXTjNkMVNIVmtiM0JqVlhkNU4zb3dRWGhZYTNwU1RucFNjVXRhWTJNMVZrOXlNMGxTYjNnemJGVllWa3hFUzJocFIzTTRRMDgwSzJsVE16QUtMelJOT1V0bmFqZzJPV3RIVGxsMFVGaDFlVVpSUnpCU05FdGpPSG9yTmxkWmRIaHlOekpTT0d4dllVVTJWM0JIV1d3ME1qVktNMnN4Wm1JeVIyOXhSZ280WkdsVFJXcHBXRlJJUVZOSVpHd3dkVkJoVFV0SmRuRmFORTlSU1dScWEwZEhLMjV6YzNwRWRqbEdUVEZTVWtKMksxQXdVak5aZFM5c1JIRjZXVGRCQ2xka1lXNTRZMXBKVkdaeFRqRlFlbk5CVmxScE1EaHlkV2RFWTNOeFdsZzRWR3R6TVhCRlVHeDZWVFJOVm5kRFptOHZRa1UwWjI1TWRGaFpXbFYyYzBvS2FVSkVlRUZ2U1VKQlVVUlpjMGxrYVZWM1kyaFpNRUpOYlVaVFN5dE1OVFZ5V2xjd1JIWkdOWE5DYlZkMmJVcEVSREJsV1Vwa1ZqaFhiRXRYVlRkU1JncGFXSEZhUjNaSE9UZExOR281ZVZCVVZHZG1lVlo0T1c5dFQyNDNMMnBITW5ORlVXNWljMDloT1Zkb2VYRmxRMHhYUjBSSFlWSXhXVGcxUTJSNlYyTTRDazh5UkRCcE9HUklNMHBQTVdrNFZscHlTMDV1VFZOeGRuaE9Zbmd5SzJweE1EZzVNVVZSYkZveVkxQkpkMHR1U1VkYU5YUlhaRGQyWTB4bFJ6Tm9WemtLV1V0ck1rWmhSVTl0YVRSblowdEtWMFJ0U1hjeVMxSXhWR3huV21sdlZFVnFlVEp5YzFwTVFYVXpUa1ZhU1ZKcFlqUjBPVGx2UnpGYUwxbFFOMlppTXdvMk1uRkJiRmhDWjJZeVpVWkVNV1psU1cxdlExRTFXa3RwU2s1c04ycDJUa0ZtVUc5S01VeFFVVFkzUkVwUVVYZERaMDkzZFhWMWVrSTVRa1JXVm1ReENqZERaM3BCTjFkSlJTdGxia2xPVlhkRlZ6SXdUbTFaWjBaWU9FTlZjV1JFUVc5SlFrRlJSRmc1UW5sSkszRnJXV3RqVFhwR0t6STNhR3BqZVdNMk9XTUtjM1ZGWkhKTVQwUm5WVzlLU0doYVR5dEZjRU54ZVVoaVREZG9kV2hxT1doaWFqbE5VRk5MV0RObVVuQm5VbVFyT0hwbVprVTFWRU54UXpWMVN5OVJaZ3AyZFdwUFp6ZFhSRGwxVUdrNGRETTBNMjEzUTJWVGJsZFhTMHB5Wm5nelRuSktWa292U3pOTVFUWnBURFJ3Tkc1eWNrWkdWams1TW5kdk4wcFhVRnB0Q25WelVXdEdjRzVUT0RJNGNVVXlZM2R5WVRObVRHUnpWR1Z3YjA0M1pISjBXRXQ0UWs0emFtbHJkakJqYkVobGVITk5kMHhTVld4eVRISk1SVTFzVVRBS056VlJZemxFTUZkc1MxaHNkSE5KWkRVMFprbG1lalJaUlVOelYxUlFiMFZYTlhJMGQzUk9NbEZXYlZKS05UUXlZMVJDYTIxdFUzUjRWbTVNWmxSek13bzNUa2xtYlVsRWQyUTVWbkEwT1hZM2FEbE5SbEEzYUhSc1VtcHVXVmh1ZERaYVVVOW1WMDFSYzNwb1F6SnBLMk4yYkZOWFpqVlZSWGh4ZFdVS0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiAwNmVkNjFkM2VmZGIwN2E2YjgwZDM1MTc3OGU0MzYwOGIyNGEzNzRhNzgzYWI4Y2Q0NDM2NzU2OWFmZjhmZjE5NzQwYjBhZjRmNjBmZjdmZDEwYzE3YzFjNGMyNmM4N2Y4MGU2ZjVmZWMwZTMyYzk0OWFiN2RlYjY5YmQzMzkyOQo=\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterUser/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2/listClusterUserCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:12:55 GMT",
       "server" : "nginx",
-      "content-length" : "13164",
+      "content-length" : "12888",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -459,25 +449,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9126a55d-e5b0-478b-9563-6ac981928f61",
+      "x-ms-correlation-request-id" : "d8f8419d-cf55-4424-acad-4c25bb40063b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024712Z:9126a55d-e5b0-478b-9563-6ac981928f61",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021255Z:d8f8419d-cf55-4424-acad-4c25bb40063b",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "55ab117f-a93c-47d9-b8ae-075be3b28c44",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterUser\",\n  \"location\": \"centralus\",\n  \"name\": \"clusterUser\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVVsRWFqZFlhbVIyYWpaTVJXcEdlVVIxVldGbWNEUjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJyZUUxRVJUUk5SRWw2VFZSQk1sZG9ZMDVPUkd0NFRVUkZkMDFFU1RCTlZFRXlWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFRWS0NtSkhNa2d3Y1RoWk56aExhSE5CUldadU5WSklWVFpGYkd0R1VGcE1VR1Z1TjNCbFlUZE9VRXBYVjJoRVJIQnhNV2M0ZG1RNVVrWjZkMVpFVGpScVJVc0tUMVZaUW1kUmNEaDNTa2xEVVV4d01VcFBlSFpZU0RacVIyTjBSalptSzJZdlMxUlpaRGs0ZURCTU5UVlljSGcyVlRkV01taHBWaTlxVDBWbE0xazFjUXAxYW5WaE0wZEVjRkU1Wm1GRlZVOW1TbEJ5UjFGc2VFdE9SbWsyT0ZCM2NXOXVkM0JvT1M5UWQwUkZaMkpuVjNZeFZtdE9RWGxtYUcxdGQwczJjbUpJQ2t0SGVXcFhObVk0ZFdkcVNHVlBWVm8zUXpKUVRWa3pZa05PZDNaalRuSklUa0ZyUlRSaVVsVkZabkpzYlZsQmQxTjNaWE0yVEdwNE5UZHVXSGg2V2tjS1lrdHJRbTFZZWk5MVUwNXRhM0pOT0dodVUyMVJNR1IwYTAxa2FsSjBaSGN5TUdOM1FrbEtTMkoxT1VZM016TXZhbmxyY2psUU9HNWpieTlsYVRKb1p3bzVNRXR3UzJWTFp6TlBRVVZPU0daNWVXRmxjMk5ITVhNMFZFTk9VV3RQTlU1SmJtZHRTMkZSUzBOU1pXcHBXWEIyVVdjMlVXOTVhR3RVU3psMmRuWndDbEZ3VTAxTGRqSmtUVE5USzJNNGIwSllPVEphVVdnNU1sbGFNVWN6VlVKU05FdHphMkprTUhkUlpIUTBkbUZITVZwTmF6RTBjV3hTVjBJclVGSllXRWtLVVRGT1Nrc3ZXbEpCYTFvMGVXWnBVMk5XYkVkMldYaG1lVTk2TnpaT0wyeGpiSE5PUW1VNE9XVnNaV3RyUXpSSWMwOURkSGRPVTBsMk4wdFZibXc0ZFFwMVVYaG5lVGQxVW1odmRGUjFRWE5IYjNWc1ZWRlBWa3RDV0VwemR6TlNWbXhzYVVsa2MydGtlRUp2Y2tkeWJHWmxTMEZoVVV4eFRtOXdhbEpCVjAwMUNrUm9NVFIzTWpNeGJXTmFOVUpETld4TldWbFhjREpSY2pScFlXcHpkMjlsZGpCd1N6ZE5iMVZVYVd4NWNqVkJjMEoyWlhsUlpHTktkSEZTWlhkdFdsSUtNa3BwUjFKNk1YaFZNak5ET0ZCMWRscEJla1ZDVG5aT09GQktlamxqYWpRclRFdG1SbEpxVUVGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlEweEpWamxyQ2pVdmMyaDZOVkkyTDI1Q2MzUTBMM05XVVZBdlUwRmhRVVpTSzFkbGVERm9jMHhNZURGQ1VVVklOSGR3TTJSQ1QwMHhVVWRRYTFaVlZESnJVVVV5TTNnS1JrTm9iVnBGWTBoRVpscFBOeXRLUkd4bGFsbHJORk53Um5ScVoxbDBNV2xGUW1Kd01EYzBSRE5wZDBsMVMzUkJSRTlHVWxKa1YzSnpVR2d2VGxKWWFncEtiM2hLUWxoV0wzUXdNbGxFV1VwcFZHTlFiVVZ3YmxObFRtaE9aSEp0VVRjelYyNXVjVFpsVTFScVZHVkdaemxFTUc1VlVFbFNNbnBUTTJkNE5tVjNDa2d5ZURocVZFZGpSbGQ0YXpoWmNYbFlTRlpwU1RKM1dWUjFMMnBoYWxnMVUwUkliVEV6TDJ0a1lWVnBPV2h1TW1STlkyOWhSRkZqWW1oUU0zVXZZV29LUmpWUmFEQjRkbkZWWjFSeFYyNHphVkIxTlZaclF6ZHVXRTA1U1RKM1FuVTNWbWxUZVU4MGJVeFpNazFKTURSUVp6WnVOa0ZWYW5STlYwMDJVRXBVVHdwRUsxbzVaRVF5ZEZscEx6VjJjbWxpWVVoaVpUQnRjVzR6UTJGWVdsaDFWM001TVVwRllUUXhXVVJwZVZkQ1drdFJUM2xaWlU5aFluTTVSeXM0UTNkQkNtRnRLMjkwWlZadGFqZDFiRWxLSzFKbVJVVnJjekpSY1hCSlpFSk1ZVVJyZVRsNE1YVjBLM0JIWkcxclNtTXpZbnB2T1ROcVRVMVVPV3RJTDJnNVEwa0thaTl0Tm1sYWRYQlBXVUprVW5CRGR6UkJLelpCY2poUVZsb3pibnB3WkM5eU5GaHFjMXBHWldnM1dYcEZTa2xWU2pNM1NVdHROM1ZMTkhab2RFMXNPQW8wZW1SdU5GZHhOemh6VEhocFZrbHdUQzl2ZW5oQ0t5dFFURUpXT1RaNGNrVllkV1Z4YTFkeVQzTnZjRXR6V1VGSmJURnRkVTF5VURKRU9HTlJSbFJhQ214elJXVldTMDlvU2pOUk5HTmxNMmg1VTJOTWMzUlFLMDlxVERGdGJXcFVjbHBVT0RoQk9HbDFVRVJQV1d4TFIyaE1jR3hMWVhSVFdubGhXWFJKTjFBS05TdFFiMkpIV2xwbUsxUlhhRUprTVd3d1dqWXJTRzlXVGs5MU1HTmpZVkJ6UkRnemEyYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zODk0NDZjLTQyZTZjZWNkLmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczQyNzg2OTM4ZjQKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczQyNzg2OTM4ZjQKICAgIHVzZXI6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzIwMzc2X2FrczQyNzg2OTM4ZjQKICBuYW1lOiBha3M0Mjc4NjkzOGY0CmN1cnJlbnQtY29udGV4dDogYWtzNDI3ODY5MzhmNApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzIwMzc2X2FrczQyNzg2OTM4ZjQKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2VkVORFFYVlhaMEYzU1VKQlowbFNRVXgxTldSd0syeDNaV05JYVhZdk16azVaMUZ6TW5OM1JGRlpTa3R2V2tsb2RtTk9RVkZGVEVKUlFYY0tSRlJGVEUxQmEwZEJNVlZGUVhoTlExa3lSWGRJYUdOT1RWUnJlRTFFUlRSTlJFbDZUVlJCTWxkb1kwNU5ha1Y0VFVSRk0wMUVTVEJOVkVFeVYycEJkd3BOVW1OM1JsRlpSRlpSVVV0RmR6VjZaVmhPTUZwWE1EWmlWMFo2WkVkV2VXTjZSVlpOUWsxSFFURlZSVUY0VFUxaVYwWjZaRWRXZVZreWVIQmFWelV3Q2sxSlNVTkpha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRkZSa0ZCVDBOQlp6aEJUVWxKUTBOblMwTkJaMFZCTURKVFVuRkJZVzQyYTNKeGNYcGxTMEpOTVRNS0x6ZHZaVVp5Y1RWdFIwbGFibXBEYlhCS1N6VXZNa1UxZDBWd1VGSkVPVXBKWkcxRVkwMVZWekE0TlhONFlqQlVhSE5PV25kbWRrbHhUMDUwWVUwNVl3cFlUazgwVDFFMlkxSnVZbk52WVRjd05HSTBibEZSTUhkUk5sQk9URVpxUWxWblRGbHRNbUZLUjJGSldYWmpZemRXWTI1dGVHRlZUa0pvU0hjNWRYaEdDbHAyVlc1dmVEbFBPVGx1YlVzMmVURlVSVXR4VEdOcVF6UmhaMjB3WkZRclYwSkpZVVZJWlVvMFJUZDBkSFJ0U0ZSdGEyNVhVR05HVm5GdmR6Z3hlVm9LVm1jeFkwcG5VVk4yVlVGaFFrUkhRVEF2YmxWV1EzQkJXVGMzTUdGalQyeEdWM2xsU2k5dVdGRlVjblphWkZGSmRYUmhVSFl5UW5OMk0zZHBWR3BEZGdwSlQyOWllbmhFYVVKalUzcDRlWGhIWlVWUVRsSnliVFl6ZEVKUVNucFZZMEk1TkVkeVZtZG9lV1pIWldwWE5VbE9TRFJ6YmpGUE5Dc3hkMG92Y0VzdkNsVjJZMFZyUXpSakwxcDRSMGhITVVwVVVHNHhURWxZTjA5Mk5ISnNjRFI2SzFrMldFODRWVXROUTJ0MlIyNTBia1pGTlU5S1lXZDJaWHA1VUZvemRUZ0tZbTVSV0VWU1JqSklUbFpPVDBKdWVtMVJOSEJFT0dJNVFsQldiMG94ZHpOVlZsVXdZa2hPVnpBeWQySnJOSEZTWkVoSFNGWlVhakpHWlc1eFpqWlFNZ3BIT1M5dlVtdEVTemQxZUhGSmJuVTRZWFV5UkhNeFdYazJhRkEyU25oNlpUUnpZaXN5VmxabFVrUlNkVE5YWmpBMVlWWmxObGxhWjJWalRsWk5hSE5qQ25jM1ZGWnFiWFEyVlhSQlZHUkJWRTFPU0RkWlZYVk9NVVJLTURaU1YzWklUMFZZVmpkYWNHNUZOR0pMZFVsMVRIaGtlV0pZYlZrMk9IWkdaSEphZUdNS1pFUklZM3BCWW1vekwwczViR2szYkRaeGR6TnFWMHRvVmxKREsxSlVRbXhXTDJ0aWNrUk5UVGhETlVwS1Rtb3lkVWhpUW5KcWJVOVZjRU4zVDNWNFpRcGtiU3RYZEdoU05FWk9ZMVZFZW1sMFNXdGxTVXBqT0VOQmQwVkJRV0ZOTVUxRVRYZEVaMWxFVmxJd1VFRlJTQzlDUVZGRVFXZFhaMDFDVFVkQk1WVmtDa3BSVVUxTlFXOUhRME56UjBGUlZVWkNkMDFEVFVGM1IwRXhWV1JGZDBWQ0wzZFJRMDFCUVhkRVVWbEtTMjlhU1doMlkwNUJVVVZNUWxGQlJHZG5TVUlLUVVsMVNucDVkbW94UmxORlJqaEJRa0Y1VWpOc2JYUk9NMjVpWld3MVJFZGlha0ZITUdWTVZXRlFSVlJOTWxKeEsyNU5ZbFV6WldwTVFVVlRhMGwzTndwcU1ubHRSM1ZNUzJWc1VHbDJVbFZJZDI5aWExZGtiakF4SzNSQmIyeFBSbEZrVkcxVlIwTklOakJTYlhOTlNEUkpWMFpFTldwc05tZHJkVFJsUmxvMkNrTXpRM1JuUWk4eVNVcENTeXRPYURsdWRtVm5WWHBIWlc1eFNqQnlLMU16UzNGNlYzVkJZVE5NTW0xVWRYSTFkMjVJYkRWUFlXdDZTM1pUZFZFemNuRUtiekJzUVVSMFFYaHhZV3RzVFRoalIycERlVEZMYTJNeVp6azJTVTB4TTJSUUwxbzNiME4zWTBWMmMzQk9iSGhvWjNCd2VXOW5hVUY0V1V0SVNHeERiZ3BWWkZKelZFSkdjV0pvVkU0dlpHMDRhalVyZGt0Q1VHTjNja0pCZUhoa1YwbHZOSFUyYlUxRGEwRnhUM1J5YVd0c09WVkdXbUZMZVRGU2JVWnpiV3hWQ25KMlNra3lSbVUyTVV4WGFISjZlVmxKY21neVdFWldTRmRSTW05UlEzbzNOMUpRYjNGV2VIbDJaRkpzZW5GTFlUbEJTRkozY25kMFVVUXhOVEJQYVVzS1JDOWtTVzFCWmt0VVJURmlNMVJsVDFKa01rWnlOeko0YzBGbUsxazVXbGxCYTJ4dE5VOWtZbXRuVVV4YWJITm1ZVTFMYW5veWMyNWtRV3RVWldGR05RcFVhbEJEYTIxVVFWSk5hM1Z4YjNSYVIwVnJZVXB0YWk4clVsRTNOMHB1U0RZelkxTm9VbUp3Y2xsQlRHdDBlR3cwY2xGbUx6QldiM1J2Ym5oUFRYRndDamx2TkVoQkszTkRkMUZ6T0daUlNFcFpWVFZSVlZRck5EZE1NV2xyU0hwWmVqVjRiR1IxV0doMk5IUkVObEp6Y0RCM1ozWkxUbUpuZUZJNVdqWjFaV3dLWm5Oc2JWazBjVXgzVG1ocVJERk9VWGQ0VGxKcVpWY3JabmR6VFVNNVVrUkpTakJOTVZsT2VHOWpZMjlHTkd4S1VIZHlkbUk0TXl0aFRHMVZZamM1UlFvMlZWRjJiamxNUldkUVVHeFVUVWg1YzNjeVYxZExiMWx0TTFkVFIyZHRNelpaT0dsQmMxWmpVR2Q2WlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCTURKVFVuRkJZVzQyYTNKeGNYcGxTMEpOTVRNdk4yOWxSbkp4TlcxSFNWcHVha050Y0VwTE5TOHlSVFYzUlhCUUNsSkVPVXBKWkcxRVkwMVZWekE0TlhONFlqQlVhSE5PV25kbWRrbHhUMDUwWVUwNVkxaE9UelJQVVRaalVtNWljMjloTnpBMFlqUnVVVkV3ZDFFMlVFNEtURVpxUWxWblRGbHRNbUZLUjJGSldYWmpZemRXWTI1dGVHRlZUa0pvU0hjNWRYaEdXblpWYm05NE9VODVPVzV0U3paNU1WUkZTM0ZNWTJwRE5HRm5iUW93WkZRclYwSkpZVVZJWlVvMFJUZDBkSFJ0U0ZSdGEyNVhVR05HVm5GdmR6Z3hlVnBXWnpGalNtZFJVM1pWUVdGQ1JFZEJNQzl1VlZaRGNFRlpOemN3Q21GalQyeEdWM2xsU2k5dVdGRlVjblphWkZGSmRYUmhVSFl5UW5OMk0zZHBWR3BEZGtsUGIySjZlRVJwUW1OVGVuaDVlRWRsUlZCT1VuSnROak4wUWxBS1NucFZZMEk1TkVkeVZtZG9lV1pIWldwWE5VbE9TRFJ6YmpGUE5Dc3hkMG92Y0VzdlZYWmpSV3RETkdNdlduaEhTRWN4U2xSUWJqRk1TVmczVDNZMGNncHNjRFI2SzFrMldFODRWVXROUTJ0MlIyNTBia1pGTlU5S1lXZDJaWHA1VUZvemRUaGlibEZZUlZKR01raE9WazVQUW01NmJWRTBjRVE0WWpsQ1VGWnZDa294ZHpOVlZsVXdZa2hPVnpBeWQySnJOSEZTWkVoSFNGWlVhakpHWlc1eFpqWlFNa2M1TDI5U2EwUkxOM1Y0Y1VsdWRUaGhkVEpFY3pGWmVUWm9VRFlLU25oNlpUUnpZaXN5VmxabFVrUlNkVE5YWmpBMVlWWmxObGxhWjJWalRsWk5hSE5qZHpkVVZtcHRkRFpWZEVGVVpFRlVUVTVJTjFsVmRVNHhSRW93TmdwU1YzWklUMFZZVmpkYWNHNUZOR0pMZFVsMVRIaGtlV0pZYlZrMk9IWkdaSEphZUdOa1JFaGpla0ZpYWpNdlN6bHNhVGRzTm5GM00ycFhTMmhXVWtNckNsSlVRbXhXTDJ0aWNrUk5UVGhETlVwS1Rtb3lkVWhpUW5KcWJVOVZjRU4zVDNWNFpXUnRLMWQwYUZJMFJrNWpWVVI2YVhSSmEyVkpTbU00UTBGM1JVRUtRVkZMUTBGblJVRjRhMHcyWjFaaVRYZGxaRVowVWs4dk9VMVZiMjFOV0dOV2IwVkhaRXMzT1ZNcmNHaFJUbFZGWTFWeGEzVllOVFJZV1M5c1lsVlFkUXBFVTFGelVuSmlRMDloYzJReGVsUTRlQzk2TTNNM05uQTNURlZsT0ZWcU5EZFVjVkYzTVROcGFtSnVhbTV3TWxSbU1sWTFUVTVqSzBwVGRWSkdVRkJ4Q2xvNFYwSk1TRTVzVGxGcVdUQTFjM0pRTkN0UVlWaFJSMUptUWxCSU1FMXhlVGhyWm1KVlNVZHhSWFY0VG1walNVZFRla1EyY0ZOck5VRlJZVVZGZGxvS0sycDJSRXR2WldOV0wxRnZMMUpsVDJWa1oydFFObGxpYUhkUlFVcEVPR1ptSzBGMVIzbFZNWGRXTUZWalRIUk9jM2x3TVdaYVpXODRSa1UwVldGSGRncHhPWEZrVlcxaFQwSlVhMkZtZGtkb2JrZEpOVmhHV2pKaWJFMXRlbGcwUlZkMU5rRnlaSGhSY1V0elZEVk9VR2xuVlZSTmVWSkZhVk0yYkRaQmNqZDNDa1ZGUVhGWlNtRnRiVUZ6YnpKWFRFWlJlVVp2ZVhkalJuTkxaVGx0T0U1UU5VSmpWRk0wZWxkTFUwVjNXVFp6VDFZek5Fb3hjbEpUUmpCb00wZzVXRFFLT1Vob1VqQTJUR2xxTUhKRk1GTjZkRXBRUTFKNlNscHNZMVozUnpOSk1FaEhRVXgxZFZsSFJ6WktZbUZHUkdOdFdHRmlabFJNZEZwb1lVVkJNWEZWTWdweE9VWjFjR3hqZFRWNE9VRlNjMjV0WVRaT05HRk1kWFZ5YmtFNWJWbFdaRmhyWlVZeU0xbzFaWFI0VjNRMlkybHdkWGhMYzFGdFoyOTRPSE5QVFhGWUNtd3JWVWRrV0haWllrWlBlRE14ZUN0TGFqTnBabVJDYzNkUFRVazJkbFJVZGs5aVVYZHdaeXRzT1dSSFZIQndjak5JZURSclptUnpkbkIyYmpkak1Hd0tOREpFZVdKRGIybEVPWGRCYUVVNGEyZE5kM2RsYWtWcmJqSkhaa05xYTJ0emFHZG5TR2htYVU0emJURnJNMjByZWxWQmFFWnBVeXR4TlhoSVZHbElUZ296YUZwTFRUVlhjazFrYjJkblZ5dDFUVFpSUm14cFR6RlhZbGhLYVVKQ1dGcHZWVW93V1RnNVQwOU9kbTF5WWpSUFIwVkRaMmRGUWtGUVdtY3pkWFpwQ21welZtcFJLMlJtVkhWQ1VIZ3pMMnNyZEZsS1lVNHdSSGRvWVRoNlJHUlVNMGxzWmtvM1lUYzBRMFJ6T1Rka1NuYzNUMncxV0dGMk0wVjZjVXBvUm1FS1JteHNaRWhZT0VkMWFqQjFOR0ZLWjJSSlZrWlJjVEpRVlVsSlNtcDJkSEkyYUVJNE9Fb3hVekpRTVhWeVFURlZOVXN6ZFNzeFNXSjJSMFZIWm1zelJBcHllWHAwVlRsU1IyaFRVV2xUVDBKM056WTNabk41ZVZwTFRrOXBWRlpSZVVOWk4wWkhVbEkyZFN0R2FscEZjazVSVlhWbmVqTjBiRTVDVUZveVQwcGhDbkZOWmtNMVdWSjJSa3N6T0RBd1NXTmxaV3B1UVc5NVFrcHJLME5SV0dGRVlXTkVTRXRqU0RnNVUxaDVPR2RpTHpsVlJqUjJjVFEzTjFsdVF6VlZlV0VLTWxKUFZUZFZLMVpRUkU1Qk9YazBZM1ZCTnpBd2NucHNSR2hoV1doU2VFNVRNRXRuVUZGUldGYzFkV1prTjNGTGIydEtUMlZpUlVRNWJYZFNURWhxVHdwNVoza3pSMVpTY2tKNlMzaDFLMnREWjJkRlFrRk9kV3czTkZWbFoydFBWRWhQTkdoWFZrbzVSamQ2T0hZdk5XaHNhak5RUms0MmVYUTJZWE0xSzFKVENpczViVGhCVm0xUVVVazRkbWMyVDI5MGFHMVRjRk5WT0dOTU5XdG1hWEIyT1ZOdWJsWmlOa1ZHTDBvck1rWnBORmN2Y2taeFMyUlZia0o2UWtaeGIxY0tPRlV3Wm1nd0szZHdaamxMVG1sNGNXOUxMM1ZCWlU4MlRFbzJhbU5uY2tGamNrOHZjblExY201SU5VUnRaRFJ1VTFSak9HMTJiMlJwWTJOdVpVaDVRZ3BvYkRWVloyY3dObVpoUTJNd00zUkZaR1ZKWm1kcU5YZFVOV1paUWpoR1lsQnNSelZtUm1ObWNVWm9VV0pNYUhsRWJUZDBXbTkzUkhsYVJHZHRabmd6Q2tKSGRYUTJkVVE0YTJ0RVNuVndNek5GY3pRdlVUTTBaR1ZFYVZWMVFXNVZlR1JtT1VveFRDdHhOM1ppTDJWeGNrWldlVk16VFZOa01qaGtSakJDTmxZS2QyVkpPV2xJVVZWTFl6aFdZMFpuZVZSWFUwOVVLMU5oYUcxd05EZFZTazVCUVZOWWNsZEpLMGRRWTBOblowVkNRVTVzWnpaUE5sbHhlakIxT0habFR3cFhUWEZEZFZaT00xWllWa3BSYUU1WGQwbFdUazlMVmsxUldsZFhkR3BTT1VkVFoxUjZRa0ZWWW1remQwaHJRVlZ6TjNaT1JEVTVXbkU0VWxjMmNrcHlDak5wUVdwWlFVeHFUbGwwYzJFMFRUQnZiVlJLVTBSVkszQnVjVGR6V2xGMFVqZFNOMVpEVWtSR1lYbzRORkpOTVRBMFUweDBValp3YlRoS05EbDJRMmNLT0RsSVNYbHBTREJ2ZUZSWk0wZzFjRGtyUzJGSVlqUXJhemMwTmpKdlJDdE9VWGxOY0VNeE0xbGlaak5tTTJsM09YcDZXV2haY0ZwVlVHUklWbnBtT0FwNFprMXZNR05DVUROaFVVaFNia1oyWkdKNlRFRlVWWFZvZWpCSGRrTnZha3BMZWtJMlNtTlRaVWhMTW5SUk5raFpNMHRpTW1KSk5FbFlWWE5tYVVWekNsYzNkMmhCY2xoV2MzWlFTRkZNVWxoTFNrZzFTMlZEY0hSa1FtOUVjekozVTJsNFNtazVjWHBtUzNkcFJIazJSMlkwU1dwMVQyZDVSVFJWWVdVMlprY0tPSE5tWjJ4NGEwTm5aMFZCVXpBdldFVTFZa1phV0ZGbmRrVnRNQzlqUzJ0cVFXeENjak5CTkdWd1RIaG1abHBpV1VGMmVrdDFaVVpOVkM4d1YyOW1lUXAzSzFkMmVHdE1TSGhZWW5od2VGaFdUbTlNZDJVME5rNTVhMDV0Y3k4NVNUQnlNMHBaYjI4NFFqTXdWV1ZsVGxvM09GbEtRbTFNT1dNNGN6SnpkekZJQ25KWlVEbHNWR04xVWpSU1pFa3pPRzVaTTBZMVdHUlNhM1k1YzJWck1tSnJZbkZ4ZUV4SGJtVkJaRWRIT1daSFFURXdaR2xYV2xwNmQzYzFTVEZWTlZRS01uVnNTek5tTkRSVFZVMTVabXRSTWtaclRtUlVWMEZEZFhwVVZsQkhOQzlaTmtOWU1YQndUVGx3TTNoNGJIQmhSalZJWWxkeFVsbFpTemwxVmtwNGJBcGlWVGs1TjBWSVYwMWtLMmhRWWtoUVJXUTVNRkoyUzNOeU5GVXJiMWxrZFhwUFppdGFVMDF4U0U5aVExTmhkM2wxYkROdGIxVlpTMEkwS3k5d1RWWjRDa2hIT0cxaFUyTXJVVUprU0hJMFQwbFRVMDlVWm0xTk1tVldlV3RrTkZsQ1QzZExRMEZSUVdFMFpWTm9MMVkzWTI1SmNFTkhZMnhEU2s1Qk1tbHhhSE1LTUhCeU5UZDFaM1pqT0N0SFRFNTZXUzlrT1daVVZrdFdjak5GZDFSclpIbGhkMmxUTnpaeWRHSm9ja1V2ZDBod1dXZFVjR0UyZGpkNVRsQmlLMnhJYXdwd1V6WkJkVFpUVjFCcmJFSmtiaTkyZUROc01sYzNjM05GWlRaM0swdHpjVTV0UkdjelJXeFNiMGRoSzFBeGFtNVhkR1ZWZFRkT01uaFlUbFJ3YVhwRENtcHBaWEF2Vm1kVlNXSmhZek41TTNWaE5FeEJVRWgwYmtwWFRUSTFhMGsyZWxNeVZGZEZhRW94VmxaV1FqVkNiamN2VkZOTWNrRkJhVUUzUkhSWlVrd0tWV2gyYUhkS05XVkJlakJJU21wTFZUZHpPSHBvTXpKNWN6aERWRXRJVUM5YVJESm5iRXRvTnk4eVIwRm1NREEwYjNkeGIzQXhSVzlTZFd0MWVIQTNVZ3BMV1hsV2VXVkJjWEpyZDAxbGFXOWhiVzgzTWtONWRrODJZVmt2TDJkS1kyUnpSRlZJZFVWTVZuWm9TVmhFZEhFeVkwMU1TbEkyUTJST1dVNEtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogSFZqS0YySmpzY25qeU5pZDAzZFFHeDNYZXF3bTgwVkhncDZ2bmhic3ZDd0sxSlVXZTVNbEZmM2xLdjhNTkt5SFRIOThXV01aRE4xRFplck4yTjJmb1U1dWFxaG1yZG40SXVMTmRQRGZJRDlCSkppQ2VtMGRvZ2pQQXl5aTRFMzcK\"\n  }\n }"
+      "x-ms-request-id" : "73f9d9b0-e457-4ba1-b63a-8c50134b0655",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterUser\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSU204NVJXMUtlRWx1YUVOQ1QxQXlkRzloZUdGSFZFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5WRlV6VFdwQ1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTlJHTjVUVVp2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSUkNsZDNkeXRJZVZGWVNVdFhSeXRuTjFWa05GUjNaRFpJYjB4c1NITlFTSGw1TTA5RE5tUkhjRzlhYkVSQ1MyMHpiemRWY3pWMlV5dHVRMEpMV1VnNE1EUUtlbEJQYWxkT2RraExVVWR5ZVRsd1pFcE9hVXhJY1ZGbWMwRkxZMjlRZUhsRlFqZDFka0pyTm00MmFreHBVakJYVldOV1NrOHlhVXBCTVVseVNqSTFiUXB0VUdWeWF6SllRMDFLVDBGWlQwTjBhM0ZLVkZsNFVFMXJLMVYzVkd0V1lrRm9WbUkwWWtKYWNtOURjMUJ6YVVSb09VdEJiV05EV0U1M1dYbHFZVWQxQ2xCSmFTdEVTMnBYU1RkdWJIcFZSWGxSVVVod2JrVk5UaTk1Vm5ab1QySlpiazk2WkZwNU5VbHdUSHB2VEhRdlJpOXViR3QzUmtkWlpubHNVVGQ0WlVVS2JEbDFZMUk1Y0RWNk9HUlRiRTlFUkZOc1kyTXdjWEJtVEZoV2JYcFpWbEpIYTNZeFMyeEdXalJxSzNSYVpGUlBSVklyTVN0aWNFTnlORUY0TlRGTFdRb3ZSbk5vVVVoUVEzTkpTVWMwUTNaTGQySlRZM1oyYjBSWk1rcEtSM1pVTWpOUU1Hd3hhblZHZFdsMGFpdEhSVkJXVVhONVNFZEZZMlZ4U2pNMkwxVnpDbFIyUXpkR1UybHVkbEZtTjI4NGMzYzRjMkpsT1dSblVsSkxPRFpCU0dkeFoyUnJNVEEyVkdKbVFWbzBkRnB5WVVOU1drOHlOWEpRU2pZd2FYZEhXVTRLYmtGM1dIQTFlakkxZVdOQk5FOUdXRk41WmxSbGJFbElha2xZYTNwQlZIWklNMWRaVFhnNVp6QnhVMVEyWmpsa09UbFdSRUptYVRJMllsWm1kemR6UkFwRFpuazVZakp0UjNkM2FrTnNRMVZsZEhwWmFtdHVNV05EWVZRd05URXpSMU5NVEV0WGRrRjFObVV2UTBaM2NEaDBRWG8yZUVwUmVVSm9TbVJxWlU5UkNrcHJiMlEyWjBoblpqZFhkakF5VTJGaVVFRkpWV2RyTWxWYU5rRmtORGt2YkZGbWFVUm1aMnhuVlVGMVVETXZhVmx6UzNkaFMxaHVkVU5NWWpSTlVGUUtkazVUYlZWWlJYZFlaemx2Y2twV1NqTXpNR05SVjNGRFFWRnNVbTUzTTBvd09WTkphWEJaV21oUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRkJhR0ZGQ2xsTFdua3hWVk0zTTNvcmNVWnFjbW92WlZSa1YzQm9SV1p1WVhsRVVIUkhUbnBtYkRsa1MwOU5SRXd6VlVkdWNFeEhNRTkwVXpOdFVXZHJZbmR3Y2lzS1dEWlpZbkZIWkZaSk5UTXpkVkZrTTJWV1NqSlRiVzFtUW5WeFNVOTBLMUpQTmpsUmJsbEJiMVIwUmt4eGNEVkRPVVpaU0Zvd2FHTndSamhvWWpCUWFncE1Sa0Z4ZG0xelozZ3JSRzk2WVhaME9UbDFkRVJVVEZwdlpIcEpWRVV3WVdSbUwwWkthSFkwZDFoT01sQTBRelpZWVZWQlFVbG9SblF4WTNGSE9UbEtDakZDTTNsVVNXVTVlVEJwUldaeU5XVXpTRFI1U2xOdWRVdzFMMVI0T0hOQ1QyNXZhMlJzZHprMlRtTmthWEJ5V2xSTmNrZFZhREZ5YUhKcmRsSllSMWNLVWpWaloxbGFWbXRoVm5WUFkxUmlWWGRPTkdvNVQyeFlMM2xTVms1eFIyWkxTREppUlhsNmRHdGFibEZCVjJkT2RrMVNkR3R6YW1odmRtWjZUSFV2YVFwMFZFNDFhakJhZEV0S2RYSTVlRVJ2U1RCMGJXMTBjM0kwTTJFelkyTnBLMnA0ZUVkMmJHTlVOVkp6VlUwNVdYQnRiMUJZYTJkM00xZEVWMUpSU3poV0NtdFJlbTlWYVdobFNXTnZlbmxpWVdwMFJXMTZZVVJxVVhkTlpXczVTa2t4YlhCWFUxRkpiSEF2TkRWMmQyZG9aR2MxY21jMk5tdDRSRlo1UTJaMlN5c0tOR3RoWjBJME9VTlpVbFZuWW1acWIxWmFjak5sUVV0bVlVbE1lVWxyUjIxMWMzbG9ZMGh3TUZGMFRUVlpSSEZhWWsxbk9XUmhOMHB3VFdjd04xSnZkQXBuWkM5NGVVSTNWV2QzUTAwMldteG1ZV1JuYzJrNWNtOVRTamhNU0hweFJVWnZVbEpFZEZSWVRuTmxNbHBtVlhNMVJtWTVla0p1Y0RCUGRqZFROV3M0Q205dVJHaEJWV2RIWjBaVlVpOVZUbGRYVmtnMlkycEZjbHBvVVRoMlIwZFhORzR6VGtsVU9VMTNXRkpqVURKNk1TdE9UbWczT1hsc2JFdElWM0ZYYm1vS1dGTm1TakpUTVRCV01qTmhXRGhDYnpGVVZXeEVXbnBNUjFCMlZGaFFRV3hEYTFNM1psUnZQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zOTQ1MTFkLTNkMjJhZTQ2LmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczY2ODQzMjgyZTIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczY2ODQzMjgyZTIKICAgIHVzZXI6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzQ5OTcxX2FrczY2ODQzMjgyZTIKICBuYW1lOiBha3M2Njg0MzI4MmUyCmN1cnJlbnQtY29udGV4dDogYWtzNjY4NDMyODJlMgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzQ5OTcxX2FrczY2ODQzMjgyZTIKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJSMk5oUlhveFVYUkNSMWgwYkc1bWVFUnpiMlE0YWtGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNVRVUkJlazFxV1hkTlZGVXpUV3BDWVVaM01IbE5ha0Y2VFdwWmQwMXFRVE5OYWtKaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJsTm05UE4xVjZOa2RCUms5S1JGVjVVMGR6UTBzS1ZtSm1kVGhzZFdOS05IWXpla1JOWmpVMGRYUjBTbWQzT0RCalpYaDZLMk41UWpWNEx6Sm5NRE4yVUZOU05rdFlWVmtyWjBzd2JtMWhWbUZUYWxOT1NncHhTU3N6ZEd4UmFDOVVWV05OU1VsMFlWQk1Wa3cyUm5Od1NDdDJMemxoV1Zoa04wNVZPRmRCUW1sWVQzTlBhME5NUjBOc2VYQlhkVVZHY1hsb09VcEhDams0Tm10Q1VIRndhVXBvVjJaTVRsbHlVVk0xUzAxMlQxWk5aek0wVHpOeVdsRXZja2RCYlZjMlRGTTRUbkYwY0VoRlRVbE1TV2t6YVZCM01VTndhVWtLWkhrd1kybGxNWEF4SzAxcGFtcHNhazFuV2tveVUyOTBNM1E1TVRsWWNHbEhialIyUjI1NFVEZFJVVk12UzNkSFEwOWlNR2RrUmxCeE5ubGhSVmxHVmdwM1N6ZE9ja0pvYjNkc1ZVaFVlV3hIVjJwU2RtNTZValZJYnpSVWIxSTNVek5sT0VZM1MzWjNVemROT1RRNVYyRk1jREZRTW5abU5HbEZheTlCT1RKc0NrMVNLMEUwVkhKemJsaEZVemhPUlVrdmRqSk5ORXBxVkVsYU9IWmFSbVpSTDBOeFEwY3diVVpxVFhaUVRFMUZTbEEwWTFNMU5GVTBaRmhsVUZScmFIQUtjSHBOWnpGQ0syWXdUMjlFVDFocldFWkNjMWRQSzJ3MFJISTROQ3RMUzFkbGFXMUhNRXRQZVZsTk1pOVhTbkppV2xndmJsVlliWEExVW5SVVNWQk5ad295T1V0YVpIVnNZbmxsUjBoUFQwZGlSemhtV1daRVdHSklOekpOTWpCblYzaHZZWEZDWXlzMWQySnpVRXN5TUZacE5HVXJhV0l5Y25KeVNEaFZTM1JhQ21sNVZHUnJOa2wyU0RSNlRYWndkSEJKVW1oM1J6azRNbGhLUVVGRmFsUnpielZqYWtFNU1sWkRUVXA0VEdaMlFYWkhheTg1ZG13d01FVjVNVFZUVkhJS05YUnhZVzFoV2tWTWRVeHlURlpEV0ZGV2FrZGxjRUpuY1cxb0syOXRVa0pTUkc0NWRsWnRhRVZ3VDJ4U04xcGxTMGhLVWpGcGFsVnFSbUl6YW1wSlNRcHBielphY0hoTGJXbDRRbXMyTTJGSFFXUjRXV1YzU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLZUhGM05YRkNSRlZCVG1aamFUbDJWbE5pVWl0dVVUVndOMEZuWm14NlZEUm5lRVZtTUdOVVQwUmFabEpSSzJ3eVJrb3pUa1kxYWpaWWMzaFJTSEZGUWdwRFptd3pXRlZoY0hFelMwdHVNbEZPUjJGVVlsVkRSSGxGVUZCeU1VeG5iM1YzZVd0alNtdFRSbVJOUVVOaFJsaGFhelk1YUd0dlptVklhMFpuVkVNeENqZFNOWEo1YkhacWVFTklXRkI2VFZVMEszZHNRa05zWkUxcmMxQnlLM2haU0RWUmJGTkdTRlpKZFRrMVREWnVOMnhPT1dsSkwwNXpjVTlUYTA1clZrTUthbmRsT0ZOcVJuWlhhbWhFT1hJdlFrVkJaVTFET0dOWFNtcG5iVlZNWWtGc09YcGhlblF4VURGSVNISklXbGRUVDJ3M04ycDRURGxyTjBjelFtMXRZd3BuSzFWWldHaHZhM2h1Y1haQ01sVnhXbmxxV2xseWQxVnFRbGRqYWtwSmJrRkxNSGsyVUhORVRteGhhSE4xZGtZcmFEbHBXVUZVT1ZVNFltWjVjWFZtQ25sSlNFUlpSVmgxU2tneWVsRkJlRXB5ZVZsT2JXbGhObGxqU1V3eU9IWlVXV2xGVlZCMWR5OXJRMFpTT1VWNVFXOXNlRkpKUzNaR2JtVktaVnBEVG5NS1RYTk1Za29yVkRWM05HTXlWa3gyVERKWVMxVnpZMkppZW1VMk1VSlBSakpFU25CWVNHbEZRM1ZEVVRsTlIxbzFaMjFvUm10U2JtMVFWa3Q1VnpWNFZ3cE9kMmQ2Y2tsUlpqRjJlbkJyWms5U1psTm1URWN3VDJ3NWVIUXZTWGhrZWxWMVEwOXBjems1Y1U1aWJrSldjbk41U0VKTFlVRmhaazlyZUhCbWJHNTVDamhaYWtkWGQxSXJiM3BKTlZGcWJIQXdjVkptUkRobVdrVjZabVJaYTJGb1Z6STJWRXhWTTB4YVdrOUZkWEJIZGtWeFpHNWlTMnhzT1RZemMxZDFUSGdLWWxwaWIyUnVMMnhxVERNNFlrdHFSMk16VlhKMFFuUTNiakJ1YUcxNEswRnhabUZuU0dSRVpYSjROVGRPWWpSNmF6TkpUMG95YjJ3dk5XUmlkM0UyY3dwblozVkliSGRGVldZeVdtRlBRME5EVlhZeFUzTkpSekZtVkdVeE1teEVkVVY1VFdGVVJFTjNVM1JaUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCTTNWeFJIVXhUU3RvWjBKVWFWRXhUV3RvY2tGcGJGY3pOM1pLWW01RFpVdzVPSGQ2U0N0bFRISmlVMWxOVUU1SUNraHpZeTl1VFdkbFkyWTViMDVPTjNvd2EyVnBiREZIVUc5RGRFbzFiV3hYYTI4d2FsTmhhVkIwTjFwVlNXWXdNVWhFUTBOTVYycDVNVk1yYUdKTFVpOEtjaTh2VjIxR00yVjZWbEJHWjBGWmJIcHlSSEJCYVhobmNHTnhWbkpvUW1GemIyWlRVblptVDNCQlZEWnhXV2xaVm01NWVsZExNRVYxVTJwTWVteFVTUXBPSzBSME5qSlZVRFo0WjBwc2RXa3dka1JoY21GU2VFUkRRM2xKZERScU9FNVJjVmxwU0dOMFNFbHVkR0ZrWm1wSmJ6UTFXWHBKUjFOa2EzRk1aRGRtQ21SbVZqWlphSEFyVEhod09GUXJNRVZGZG5selFtZHFiVGxKU0ZKVU5uVnpiV2hIUWxaalEzVjZZWGRaWVUxS1ZrSXdPSEJTYkc4d1lqVTRNR1ZTTms4S1JUWkZaVEIwTTNaQ1pYbHlPRVYxZWxCbFVGWnRhVFprVkRseU15dEphRXBRZDFCa2NGUkZabWRQUlRZM1NqRjRSWFpFVWtOUU56bHFUME5aTUhsSFpncE1NbEpZTUZCM2NXZG9kRXBvV1hwTWVubDZRa05VSzBoRmRXVkdUMGhXTTJvd05VbGhZV042U1U1UlptNDVSSEZCZW13MVJuaFJZa1pxZG5CbFFUWXZDazlRYVdsc2JtOXdhSFJEYW5OdFJFNTJNV2xoTWpKV0x6VXhSalZ4WlZWaVZYbEVla2xPZGxOdFdHSndWemh1YUdoNmFtaHRlSFpJTWtoM01USjRLemtLYWs1MFNVWnpZVWR4WjFoUWRXTkhOMFI1ZEhSR1dYVklkbTl0T1hFMk5uZ3ZSa055VjFsemF6TmFUMmxNZUN0TmVrdzJZbUZUUlZsalFuWm1UbXg1VVFwQlFra3dOMHRQV0VsM1VHUnNVV3BEWTFNek4zZE1lSEJRTDJJMVpFNUNUWFJsVldzMksySmhiWEJ0YlZKRE4yazJlVEZSYkRCR1dYaHVjVkZaUzNCdkNtWnhTbXRSVlZFMUwySXhXbTlTUzFSd1ZXVXlXR2xvZVZWa1dXOHhTWGhYT1RRMGVVTkpjVTl0WVdOVGNHOXpVVnBQZERKb1owaGpWMGh6UTBGM1JVRUtRVkZMUTBGblFtMTVLMHN2Y1dReU1WVmpWWG9yUjNkT1NFVlZZVUptYkhsUFZsWkNjRFJOUjFoTFdtVXlhRzk0Ylc5NGMxWnRUeTl5T0dGSUswVnJRZ28zVUZGVVNGcFdNbkpSTkhac1lUaFVMelpLZFc1TWEwNXJRVkp5TTFVeVdsQklNa1I0ZHpaTk1URnVVWE4zY2pSblMxTkRVVEJIVnpKbVdVOUJXWFpVQ2xOQlVsWjVNeTh6TVhWRk9ETldXV05ZYkZjd1JsWnhaRFZqUWpCa1lWcFlVVTk1VHpkaGVrTm9XRXd6VHpaS2JpdEpXWHAxYVd0NWFUUnNjaXRuYW1vS1RYZDVTa05RY2k5eFNEVllWa2M0WXk4NWVEQk9jbTFJYUVWR1pTOVJXbE50VGtKbk9VOTFUR0psWWswNVlUWnpjek5oWkM5S09Ib3JSMWhrWnpkWldRbzFjUzlaT0RoWWFrMDFNMjlyYjFwbGVuUmlSbFpNWldSMlQwUldkVXQwYW5OVE56UmpSbFpvY2pSSGNreGpTSE5xTlVKV1NXMUJSMk5XUTFSclZVTXJDbXBMZFd4bWJVNUVPRk5NTlc1UVJubGtPVzVQVWtweWVXTnJablJJZUhwclNtdGFVMVp3TUV4WWIyeFZhRkJoT1ZBMmRpdHZLMmd4VjJ3NE9XVTNjVVlLV21vMk0zRjBkblp0UVdoM00zZHpVR1p3U1ZZM1UyMVBOMVkzUjA1bU4yZEhMMFJOV1RnelFWQmlRM2Q2VWtaVFZqWkpjMk5EVFdSQk9WVndXVTFPVGdwNU0yODBNbGsyU0hSeGJtWnphRkZvWjJsM2RrRlpUazVRVldGaE9WRk9PREJPTDI5b2RrZFlSSEp5S3pSUlNteFdSMjFpZW1GRFdXUTBjRkV6Y0RkSENsbENVRE5HTVVsUE1WVTFSbGcwTVdsQ09IVkpVVWxLVkZocVRrVlVSalZKZEROUk1FbDZRMDVzUTFJclp6UXZSaTl1U2t4NmNsUnRZeTl2WlZwQmJWVUtkaXQxWmpreVUxRlhla2hhWVRkd2NHODBZMkY0TDFFeVZ6RlZhREZVZUVzMVNUaE9VV2xVY2poM0wwSlljM04xTnpJcmFHcHpTelIyVHpVdk5WWkZVQXB1VDB0WlZ5dExhMDlJWjJvMGVYQjRSMnQ1YkZKcU5WRnRlazVsTDBoWFZXdHNTRTkwWlhZNVltb3haMkZIYlZKM1VVdERRVkZGUVRSdUt5czRRWFF5Q21GYWVFdGlTbFkxU1VJdlNubEhOaTlKWjNZeVVrSkdNbXR1VWpObmQzTk9jMEUwTmsxSGJGRnZkR1p5UjNocFZGVk5NRFV4VjFwbVIxSkNOamRHVTNJS2QxWlJSbWhLWkZWb1p6azVLMXBOVFU5dk4zaFNla3AxVTBWaWEyRjFUekpPWWtSV1RHOUxhMFZKTTNGb09HTkNPRE5hWjJjM2RWWTJTekJNVkdwdmNncFRZa2hDVUhWak1sbFJWMmhTWmpsaWVHMUtVVTlLVTJac09WbEhRbkZLY1c5d1ZHd3hSa280WnpZdlVGSTRUR1JKV2twbk9WSlBhbTFqY1ZBeGQzRk1DbXBtVERoTVNrSmxaMDVNZFhSaFJrRmxRbk5ZVG0xQ1VYcHBkMWN2YXpaNUsxTndObXB0TURodVYydDFibXBrVjBKdVYwUkdja2wxWmtoTVFUWTRVbWtLTldOM2RrTXJPWE5tUkdWYVdETlVhamgzTTNCWldYaEtXSFpaZFV0RmJqWjFjbmhyWWtwNU9VMUNVRTV4WTNJeFRrODJheXN4YXpWVmFYRnFhblZCTUFwVFRVTklMMUpwVmtaYVJrMHdVVXREUVZGRlFTc3ZUazVLSzJKak9GbDFUREJqVW1VclltdzBNV3hJYm1rMVIxZERjMVo1YzNSU2IxWXlVa2xNVWxKbENsVlFLMEZEUmtGWU5FaG5lRFJaWjBjMlJrNU5TVTlPT1dOV1ZHVndSbWxzWW1sRFMxUTVSMmRoY1M4ME5tUlBVbEo2UzJSeWRsVklTa0ZxVldOWFVVY0tRbVJQYlRCeGMwdGpTMUJpVG1aMWFGSnBaM042TW01eFRuZExlWFpRZW5GWldFRnpUbkJ6VUhVeFFWQllOVGhPVmxwUVpERnlaVU53YVc5a1VFVXZkZ29yTXpSM2JqTlpNRXRxZEZKd1NXZE9SVVJqYTBoWWNtSkRPWEJZU0dsbmRUQXpVSFoyVmk5T1YwZHdZMnBHWWtoT1RFMW9URmRWUTFkcWNFUkpSRFJQQ2pKbVQyUXhNMFZPTDJseE1teDVhMjloU1dsbFVXVnZNbUZMUWpCVGNqbGxTMFJ1ZUhaaVFVeFpla0ZWVldoUFRtRmFUekJpT1ZsMFFUVlhZMkpoZEhnS1RuSXZaVFprYTBWUWEyRmFVVGhLVkVWaGRIZGFjbWhoY1VzcmNUZG9USEExTHpFNVNWbHZlbWwzUzBOQlVVSlRhVzVGTDNONk1uTXdVWE5EVGxKeFZ3cEVWaXRSYW0xT1V5dG1OemswVlhSUWNHVm1hblJ2VWk5amVpOWlXWEJZUkUxdFNqUldiVlpvU0dSclJXNXlSSEpTYldzeFpFMXRLM2N5Y21KWVptRnpDbWRFY2s1V04zZDFTSFZrYjNCalZYZDVOM293UVhoWWEzcFNUbnBTY1V0YVkyTTFWazl5TTBsU2IzZ3piRlZZVmt4RVMyaHBSM000UTA4MEsybFRNekFLTHpSTk9VdG5hamcyT1d0SFRsbDBVRmgxZVVaUlJ6QlNORXRqT0hvck5sZFpkSGh5TnpKU09HeHZZVVUyVjNCSFdXdzBNalZLTTJzeFptSXlSMjl4UmdvNFpHbFRSV3BwV0ZSSVFWTklaR3d3ZFZCaFRVdEpkbkZhTkU5UlNXUnFhMGRISzI1emMzcEVkamxHVFRGU1VrSjJLMUF3VWpOWmRTOXNSSEY2V1RkQkNsZGtZVzU0WTFwSlZHWnhUakZRZW5OQlZsUnBNRGh5ZFdkRVkzTnhXbGc0Vkd0ek1YQkZVR3g2VlRSTlZuZERabTh2UWtVMFoyNU1kRmhaV2xWMmMwb0thVUpFZUVGdlNVSkJVVVJaYzBsa2FWVjNZMmhaTUVKTmJVWlRTeXRNTlRWeVdsY3dSSFpHTlhOQ2JWZDJiVXBFUkRCbFdVcGtWamhYYkV0WFZUZFNSZ3BhV0hGYVIzWkhPVGRMTkdvNWVWQlVWR2RtZVZaNE9XOXRUMjQzTDJwSE1uTkZVVzVpYzA5aE9WZG9lWEZsUTB4WFIwUkhZVkl4V1RnMVEyUjZWMk00Q2s4eVJEQnBPR1JJTTBwUE1XazRWbHB5UzA1dVRWTnhkbmhPWW5neUsycHhNRGc1TVVWUmJGb3lZMUJKZDB0dVNVZGFOWFJYWkRkMlkweGxSek5vVnprS1dVdHJNa1poUlU5dGFUUm5aMHRLVjBSdFNYY3lTMUl4Vkd4bldtbHZWRVZxZVRKeWMxcE1RWFV6VGtWYVNWSnBZalIwT1RsdlJ6RmFMMWxRTjJaaU13bzJNbkZCYkZoQ1oyWXlaVVpFTVdabFNXMXZRMUUxV2t0cFNrNXNOMnAyVGtGbVVHOUtNVXhRVVRZM1JFcFFVWGREWjA5M2RYVjFla0k1UWtSV1ZtUXhDamREWjNwQk4xZEpSU3RsYmtsT1ZYZEZWekl3VG0xWlowWllPRU5WY1dSRVFXOUpRa0ZSUkZnNVFubEpLM0ZyV1d0alRYcEdLekkzYUdwamVXTTJPV01LYzNWRlpISk1UMFJuVlc5S1NHaGFUeXRGY0VOeGVVaGlURGRvZFdocU9XaGlhamxOVUZOTFdETm1VbkJuVW1Rck9IcG1aa1UxVkVOeFF6VjFTeTlSWmdwMmRXcFBaemRYUkRsMVVHazRkRE0wTTIxM1EyVlRibGRYUzBweVpuZ3pUbkpLVmtvdlN6Tk1RVFpwVERSd05HNXlja1pHVmprNU1uZHZOMHBYVUZwdENuVnpVV3RHY0c1VE9ESTRjVVV5WTNkeVlUTm1UR1J6VkdWd2IwNDNaSEowV0V0NFFrNHphbWxyZGpCamJFaGxlSE5OZDB4U1ZXeHlUSEpNUlUxc1VUQUtOelZSWXpsRU1GZHNTMWhzZEhOSlpEVTBaa2xtZWpSWlJVTnpWMVJRYjBWWE5YSTBkM1JPTWxGV2JWSktOVFF5WTFSQ2EyMXRVM1I0Vm01TVpsUnpNd28zVGtsbWJVbEVkMlE1Vm5BME9YWTNhRGxOUmxBM2FIUnNVbXB1V1ZodWREWmFVVTltVjAxUmMzcG9RekpwSzJOMmJGTlhaalZWUlhoeGRXVUtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogNjY0N2Y2ZTE5OTI2Nzk0Nzc4ZmRmNDE0NDcwODgxYjg0MDMyM2Q4NGMxNWQ4ZWM4YmJmMzhlNjA3NmJkYjQ0Y2QzOGMwZjQ1NGZlODdkNTI2OTM0YjU0NjQ0ZTBhNTE0MmVhNzc4YmEyODRlNTllZDgzZjBiNjQyMDI5Yjg3MjEK\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:19 GMT",
+      "date" : "Thu, 26 Mar 2020 02:13:03 GMT",
       "server" : "nginx",
-      "content-length" : "1801",
+      "content-length" : "1802",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -486,23 +477,51 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "79fef052-f779-4085-ad86-aa12900b9f6a",
+      "x-ms-correlation-request-id" : "33c30c27-f06c-44dc-8676-d94566e46f66",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024720Z:79fef052-f779-4085-ad86-aa12900b9f6a",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021304Z:33c30c27-f06c-44dc-8676-d94566e46f66",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7b62febc-a1cd-4980-aa99-e72d109da197",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4\",\n  \"location\": \"centralus\",\n  \"name\": \"aks42786938f4\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Scaling\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"mp1dns89446c\",\n   \"fqdn\": \"mp1dns89446c-42e6cecd.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap014819f\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Scaling\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg20376_aks42786938f4_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
-      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31"
+      "x-ms-request-id" : "24ebd7b4-7edd-4b8f-87d6-2126817a487c",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\n  \"location\": \"centralus\",\n  \"name\": \"aks66843282e2\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Scaling\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"mp1dns94511d\",\n   \"fqdn\": \"mp1dns94511d-3d22ae46.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap0470064\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Scaling\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg49971_aks66843282e2_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 10\n  }\n }",
+      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:20 GMT",
+      "date" : "Thu, 26 Mar 2020 02:13:04 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11986",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "d077bb98-3d17-48b6-bcf2-b4a500feb0b0",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021304Z:d077bb98-3d17-48b6-bcf2-b4a500feb0b0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b9a0a839-91e9-42f0-aa7a-76e467f0729c",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:13:34 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -513,22 +532,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "949c6994-4090-4c51-ab3f-71b4f1d4c564",
+      "x-ms-correlation-request-id" : "66aa179c-8e9d-4ae8-8ab0-e54398455f32",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024720Z:949c6994-4090-4c51-ab3f-71b4f1d4c564",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021334Z:66aa179c-8e9d-4ae8-8ab0-e54398455f32",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "fdb734f3-7c79-4276-9085-e47013ece74e",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "1ee0683f-1361-4842-9420-58b36bd64fd3",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:47:50 GMT",
+      "date" : "Thu, 26 Mar 2020 02:14:05 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -539,22 +559,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "3ab92dbf-c03c-4cb1-95cb-474ea388b4eb",
+      "x-ms-correlation-request-id" : "f596b94e-b7f9-4d0f-ad20-24581615142c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024751Z:3ab92dbf-c03c-4cb1-95cb-474ea388b4eb",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021405Z:f596b94e-b7f9-4d0f-ad20-24581615142c",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "411e4186-8050-4261-80d2-217662048dfe",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "88c482f2-32c6-4159-afec-ca5429ff3a57",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:48:22 GMT",
+      "date" : "Thu, 26 Mar 2020 02:14:35 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -565,22 +586,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "7cccd1c2-caa3-47de-9b05-49e155955baf",
+      "x-ms-correlation-request-id" : "1c8e26f3-d995-4089-a434-ff428a066fc9",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024822Z:7cccd1c2-caa3-47de-9b05-49e155955baf",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021436Z:1c8e26f3-d995-4089-a434-ff428a066fc9",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "17882822-79e2-46cc-b459-e275f919c9ff",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "d3a40de0-8ae4-46ad-b279-4f1de90f79f7",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:48:52 GMT",
+      "date" : "Thu, 26 Mar 2020 02:15:06 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -591,22 +613,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2df0f0f6-764f-44ae-ba16-4047e309e94f",
+      "x-ms-correlation-request-id" : "07b34c40-e13b-4107-8dba-3706cbc27d0c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024852Z:2df0f0f6-764f-44ae-ba16-4047e309e94f",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021506Z:07b34c40-e13b-4107-8dba-3706cbc27d0c",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1fa93efe-8baa-4b58-81c6-ed3378607c47",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "5e49c867-b1fe-4006-8fb4-74859fbc2225",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:49:22 GMT",
+      "date" : "Thu, 26 Mar 2020 02:15:36 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -617,22 +640,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "08dc36d7-1cfc-4755-8fd0-963a2424961b",
+      "x-ms-correlation-request-id" : "d722b55d-458d-4bd7-989d-36e961c500c5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024923Z:08dc36d7-1cfc-4755-8fd0-963a2424961b",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021536Z:d722b55d-458d-4bd7-989d-36e961c500c5",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c6324b76-d605-43e0-91c9-e5b93fe56f59",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "24a8167f-20f8-434f-9572-bfb308e259dc",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:49:52 GMT",
+      "date" : "Thu, 26 Mar 2020 02:16:07 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -643,22 +667,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "59858ca2-dbf2-4a20-bb25-e744359bd605",
+      "x-ms-correlation-request-id" : "3c2c54de-5e1e-4d81-a079-cb9ca6111733",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T024953Z:59858ca2-dbf2-4a20-bb25-e744359bd605",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021607Z:3c2c54de-5e1e-4d81-a079-cb9ca6111733",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "b2dd936e-8e0e-41ab-a801-68264a16af0b",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "7aa5d337-5d1d-4efe-a0a0-2f0705b01b03",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:50:24 GMT",
+      "date" : "Thu, 26 Mar 2020 02:16:37 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -669,22 +694,23 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "40a58e9b-9532-4696-a5ff-b60182bba6c1",
+      "x-ms-correlation-request-id" : "020ae4c3-7296-4b78-98b7-7be4b2cc84d6",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025024Z:40a58e9b-9532-4696-a5ff-b60182bba6c1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021638Z:020ae4c3-7296-4b78-98b7-7be4b2cc84d6",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "614262f8-bb93-496d-b076-f34f95add7e6",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "a35aba4e-764e-4aba-94ab-24678ed2be0e",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:50:54 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:08 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
@@ -695,24 +721,25 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d789027c-9148-4f89-a45a-81b2b146ddd6",
+      "x-ms-correlation-request-id" : "afc42d36-9f90-43d5-b3a2-c9334d2c695d",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025055Z:d789027c-9148-4f89-a45a-81b2b146ddd6",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021708Z:afc42d36-9f90-43d5-b3a2-c9334d2c695d",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ead24ced-229e-4589-8fb6-e6b3ef8e4fe3",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "f959fddd-0505-4c16-9bc6-ef7e9d348aee",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/24ebd7b4-7edd-4b8f-87d6-2126817a487c?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:51:24 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:38 GMT",
       "server" : "nginx",
-      "content-length" : "126",
+      "content-length" : "170",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -721,24 +748,25 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "b5d49cff-5605-4526-a009-45a0a3f1701c",
+      "x-ms-correlation-request-id" : "62707b1f-98ec-4ac7-9df6-09481995b9bf",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025125Z:b5d49cff-5605-4526-a009-45a0a3f1701c",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021739Z:62707b1f-98ec-4ac7-9df6-09481995b9bf",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7eb360b7-8d2d-4762-a5b2-b0c70bbd8891",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\"\n }"
+      "x-ms-request-id" : "8a1aac2b-4482-4f53-84e2-f3d26ddbdcaf",
+      "Body" : "{\n  \"name\": \"b4d7eb24-dd7e-8f4b-87d6-2126817a487c\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2020-03-26T02:13:00.9164742Z\",\n  \"endTime\": \"2020-03-26T02:17:30.3513434Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/centralus/operations/7b62febc-a1cd-4980-aa99-e72d109da197?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:51:55 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:39 GMT",
       "server" : "nginx",
-      "content-length" : "170",
+      "content-length" : "1806",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -747,51 +775,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "36254c28-c4ea-4b99-b3a7-6ff873be9fd2",
+      "x-ms-correlation-request-id" : "468540c9-9903-43c2-a8e6-2a9478d1c83e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025156Z:36254c28-c4ea-4b99-b3a7-6ff873be9fd2",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021740Z:468540c9-9903-43c2-a8e6-2a9478d1c83e",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "88a12e7c-9572-4114-9dfb-75a0392437dc",
-      "Body" : "{\n  \"name\": \"bcfe627b-cda1-8049-aa99-e72d109da197\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2019-10-18T02:47:18.5587599Z\",\n  \"endTime\": \"2019-10-18T02:51:47.1155321Z\"\n }"
-    }
-  }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)"
-    },
-    "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:51:57 GMT",
-      "server" : "nginx",
-      "content-length" : "1805",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11975",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "4f3560fe-6b17-4c0c-a5c7-94d05ee7f780",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025157Z:4f3560fe-6b17-4c0c-a5c7-94d05ee7f780",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "531b4beb-6887-46cf-b23d-c7dd37aa058e",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4\",\n  \"location\": \"centralus\",\n  \"name\": \"aks42786938f4\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"mp1dns89446c\",\n   \"fqdn\": \"mp1dns89446c-42e6cecd.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap014819f\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg20376_aks42786938f4_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+      "x-ms-request-id" : "96ce82e0-e1c8-464c-b250-808f02b32b67",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\n  \"location\": \"centralus\",\n  \"name\": \"aks66843282e2\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"mp1dns94511d\",\n   \"fqdn\": \"mp1dns94511d-3d22ae46.hcp.centralus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"ap0470064\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D1\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"testaks\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_javaacsrg49971_aks66843282e2_centralus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 10\n  }\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterAdmin/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2/listClusterAdminCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:51:58 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:40 GMT",
       "server" : "nginx",
-      "content-length" : "13170",
+      "content-length" : "12893",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -800,25 +803,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2481317c-bf23-4666-9f36-a0807cf6ddd1",
+      "x-ms-correlation-request-id" : "5158cc96-f052-4368-af3d-4fb318976872",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025158Z:2481317c-bf23-4666-9f36-a0807cf6ddd1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021740Z:5158cc96-f052-4368-af3d-4fb318976872",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3bed2816-2503-4405-bc2b-2beadf0c1d2d",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterAdmin\",\n  \"location\": \"centralus\",\n  \"name\": \"clusterAdmin\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVVsRWFqZFlhbVIyYWpaTVJXcEdlVVIxVldGbWNEUjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJyZUUxRVJUUk5SRWw2VFZSQk1sZG9ZMDVPUkd0NFRVUkZkMDFFU1RCTlZFRXlWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFRWS0NtSkhNa2d3Y1RoWk56aExhSE5CUldadU5WSklWVFpGYkd0R1VGcE1VR1Z1TjNCbFlUZE9VRXBYVjJoRVJIQnhNV2M0ZG1RNVVrWjZkMVpFVGpScVJVc0tUMVZaUW1kUmNEaDNTa2xEVVV4d01VcFBlSFpZU0RacVIyTjBSalptSzJZdlMxUlpaRGs0ZURCTU5UVlljSGcyVlRkV01taHBWaTlxVDBWbE0xazFjUXAxYW5WaE0wZEVjRkU1Wm1GRlZVOW1TbEJ5UjFGc2VFdE9SbWsyT0ZCM2NXOXVkM0JvT1M5UWQwUkZaMkpuVjNZeFZtdE9RWGxtYUcxdGQwczJjbUpJQ2t0SGVXcFhObVk0ZFdkcVNHVlBWVm8zUXpKUVRWa3pZa05PZDNaalRuSklUa0ZyUlRSaVVsVkZabkpzYlZsQmQxTjNaWE0yVEdwNE5UZHVXSGg2V2tjS1lrdHJRbTFZZWk5MVUwNXRhM0pOT0dodVUyMVJNR1IwYTAxa2FsSjBaSGN5TUdOM1FrbEtTMkoxT1VZM016TXZhbmxyY2psUU9HNWpieTlsYVRKb1p3bzVNRXR3UzJWTFp6TlBRVVZPU0daNWVXRmxjMk5ITVhNMFZFTk9VV3RQTlU1SmJtZHRTMkZSUzBOU1pXcHBXWEIyVVdjMlVXOTVhR3RVU3psMmRuWndDbEZ3VTAxTGRqSmtUVE5USzJNNGIwSllPVEphVVdnNU1sbGFNVWN6VlVKU05FdHphMkprTUhkUlpIUTBkbUZITVZwTmF6RTBjV3hTVjBJclVGSllXRWtLVVRGT1Nrc3ZXbEpCYTFvMGVXWnBVMk5XYkVkMldYaG1lVTk2TnpaT0wyeGpiSE5PUW1VNE9XVnNaV3RyUXpSSWMwOURkSGRPVTBsMk4wdFZibXc0ZFFwMVVYaG5lVGQxVW1odmRGUjFRWE5IYjNWc1ZWRlBWa3RDV0VwemR6TlNWbXhzYVVsa2MydGtlRUp2Y2tkeWJHWmxTMEZoVVV4eFRtOXdhbEpCVjAwMUNrUm9NVFIzTWpNeGJXTmFOVUpETld4TldWbFhjREpSY2pScFlXcHpkMjlsZGpCd1N6ZE5iMVZVYVd4NWNqVkJjMEoyWlhsUlpHTktkSEZTWlhkdFdsSUtNa3BwUjFKNk1YaFZNak5ET0ZCMWRscEJla1ZDVG5aT09GQktlamxqYWpRclRFdG1SbEpxVUVGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlEweEpWamxyQ2pVdmMyaDZOVkkyTDI1Q2MzUTBMM05XVVZBdlUwRmhRVVpTSzFkbGVERm9jMHhNZURGQ1VVVklOSGR3TTJSQ1QwMHhVVWRRYTFaVlZESnJVVVV5TTNnS1JrTm9iVnBGWTBoRVpscFBOeXRLUkd4bGFsbHJORk53Um5ScVoxbDBNV2xGUW1Kd01EYzBSRE5wZDBsMVMzUkJSRTlHVWxKa1YzSnpVR2d2VGxKWWFncEtiM2hLUWxoV0wzUXdNbGxFV1VwcFZHTlFiVVZ3YmxObFRtaE9aSEp0VVRjelYyNXVjVFpsVTFScVZHVkdaemxFTUc1VlVFbFNNbnBUTTJkNE5tVjNDa2d5ZURocVZFZGpSbGQ0YXpoWmNYbFlTRlpwU1RKM1dWUjFMMnBoYWxnMVUwUkliVEV6TDJ0a1lWVnBPV2h1TW1STlkyOWhSRkZqWW1oUU0zVXZZV29LUmpWUmFEQjRkbkZWWjFSeFYyNHphVkIxTlZaclF6ZHVXRTA1U1RKM1FuVTNWbWxUZVU4MGJVeFpNazFKTURSUVp6WnVOa0ZWYW5STlYwMDJVRXBVVHdwRUsxbzVaRVF5ZEZscEx6VjJjbWxpWVVoaVpUQnRjVzR6UTJGWVdsaDFWM001TVVwRllUUXhXVVJwZVZkQ1drdFJUM2xaWlU5aFluTTVSeXM0UTNkQkNtRnRLMjkwWlZadGFqZDFiRWxLSzFKbVJVVnJjekpSY1hCSlpFSk1ZVVJyZVRsNE1YVjBLM0JIWkcxclNtTXpZbnB2T1ROcVRVMVVPV3RJTDJnNVEwa0thaTl0Tm1sYWRYQlBXVUprVW5CRGR6UkJLelpCY2poUVZsb3pibnB3WkM5eU5GaHFjMXBHWldnM1dYcEZTa2xWU2pNM1NVdHROM1ZMTkhab2RFMXNPQW8wZW1SdU5GZHhOemh6VEhocFZrbHdUQzl2ZW5oQ0t5dFFURUpXT1RaNGNrVllkV1Z4YTFkeVQzTnZjRXR6V1VGSmJURnRkVTF5VURKRU9HTlJSbFJhQ214elJXVldTMDlvU2pOUk5HTmxNMmg1VTJOTWMzUlFLMDlxVERGdGJXcFVjbHBVT0RoQk9HbDFVRVJQV1d4TFIyaE1jR3hMWVhSVFdubGhXWFJKTjFBS05TdFFiMkpIV2xwbUsxUlhhRUprTVd3d1dqWXJTRzlXVGs5MU1HTmpZVkJ6UkRnemEyYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zODk0NDZjLTQyZTZjZWNkLmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczQyNzg2OTM4ZjQKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczQyNzg2OTM4ZjQKICAgIHVzZXI6IGNsdXN0ZXJBZG1pbl9qYXZhYWNzcmcyMDM3Nl9ha3M0Mjc4NjkzOGY0CiAgbmFtZTogYWtzNDI3ODY5MzhmNApjdXJyZW50LWNvbnRleHQ6IGFrczQyNzg2OTM4ZjQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyQWRtaW5famF2YWFjc3JnMjAzNzZfYWtzNDI3ODY5MzhmNAogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZWRU5EUVhWWFowRjNTVUpCWjBsU1FVeDFOV1J3SzJ4M1pXTklhWFl2TXprNVoxRnpNbk4zUkZGWlNrdHZXa2xvZG1OT1FWRkZURUpSUVhjS1JGUkZURTFCYTBkQk1WVkZRWGhOUTFreVJYZElhR05PVFZScmVFMUVSVFJOUkVsNlRWUkJNbGRvWTA1TmFrVjRUVVJGTTAxRVNUQk5WRUV5VjJwQmR3cE5VbU4zUmxGWlJGWlJVVXRGZHpWNlpWaE9NRnBYTURaaVYwWjZaRWRXZVdONlJWWk5RazFIUVRGVlJVRjRUVTFpVjBaNlpFZFdlVmt5ZUhCYVZ6VXdDazFKU1VOSmFrRk9RbWRyY1docmFVYzVkekJDUVZGRlJrRkJUME5CWnpoQlRVbEpRME5uUzBOQlowVkJNREpUVW5GQllXNDJhM0p4Y1hwbFMwSk5NVE1LTHpkdlpVWnljVFZ0UjBsYWJtcERiWEJLU3pVdk1rVTFkMFZ3VUZKRU9VcEpaRzFFWTAxVlZ6QTROWE40WWpCVWFITk9XbmRtZGtseFQwNTBZVTA1WXdwWVRrODBUMUUyWTFKdVluTnZZVGN3TkdJMGJsRlJNSGRSTmxCT1RFWnFRbFZuVEZsdE1tRktSMkZKV1haall6ZFdZMjV0ZUdGVlRrSm9TSGM1ZFhoR0NscDJWVzV2ZURsUE9UbHViVXMyZVRGVVJVdHhUR05xUXpSaFoyMHdaRlFyVjBKSllVVklaVW8wUlRkMGRIUnRTRlJ0YTI1WFVHTkdWbkZ2ZHpneGVWb0tWbWN4WTBwblVWTjJWVUZoUWtSSFFUQXZibFZXUTNCQldUYzNNR0ZqVDJ4R1YzbGxTaTl1V0ZGVWNuWmFaRkZKZFhSaFVIWXlRbk4yTTNkcFZHcERkZ3BKVDI5aWVuaEVhVUpqVTNwNGVYaEhaVVZRVGxKeWJUWXpkRUpRU25wVlkwSTVORWR5Vm1kb2VXWkhaV3BYTlVsT1NEUnpiakZQTkNzeGQwb3ZjRXN2Q2xWMlkwVnJRelJqTDFwNFIwaEhNVXBVVUc0eFRFbFlOMDkyTkhKc2NEUjZLMWsyV0U4NFZVdE5RMnQyUjI1MGJrWkZOVTlLWVdkMlpYcDVVRm96ZFRnS1ltNVJXRVZTUmpKSVRsWk9UMEp1ZW0xUk5IQkVPR0k1UWxCV2Iwb3hkek5WVmxVd1lraE9WekF5ZDJKck5IRlNaRWhIU0ZaVWFqSkdaVzV4WmpaUU1ncEhPUzl2VW10RVN6ZDFlSEZKYm5VNFlYVXlSSE14V1hrMmFGQTJTbmg2WlRSellpc3lWbFpsVWtSU2RUTlhaakExWVZabE5sbGFaMlZqVGxaTmFITmpDbmMzVkZacWJYUTJWWFJCVkdSQlZFMU9TRGRaVlhWT01VUktNRFpTVjNaSVQwVllWamRhY0c1Rk5HSkxkVWwxVEhoa2VXSlliVmsyT0haR1pISmFlR01LWkVSSVkzcEJZbW96TDBzNWJHazNiRFp4ZHpOcVYwdG9WbEpESzFKVVFteFdMMnRpY2tSTlRUaEROVXBLVG1veWRVaGlRbkpxYlU5VmNFTjNUM1Y0WlFwa2JTdFhkR2hTTkVaT1kxVkVlbWwwU1d0bFNVcGpPRU5CZDBWQlFXRk5NVTFFVFhkRVoxbEVWbEl3VUVGUlNDOUNRVkZFUVdkWFowMUNUVWRCTVZWa0NrcFJVVTFOUVc5SFEwTnpSMEZSVlVaQ2QwMURUVUYzUjBFeFZXUkZkMFZDTDNkUlEwMUJRWGRFVVZsS1MyOWFTV2gyWTA1QlVVVk1RbEZCUkdkblNVSUtRVWwxU25wNWRtb3hSbE5GUmpoQlFrRjVVak5zYlhST00yNWlaV3cxUkVkaWFrRkhNR1ZNVldGUVJWUk5NbEp4SzI1TllsVXpaV3BNUVVWVGEwbDNOd3BxTW5sdFIzVk1TMlZzVUdsMlVsVklkMjlpYTFka2JqQXhLM1JCYjJ4UFJsRmtWRzFWUjBOSU5qQlNiWE5OU0RSSlYwWkVOV3BzTm1kcmRUUmxSbG8yQ2tNelEzUm5RaTh5U1VwQ1N5dE9hRGx1ZG1WblZYcEhaVzV4U2pCeUsxTXpTM0Y2VjNWQllUTk1NbTFVZFhJMWQyNUliRFZQWVd0NlMzWlRkVkV6Y25FS2J6QnNRVVIwUVhoeFlXdHNUVGhqUjJwRGVURkxhMk15WnprMlNVMHhNMlJRTDFvM2IwTjNZMFYyYzNCT2JIaG9aM0J3ZVc5bmFVRjRXVXRJU0d4RGJncFZaRkp6VkVKR2NXSm9WRTR2WkcwNGFqVXJka3RDVUdOM2NrSkJlSGhrVjBsdk5IVTJiVTFEYTBGeFQzUnlhV3RzT1ZWR1dtRkxlVEZTYlVaemJXeFZDbkoyU2treVJtVTJNVXhYYUhKNmVWbEpjbWd5V0VaV1NGZFJNbTlSUTNvM04xSlFiM0ZXZUhsMlpGSnNlbkZMWVRsQlNGSjNjbmQwVVVReE5UQlBhVXNLUkM5a1NXMUJaa3RVUlRGaU0xUmxUMUprTWtaeU56SjRjMEZtSzFrNVdsbEJhMnh0TlU5a1ltdG5VVXhhYkhObVlVMUxhbm95YzI1a1FXdFVaV0ZHTlFwVWFsQkRhMjFVUVZKTmEzVnhiM1JhUjBWcllVcHRhaThyVWxFM04wcHVTRFl6WTFOb1VtSndjbGxCVEd0MGVHdzBjbEZtTHpCV2IzUnZibmhQVFhGd0NqbHZORWhCSzNORGQxRnpPR1pSU0VwWlZUVlJWVlFyTkRkTU1XbHJTSHBaZWpWNGJHUjFXR2gyTkhSRU5sSnpjREIzWjNaTFRtSm5lRkk1V2paMVpXd0tabk5zYlZrMGNVeDNUbWhxUkRGT1VYZDRUbEpxWlZjclpuZHpUVU01VWtSSlNqQk5NVmxPZUc5alkyOUdOR3hLVUhkeWRtSTRNeXRoVEcxVllqYzVSUW8yVlZGMmJqbE1SV2RRVUd4VVRVaDVjM2N5VjFkTGIxbHRNMWRUUjJkdE16WlpPR2xCYzFaalVHZDZaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJNREpUVW5GQllXNDJhM0p4Y1hwbFMwSk5NVE12TjI5bFJuSnhOVzFIU1ZwdWFrTnRjRXBMTlM4eVJUVjNSWEJRQ2xKRU9VcEpaRzFFWTAxVlZ6QTROWE40WWpCVWFITk9XbmRtZGtseFQwNTBZVTA1WTFoT1R6UlBVVFpqVW01aWMyOWhOekEwWWpSdVVWRXdkMUUyVUU0S1RFWnFRbFZuVEZsdE1tRktSMkZKV1haall6ZFdZMjV0ZUdGVlRrSm9TSGM1ZFhoR1duWlZibTk0T1U4NU9XNXRTelo1TVZSRlMzRk1ZMnBETkdGbmJRb3daRlFyVjBKSllVVklaVW8wUlRkMGRIUnRTRlJ0YTI1WFVHTkdWbkZ2ZHpneGVWcFdaekZqU21kUlUzWlZRV0ZDUkVkQk1DOXVWVlpEY0VGWk56Y3dDbUZqVDJ4R1YzbGxTaTl1V0ZGVWNuWmFaRkZKZFhSaFVIWXlRbk4yTTNkcFZHcERka2xQYjJKNmVFUnBRbU5UZW5oNWVFZGxSVkJPVW5KdE5qTjBRbEFLU25wVlkwSTVORWR5Vm1kb2VXWkhaV3BYTlVsT1NEUnpiakZQTkNzeGQwb3ZjRXN2VlhaalJXdEROR012V25oSFNFY3hTbFJRYmpGTVNWZzNUM1kwY2dwc2NEUjZLMWsyV0U4NFZVdE5RMnQyUjI1MGJrWkZOVTlLWVdkMlpYcDVVRm96ZFRoaWJsRllSVkpHTWtoT1ZrNVBRbTU2YlZFMGNFUTRZamxDVUZadkNrb3hkek5WVmxVd1lraE9WekF5ZDJKck5IRlNaRWhIU0ZaVWFqSkdaVzV4WmpaUU1rYzVMMjlTYTBSTE4zVjRjVWx1ZFRoaGRUSkVjekZaZVRab1VEWUtTbmg2WlRSellpc3lWbFpsVWtSU2RUTlhaakExWVZabE5sbGFaMlZqVGxaTmFITmpkemRVVm1wdGREWlZkRUZVWkVGVVRVNUlOMWxWZFU0eFJFb3dOZ3BTVjNaSVQwVllWamRhY0c1Rk5HSkxkVWwxVEhoa2VXSlliVmsyT0haR1pISmFlR05rUkVoamVrRmlhak12U3psc2FUZHNObkYzTTJwWFMyaFdVa01yQ2xKVVFteFdMMnRpY2tSTlRUaEROVXBLVG1veWRVaGlRbkpxYlU5VmNFTjNUM1Y0WldSdEsxZDBhRkkwUms1alZVUjZhWFJKYTJWSlNtTTRRMEYzUlVFS1FWRkxRMEZuUlVGNGEwdzJaMVppVFhkbFpFWjBVazh2T1UxVmIyMU5XR05XYjBWSFpFczNPVk1yY0doUlRsVkZZMVZ4YTNWWU5UUllXUzlzWWxWUWRRcEVVMUZ6VW5KaVEwOWhjMlF4ZWxRNGVDOTZNM00zTm5BM1RGVmxPRlZxTkRkVWNWRjNNVE5wYW1KdWFtNXdNbFJtTWxZMVRVNWpLMHBUZFZKR1VGQnhDbG80VjBKTVNFNXNUbEZxV1RBMWMzSlFOQ3RRWVZoUlIxSm1RbEJJTUUxeGVUaHJabUpWU1VkeFJYVjRUbXBqU1VkVGVrUTJjRk5yTlVGUllVVkZkbG9LSzJwMlJFdHZaV05XTDFGdkwxSmxUMlZrWjJ0UU5sbGlhSGRSUVVwRU9HWm1LMEYxUjNsVk1YZFdNRlZqVEhST2MzbHdNV1phWlc4NFJrVTBWV0ZIZGdweE9YRmtWVzFoVDBKVWEyRm1ka2RvYmtkSk5WaEdXakppYkUxdGVsZzBSVmQxTmtGeVpIaFJjVXR6VkRWT1VHbG5WVlJOZVZKRmFWTTJiRFpCY2pkM0NrVkZRWEZaU21GdGJVRnpiekpYVEVaUmVVWnZlWGRqUm5OTFpUbHRPRTVRTlVKalZGTTBlbGRMVTBWM1dUWnpUMVl6TkVveGNsSlRSakJvTTBnNVdEUUtPVWhvVWpBMlRHbHFNSEpGTUZONmRFcFFRMUo2U2xwc1kxWjNSek5KTUVoSFFVeDFkVmxIUnpaS1ltRkdSR050V0dGaVpsUk1kRnBvWVVWQk1YRlZNZ3B4T1VaMWNHeGpkVFY0T1VGU2MyNXRZVFpPTkdGTWRYVnlia0U1YlZsV1pGaHJaVVl5TTFvMVpYUjRWM1EyWTJsd2RYaExjMUZ0WjI5NE9ITlBUWEZZQ213clZVZGtXSFpaWWtaUGVETXhlQ3RMYWpOcFptUkNjM2RQVFVrMmRsUlVkazlpVVhkd1p5dHNPV1JIVkhCd2NqTkllRFJyWm1SemRuQjJiamRqTUd3S05ESkVlV0pEYjJsRU9YZEJhRVU0YTJkTmQzZGxha1ZyYmpKSFprTnFhMnR6YUdkblNHaG1hVTR6YlRGck0yMHJlbFZCYUVacFV5dHhOWGhJVkdsSVRnb3phRnBMVFRWWGNrMWtiMmRuVnl0MVRUWlJSbXhwVHpGWFlsaEthVUpDV0ZwdlZVb3dXVGc1VDA5T2RtMXlZalJQUjBWRFoyZEZRa0ZRV21jemRYWnBDbXB6Vm1wUksyUm1WSFZDVUhnekwyc3JkRmxLWVU0d1JIZG9ZVGg2UkdSVU0wbHNaa28zWVRjMFEwUnpPVGRrU25jM1QydzFXR0YyTTBWNmNVcG9SbUVLUm14c1pFaFlPRWQxYWpCMU5HRktaMlJKVmtaUmNUSlFWVWxKU21wMmRISTJhRUk0T0VveFV6SlFNWFZ5UVRGVk5Vc3pkU3N4U1dKMlIwVkhabXN6UkFweWVYcDBWVGxTUjJoVFVXbFRUMEozTnpZM1puTjVlVnBMVGs5cFZGWlJlVU5aTjBaSFVsSTJkU3RHYWxwRmNrNVJWWFZuZWpOMGJFNUNVRm95VDBwaENuRk5aa00xV1ZKMlJrc3pPREF3U1dObFpXcHVRVzk1UWtwckswTlJXR0ZFWVdORVNFdGpTRGc1VTFoNU9HZGlMemxWUmpSMmNUUTNOMWx1UXpWVmVXRUtNbEpQVlRkVksxWlFSRTVCT1hrMFkzVkJOekF3Y25wc1JHaGhXV2hTZUU1VE1FdG5VRkZSV0ZjMWRXWmtOM0ZMYjJ0S1QyVmlSVVE1YlhkU1RFaHFUd3A1WjNrelIxWlNja0o2UzNoMUsydERaMmRGUWtGT2RXdzNORlZsWjJ0UFZFaFBOR2hYVmtvNVJqZDZPSFl2Tldoc2FqTlFSazQyZVhRMllYTTFLMUpUQ2lzNWJUaEJWbTFRVVVrNGRtYzJUMjkwYUcxVGNGTlZPR05NTld0bWFYQjJPVk51YmxaaU5rVkdMMG9yTWtacE5GY3Zja1p4UzJSVmJrSjZRa1p4YjFjS09GVXdabWd3SzNkd1pqbExUbWw0Y1c5TEwzVkJaVTgyVEVvMmFtTm5ja0ZqY2s4dmNuUTFjbTVJTlVSdFpEUnVVMVJqT0cxMmIyUnBZMk51WlVoNVFncG9iRFZWWjJjd05tWmhRMk13TTNSRlpHVkpabWRxTlhkVU5XWlpRamhHWWxCc1J6Vm1SbU5tY1Vab1VXSk1hSGxFYlRkMFdtOTNSSGxhUkdkdFpuZ3pDa0pIZFhRMmRVUTRhMnRFU25Wd016TkZjelF2VVRNMFpHVkVhVlYxUVc1VmVHUm1PVW94VEN0eE4zWmlMMlZ4Y2taV2VWTXpUVk5rTWpoa1JqQkNObFlLZDJWSk9XbElVVlZMWXpoV1kwWm5lVlJYVTA5VUsxTmhhRzF3TkRkVlNrNUJRVk5ZY2xkSkswZFFZME5uWjBWQ1FVNXNaelpQTmxseGVqQjFPSFpsVHdwWFRYRkRkVlpPTTFaWVZrcFJhRTVYZDBsV1RrOUxWazFSV2xkWGRHcFNPVWRUWjFSNlFrRlZZbWt6ZDBoclFWVnpOM1pPUkRVNVduRTRVbGMyY2tweUNqTnBRV3BaUVV4cVRsbDBjMkUwVFRCdmJWUktVMFJWSzNCdWNUZHpXbEYwVWpkU04xWkRVa1JHWVhvNE5GSk5NVEEwVTB4MFVqWndiVGhLTkRsMlEyY0tPRGxJU1hscFNEQnZlRlJaTTBnMWNEa3JTMkZJWWpRcmF6YzBOakp2UkN0T1VYbE5jRU14TTFsaVpqTm1NMmwzT1hwNldXaFpjRnBWVUdSSVZucG1PQXA0Wmsxdk1HTkNVRE5oVVVoU2JrWjJaR0o2VEVGVVZYVm9lakJIZGtOdmFrcExla0kyU21OVFpVaExNblJSTmtoWk0wdGlNbUpKTkVsWVZYTm1hVVZ6Q2xjM2QyaEJjbGhXYzNaUVNGRk1VbGhMU2tnMVMyVkRjSFJrUW05RWN6SjNVMmw0U21rNWNYcG1TM2RwUkhrMlIyWTBTV3AxVDJkNVJUUlZZV1UyWmtjS09ITm1aMng0YTBOblowVkJVekF2V0VVMVlrWmFXRkZuZGtWdE1DOWpTMnRxUVd4Q2NqTkJOR1Z3VEhobVpscGlXVUYyZWt0MVpVWk5WQzh3VjI5bWVRcDNLMWQyZUd0TVNIaFlZbmh3ZUZoV1RtOU1kMlUwTms1NWEwNXRjeTg1U1RCeU0wcFpiMjg0UWpNd1ZXVmxUbG8zT0ZsS1FtMU1PV000Y3pKemR6RklDbkpaVURsc1ZHTjFValJTWkVrek9HNVpNMFkxV0dSU2EzWTVjMlZyTW1KclluRnhlRXhIYm1WQlpFZEhPV1pIUVRFd1pHbFhXbHA2ZDNjMVNURlZOVlFLTW5Wc1N6Tm1ORFJUVlUxNVptdFJNa1pyVG1SVVYwRkRkWHBVVmxCSE5DOVpOa05ZTVhCd1RUbHdNM2g0YkhCaFJqVklZbGR4VWxsWlN6bDFWa3A0YkFwaVZUazVOMFZJVjAxa0syaFFZa2hRUldRNU1GSjJTM055TkZVcmIxbGtkWHBQWml0YVUwMXhTRTlpUTFOaGQzbDFiRE50YjFWWlMwSTBLeTl3VFZaNENraEhPRzFoVTJNclVVSmtTSEkwVDBsVFUwOVVabTFOTW1WV2VXdGtORmxDVDNkTFEwRlJRV0UwWlZOb0wxWTNZMjVKY0VOSFkyeERTazVCTW1seGFITUtNSEJ5TlRkMVozWmpPQ3RIVEU1NldTOWtPV1pVVmt0V2NqTkZkMVJyWkhsaGQybFROelp5ZEdKb2NrVXZkMGh3V1dkVWNHRTJkamQ1VGxCaUsyeElhd3B3VXpaQmRUWlRWMUJyYkVKa2JpOTJlRE5zTWxjM2MzTkZaVFozSzB0emNVNXRSR2N6Uld4U2IwZGhLMUF4YW01WGRHVlZkVGRPTW5oWVRsUndhWHBEQ21wcFpYQXZWbWRWU1dKaFl6TjVNM1ZoTkV4QlVFaDBia3BYVFRJMWEwazJlbE15VkZkRmFFb3hWbFpXUWpWQ2JqY3ZWRk5NY2tGQmFVRTNSSFJaVWt3S1ZXaDJhSGRLTldWQmVqQklTbXBMVlRkek9IcG9Neko1Y3poRFZFdElVQzlhUkRKbmJFdG9OeTh5UjBGbU1EQTBiM2R4YjNBeFJXOVNkV3QxZUhBM1VncExXWGxXZVdWQmNYSnJkMDFsYVc5aGJXODNNa041ZGs4MllWa3ZMMmRLWTJSelJGVklkVVZNVm5ab1NWaEVkSEV5WTAxTVNsSTJRMlJPV1U0S0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiBjVGZoWkgyWFFzZzkwUkJnTlVvMkVaWm9kQUFTcVNvWUlGdmZRZ3MxalcwNXMxS3Y5R1o3M3JjNHFkeUtRblprWUJyOVg4RTAzdkFmRWR1bnZEdGYxYUF3ODdaaWljNUFqc2hzd1owblI2dXRYWnIxSDlHVml6YXY1aUdYWDYxdgo=\"\n  }\n }"
+      "x-ms-request-id" : "c933f971-99a0-4c29-9b5e-d8acda4a0411",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterAdmin\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSU204NVJXMUtlRWx1YUVOQ1QxQXlkRzloZUdGSFZFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5WRlV6VFdwQ1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTlJHTjVUVVp2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSUkNsZDNkeXRJZVZGWVNVdFhSeXRuTjFWa05GUjNaRFpJYjB4c1NITlFTSGw1TTA5RE5tUkhjRzlhYkVSQ1MyMHpiemRWY3pWMlV5dHVRMEpMV1VnNE1EUUtlbEJQYWxkT2RraExVVWR5ZVRsd1pFcE9hVXhJY1ZGbWMwRkxZMjlRZUhsRlFqZDFka0pyTm00MmFreHBVakJYVldOV1NrOHlhVXBCTVVseVNqSTFiUXB0VUdWeWF6SllRMDFLVDBGWlQwTjBhM0ZLVkZsNFVFMXJLMVYzVkd0V1lrRm9WbUkwWWtKYWNtOURjMUJ6YVVSb09VdEJiV05EV0U1M1dYbHFZVWQxQ2xCSmFTdEVTMnBYU1RkdWJIcFZSWGxSVVVod2JrVk5UaTk1Vm5ab1QySlpiazk2WkZwNU5VbHdUSHB2VEhRdlJpOXViR3QzUmtkWlpubHNVVGQ0WlVVS2JEbDFZMUk1Y0RWNk9HUlRiRTlFUkZOc1kyTXdjWEJtVEZoV2JYcFpWbEpIYTNZeFMyeEdXalJxSzNSYVpGUlBSVklyTVN0aWNFTnlORUY0TlRGTFdRb3ZSbk5vVVVoUVEzTkpTVWMwUTNaTGQySlRZM1oyYjBSWk1rcEtSM1pVTWpOUU1Hd3hhblZHZFdsMGFpdEhSVkJXVVhONVNFZEZZMlZ4U2pNMkwxVnpDbFIyUXpkR1UybHVkbEZtTjI4NGMzYzRjMkpsT1dSblVsSkxPRFpCU0dkeFoyUnJNVEEyVkdKbVFWbzBkRnB5WVVOU1drOHlOWEpRU2pZd2FYZEhXVTRLYmtGM1dIQTFlakkxZVdOQk5FOUdXRk41WmxSbGJFbElha2xZYTNwQlZIWklNMWRaVFhnNVp6QnhVMVEyWmpsa09UbFdSRUptYVRJMllsWm1kemR6UkFwRFpuazVZakp0UjNkM2FrTnNRMVZsZEhwWmFtdHVNV05EWVZRd05URXpSMU5NVEV0WGRrRjFObVV2UTBaM2NEaDBRWG8yZUVwUmVVSm9TbVJxWlU5UkNrcHJiMlEyWjBoblpqZFhkakF5VTJGaVVFRkpWV2RyTWxWYU5rRmtORGt2YkZGbWFVUm1aMnhuVlVGMVVETXZhVmx6UzNkaFMxaHVkVU5NWWpSTlVGUUtkazVUYlZWWlJYZFlaemx2Y2twV1NqTXpNR05SVjNGRFFWRnNVbTUzTTBvd09WTkphWEJaV21oUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRkJhR0ZGQ2xsTFdua3hWVk0zTTNvcmNVWnFjbW92WlZSa1YzQm9SV1p1WVhsRVVIUkhUbnBtYkRsa1MwOU5SRXd6VlVkdWNFeEhNRTkwVXpOdFVXZHJZbmR3Y2lzS1dEWlpZbkZIWkZaSk5UTXpkVkZrTTJWV1NqSlRiVzFtUW5WeFNVOTBLMUpQTmpsUmJsbEJiMVIwUmt4eGNEVkRPVVpaU0Zvd2FHTndSamhvWWpCUWFncE1Sa0Z4ZG0xelozZ3JSRzk2WVhaME9UbDFkRVJVVEZwdlpIcEpWRVV3WVdSbUwwWkthSFkwZDFoT01sQTBRelpZWVZWQlFVbG9SblF4WTNGSE9UbEtDakZDTTNsVVNXVTVlVEJwUldaeU5XVXpTRFI1U2xOdWRVdzFMMVI0T0hOQ1QyNXZhMlJzZHprMlRtTmthWEJ5V2xSTmNrZFZhREZ5YUhKcmRsSllSMWNLVWpWaloxbGFWbXRoVm5WUFkxUmlWWGRPTkdvNVQyeFlMM2xTVms1eFIyWkxTREppUlhsNmRHdGFibEZCVjJkT2RrMVNkR3R6YW1odmRtWjZUSFV2YVFwMFZFNDFhakJhZEV0S2RYSTVlRVJ2U1RCMGJXMTBjM0kwTTJFelkyTnBLMnA0ZUVkMmJHTlVOVkp6VlUwNVdYQnRiMUJZYTJkM00xZEVWMUpSU3poV0NtdFJlbTlWYVdobFNXTnZlbmxpWVdwMFJXMTZZVVJxVVhkTlpXczVTa2t4YlhCWFUxRkpiSEF2TkRWMmQyZG9aR2MxY21jMk5tdDRSRlo1UTJaMlN5c0tOR3RoWjBJME9VTlpVbFZuWW1acWIxWmFjak5sUVV0bVlVbE1lVWxyUjIxMWMzbG9ZMGh3TUZGMFRUVlpSSEZhWWsxbk9XUmhOMHB3VFdjd04xSnZkQXBuWkM5NGVVSTNWV2QzUTAwMldteG1ZV1JuYzJrNWNtOVRTamhNU0hweFJVWnZVbEpFZEZSWVRuTmxNbHBtVlhNMVJtWTVla0p1Y0RCUGRqZFROV3M0Q205dVJHaEJWV2RIWjBaVlVpOVZUbGRYVmtnMlkycEZjbHBvVVRoMlIwZFhORzR6VGtsVU9VMTNXRkpqVURKNk1TdE9UbWczT1hsc2JFdElWM0ZYYm1vS1dGTm1TakpUTVRCV01qTmhXRGhDYnpGVVZXeEVXbnBNUjFCMlZGaFFRV3hEYTFNM1psUnZQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zOTQ1MTFkLTNkMjJhZTQ2LmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczY2ODQzMjgyZTIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczY2ODQzMjgyZTIKICAgIHVzZXI6IGNsdXN0ZXJBZG1pbl9qYXZhYWNzcmc0OTk3MV9ha3M2Njg0MzI4MmUyCiAgbmFtZTogYWtzNjY4NDMyODJlMgpjdXJyZW50LWNvbnRleHQ6IGFrczY2ODQzMjgyZTIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyQWRtaW5famF2YWFjc3JnNDk5NzFfYWtzNjY4NDMyODJlMgogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZSRU5EUVhWVFowRjNTVUpCWjBsUlIyTmhSWG94VVhSQ1IxaDBiRzVtZUVSemIyUTRha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRnpSa0ZFUVU0S1RWRnpkME5SV1VSV1VWRkVSWGRLYWxsVVFXVkdkekI1VFVSQmVrMXFXWGROVkZVelRXcENZVVozTUhsTmFrRjZUV3BaZDAxcVFUTk5ha0poVFVSQmVBcEdla0ZXUW1kT1ZrSkJiMVJFYms0MVl6TlNiR0pVY0hSWldFNHdXbGhLZWsxU1ZYZEZkMWxFVmxGUlJFVjNlSFJaV0U0d1dsaEthbUpIYkd4aWJsRjNDbWRuU1dsTlFUQkhRMU54UjFOSllqTkVVVVZDUVZGVlFVRTBTVU5FZDBGM1oyZEpTMEZ2U1VOQlVVUmxObTlQTjFWNk5rZEJSazlLUkZWNVUwZHpRMHNLVm1KbWRUaHNkV05LTkhZemVrUk5aalUwZFhSMFNtZDNPREJqWlhoNksyTjVRalY0THpKbk1ETjJVRk5TTmt0WVZWa3JaMHN3Ym0xaFZtRlRhbE5PU2dweFNTc3pkR3hSYUM5VVZXTk5TVWwwWVZCTVZrdzJSbk53U0N0Mkx6bGhXVmhrTjA1Vk9GZEJRbWxZVDNOUGEwTk1SME5zZVhCWGRVVkdjWGxvT1VwSENqazRObXRDVUhGd2FVcG9WMlpNVGxseVVWTTFTMDEyVDFaTlp6TTBUek55V2xFdmNrZEJiVmMyVEZNNFRuRjBjRWhGVFVsTVNXa3phVkIzTVVOd2FVa0taSGt3WTJsbE1YQXhLMDFwYW1wc2FrMW5Xa295VTI5ME0zUTVNVGxZY0dsSGJqUjJSMjU0VURkUlVWTXZTM2RIUTA5aU1HZGtSbEJ4Tm5saFJWbEdWZ3AzU3pkT2NrSm9iM2RzVlVoVWVXeEhWMnBTZG01NlVqVklielJVYjFJM1V6TmxPRVkzUzNaM1V6ZE5PVFE1VjJGTWNERlFNblptTkdsRmF5OUJPVEpzQ2sxU0swRTBWSEp6YmxoRlV6aE9SVWt2ZGpKTk5FcHFWRWxhT0haYVJtWlJMME54UTBjd2JVWnFUWFpRVEUxRlNsQTBZMU0xTkZVMFpGaGxVRlJyYUhBS2NIcE5aekZDSzJZd1QyOUVUMWhyV0VaQ2MxZFBLMncwUkhJNE5DdExTMWRsYVcxSE1FdFBlVmxOTWk5WFNuSmlXbGd2YmxWWWJYQTFVblJVU1ZCTlp3b3lPVXRhWkhWc1lubGxSMGhQVDBkaVJ6aG1XV1pFV0dKSU56Sk5NakJuVjNodllYRkNZeXMxZDJKelVFc3lNRlpwTkdVcmFXSXljbkp5U0RoVlMzUmFDbWw1VkdSck5rbDJTRFI2VFhad2RIQkpVbWgzUnprNE1saEtRVUZGYWxSemJ6Vmpha0U1TWxaRFRVcDRUR1oyUVhaSGF5ODVkbXd3TUVWNU1UVlRWSElLTlhSeFlXMWhXa1ZNZFV4eVRGWkRXRkZXYWtkbGNFSm5jVzFvSzI5dFVrSlNSRzQ1ZGxadGFFVndUMnhTTjFwbFMwaEtVakZwYWxWcVJtSXphbXBKU1FwcGJ6WmFjSGhMYldsNFFtczJNMkZIUVdSNFdXVjNTVVJCVVVGQ2IzcFZkMDE2UVU5Q1owNVdTRkU0UWtGbU9FVkNRVTFEUW1GQmQwVjNXVVJXVWpCc0NrSkJkM2REWjFsSlMzZFpRa0pSVlVoQmQwbDNSRUZaUkZaU01GUkJVVWd2UWtGSmQwRkVRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRUtlSEYzTlhGQ1JGVkJUbVpqYVRsMlZsTmlVaXR1VVRWd04wRm5abXg2VkRSbmVFVm1NR05VVDBSYVpsSlJLMnd5UmtvelRrWTFhalpZYzNoUlNIRkZRZ3BEWm13eldGVmhjSEV6UzB0dU1sRk9SMkZVWWxWRFJIbEZVRkJ5TVV4bmIzVjNlV3RqU210VFJtUk5RVU5oUmxoYWF6WTVhR3R2Wm1WSWEwWm5WRU14Q2pkU05YSjViSFpxZUVOSVdGQjZUVlUwSzNkc1FrTnNaRTFyYzFCeUszaFpTRFZSYkZOR1NGWkpkVGsxVERadU4yeE9PV2xKTDA1emNVOVRhMDVyVmtNS2FuZGxPRk5xUm5aWGFtaEVPWEl2UWtWQlpVMURPR05YU21wbmJWVk1Za0ZzT1hwaGVuUXhVREZJU0hKSVdsZFRUMnczTjJwNFREbHJOMGN6UW0xdFl3cG5LMVZaV0dodmEzaHVjWFpDTWxWeFdubHFXbGx5ZDFWcVFsZGpha3BKYmtGTE1IazJVSE5FVG14aGFITjFka1lyYURscFdVRlVPVlU0WW1aNWNYVm1DbmxKU0VSWlJWaDFTa2d5ZWxGQmVFcHllVmxPYldsaE5sbGpTVXd5T0haVVdXbEZWVkIxZHk5clEwWlNPVVY1UVc5c2VGSkpTM1pHYm1WS1pWcERUbk1LVFhOTVlrb3JWRFYzTkdNeVZreDJUREpZUzFWelkySmllbVUyTVVKUFJqSkVTbkJZU0dsRlEzVkRVVGxOUjFvMVoyMW9SbXRTYm0xUVZrdDVWelY0VndwT2QyZDZja2xSWmpGMmVuQnJaazlTWmxObVRFY3dUMnc1ZUhRdlNYaGtlbFYxUTA5cGN6azVjVTVpYmtKV2NuTjVTRUpMWVVGaFprOXJlSEJtYkc1NUNqaFpha2RYZDFJcmIzcEpOVkZxYkhBd2NWSm1SRGhtV2tWNlptUlphMkZvVnpJMlZFeFZNMHhhV2s5RmRYQkhka1Z4Wkc1aVMyeHNPVFl6YzFkMVRIZ0tZbHBpYjJSdUwyeHFURE00WWt0cVIyTXpWWEowUW5RM2JqQnVhRzE0SzBGeFptRm5TR1JFWlhKNE5UZE9ZalI2YXpOSlQwb3liMnd2TldSaWQzRTJjd3BuWjNWSWJIZEZWV1l5V21GUFEwTkRWWFl4VTNOSlJ6Rm1WR1V4TW14RWRVVjVUV0ZVUkVOM1UzUlpQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJNM1Z4UkhVeFRTdG9aMEpVYVZFeFRXdG9ja0ZwYkZjek4zWktZbTVEWlV3NU9IZDZTQ3RsVEhKaVUxbE5VRTVJQ2toell5OXVUV2RsWTJZNWIwNU9OM293YTJWcGJERkhVRzlEZEVvMWJXeFhhMjh3YWxOaGFWQjBOMXBWU1dZd01VaEVRME5NVjJwNU1WTXJhR0pMVWk4S2NpOHZWMjFHTTJWNlZsQkdaMEZaYkhweVJIQkJhWGhuY0dOeFZuSm9RbUZ6YjJaVFVuWm1UM0JCVkRaeFdXbFpWbTU1ZWxkTE1FVjFVMnBNZW14VVNRcE9LMFIwTmpKVlVEWjRaMHBzZFdrd2RrUmhjbUZTZUVSRFEzbEpkRFJxT0U1UmNWbHBTR04wU0VsdWRHRmtabXBKYnpRMVdYcEpSMU5rYTNGTVpEZG1DbVJtVmpaWmFIQXJUSGh3T0ZRck1FVkZkbmx6UW1kcWJUbEpTRkpVTm5WemJXaEhRbFpqUTNWNllYZFpZVTFLVmtJd09IQlNiRzh3WWpVNE1HVlNOazhLUlRaRlpUQjBNM1pDWlhseU9FVjFlbEJsVUZadGFUWmtWRGx5TXl0SmFFcFFkMUJrY0ZSRlptZFBSVFkzU2pGNFJYWkVVa05RTnpscVQwTlpNSGxIWmdwTU1sSllNRkIzY1dkb2RFcG9XWHBNZW5sNlFrTlVLMGhGZFdWR1QwaFdNMm93TlVsaFlXTjZTVTVSWm00NVJIRkJlbXcxUm5oUllrWnFkbkJsUVRZdkNrOVFhV2xzYm05d2FIUkRhbk50UkU1Mk1XbGhNakpXTHpVeFJqVnhaVlZpVlhsRWVrbE9kbE50V0dKd1Z6aHVhR2g2YW1odGVIWklNa2gzTVRKNEt6a0thazUwU1VaellVZHhaMWhRZFdOSE4wUjVkSFJHV1hWSWRtOXRPWEUyTm5ndlJrTnlWMWx6YXpOYVQybE1lQ3ROZWt3MlltRlRSVmxqUW5abVRteDVVUXBCUWtrd04wdFBXRWwzVUdSc1VXcERZMU16TjNkTWVIQlFMMkkxWkU1Q1RYUmxWV3MySzJKaGJYQnRiVkpETjJrMmVURlJiREJHV1hodWNWRlpTM0J2Q21aeFNtdFJWVkUxTDJJeFdtOVNTMVJ3VldVeVdHbG9lVlZrV1c4eFNYaFhPVFEwZVVOSmNVOXRZV05UY0c5elVWcFBkREpvWjBoalYwaHpRMEYzUlVFS1FWRkxRMEZuUW0xNUswc3ZjV1F5TVZWalZYb3JSM2RPU0VWVllVSm1iSGxQVmxaQ2NEUk5SMWhMV21VeWFHOTRiVzk0YzFadFR5OXlPR0ZJSzBWclFnbzNVRkZVU0ZwV01uSlJOSFpzWVRoVUx6WktkVzVNYTA1clFWSnlNMVV5V2xCSU1rUjRkelpOTVRGdVVYTjNjalJuUzFORFVUQkhWekptV1U5QldYWlVDbE5CVWxaNU15OHpNWFZGT0ROV1dXTlliRmN3UmxaeFpEVmpRakJrWVZwWVVVOTVUemRoZWtOb1dFd3pUelpLYml0SldYcDFhV3Q1YVRSc2NpdG5hbW9LVFhkNVNrTlFjaTl4U0RWWVZrYzRZeTg1ZURCT2NtMUlhRVZHWlM5UldsTnRUa0puT1U5MVRHSmxZazA1WVRaemN6TmhaQzlLT0hvclIxaGtaemRaV1FvMWNTOVpPRGhZYWswMU0yOXJiMXBsZW5SaVJsWk1aV1IyVDBSV2RVdDBhbk5UTnpSalJsWm9jalJIY2t4alNITnFOVUpXU1cxQlIyTldRMVJyVlVNckNtcExkV3htYlU1RU9GTk1OVzVRUm5sa09XNVBVa3B5ZVdOclpuUkllSHByU210YVUxWndNRXhZYjJ4VmFGQmhPVkEyZGl0dksyZ3hWMnc0T1dVM2NVWUtXbW8yTTNGMGRuWnRRV2gzTTNkelVHWndTVlkzVTIxUE4xWTNSMDVtTjJkSEwwUk5XVGd6UVZCaVEzZDZVa1pUVmpaSmMyTkRUV1JCT1ZWd1dVMU9UZ3A1TTI4ME1sazJTSFJ4Ym1aemFGRm9aMmwzZGtGWlRrNVFWV0ZoT1ZGT09EQk9MMjlvZGtkWVJISnlLelJSU214V1IyMWllbUZEV1dRMGNGRXpjRGRIQ2xsQ1VETkdNVWxQTVZVMVJsZzBNV2xDT0hWSlVVbEtWRmhxVGtWVVJqVkpkRE5STUVsNlEwNXNRMUlyWnpRdlJpOXVTa3g2Y2xSdFl5OXZaVnBCYlZVS2RpdDFaamt5VTFGWGVraGFZVGR3Y0c4MFkyRjRMMUV5VnpGVmFERlVlRXMxU1RoT1VXbFVjamgzTDBKWWMzTjFOeklyYUdwelN6UjJUelV2TlZaRlVBcHVUMHRaVnl0TGEwOUlaMm8wZVhCNFIydDViRkpxTlZGdGVrNWxMMGhYVld0c1NFOTBaWFk1WW1veFoyRkhiVkozVVV0RFFWRkZRVFJ1S3lzNFFYUXlDbUZhZUV0aVNsWTFTVUl2U25sSE5pOUpaM1l5VWtKR01tdHVVak5uZDNOT2MwRTBOazFIYkZGdmRHWnlSM2hwVkZWTk1EVXhWMXBtUjFKQ05qZEdVM0lLZDFaUlJtaEtaRlZvWnprNUsxcE5UVTl2TjNoU2VrcDFVMFZpYTJGMVR6Sk9Za1JXVEc5TGEwVkpNM0ZvT0dOQ09ETmFaMmMzZFZZMlN6Qk1WR3B2Y2dwVFlraENVSFZqTWxsUlYyaFNaamxpZUcxS1VVOUtVMlpzT1ZsSFFuRktjVzl3Vkd3eFJrbzRaell2VUZJNFRHUkpXa3BuT1ZKUGFtMWpjVkF4ZDNGTUNtcG1URGhNU2tKbFowNU1kWFJoUmtGbFFuTllUbTFDVVhwcGQxY3Zhelo1SzFOd05tcHRNRGh1VjJ0MWJtcGtWMEp1VjBSR2NrbDFaa2hNUVRZNFVta0tOV04zZGtNck9YTm1SR1ZhV0ROVWFqaDNNM0JaV1hoS1dIWlpkVXRGYmpaMWNuaHJZa3A1T1UxQ1VFNXhZM0l4VGs4MmF5c3hhelZWYVhGcWFuVkJNQXBUVFVOSUwxSnBWa1phUmswd1VVdERRVkZGUVNzdlRrNUtLMkpqT0ZsMVREQmpVbVVyWW13ME1XeElibWsxUjFkRGMxWjVjM1JTYjFZeVVrbE1VbEpsQ2xWUUswRkRSa0ZZTkVobmVEUlpaMGMyUms1TlNVOU9PV05XVkdWd1JtbHNZbWxEUzFRNVIyZGhjUzgwTm1SUFVsSjZTMlJ5ZGxWSVNrRnFWV05YVVVjS1FtUlBiVEJ4YzB0alMxQmlUbVoxYUZKcFozTjZNbTV4VG5kTGVYWlFlbkZaV0VGelRuQnpVSFV4UVZCWU5UaE9WbHBRWkRGeVpVTndhVzlrVUVVdmRnb3JNelIzYmpOWk1FdHFkRkp3U1dkT1JVUmphMGhZY21KRE9YQllTR2xuZFRBelVIWjJWaTlPVjBkd1kycEdZa2hPVEUxb1RGZFZRMWRxY0VSSlJEUlBDakptVDJReE0wVk9MMmx4TW14NWEyOWhTV2xsVVdWdk1tRkxRakJUY2psbFMwUnVlSFppUVV4WmVrRlZWV2hQVG1GYVR6QmlPVmwwUVRWWFkySmhkSGdLVG5JdlpUWmthMFZRYTJGYVVUaEtWRVZoZEhkYWNtaGhjVXNyY1Rkb1RIQTFMekU1U1ZsdmVtbDNTME5CVVVKVGFXNUZMM042TW5Nd1VYTkRUbEp4VndwRVZpdFJhbTFPVXl0bU56azBWWFJRY0dWbWFuUnZVaTlqZWk5aVdYQllSRTF0U2pSV2JWWm9TR1JyUlc1eVJISlNiV3N4WkUxdEszY3ljbUpZWm1GekNtZEVjazVXTjNkMVNIVmtiM0JqVlhkNU4zb3dRWGhZYTNwU1RucFNjVXRhWTJNMVZrOXlNMGxTYjNnemJGVllWa3hFUzJocFIzTTRRMDgwSzJsVE16QUtMelJOT1V0bmFqZzJPV3RIVGxsMFVGaDFlVVpSUnpCU05FdGpPSG9yTmxkWmRIaHlOekpTT0d4dllVVTJWM0JIV1d3ME1qVktNMnN4Wm1JeVIyOXhSZ280WkdsVFJXcHBXRlJJUVZOSVpHd3dkVkJoVFV0SmRuRmFORTlSU1dScWEwZEhLMjV6YzNwRWRqbEdUVEZTVWtKMksxQXdVak5aZFM5c1JIRjZXVGRCQ2xka1lXNTRZMXBKVkdaeFRqRlFlbk5CVmxScE1EaHlkV2RFWTNOeFdsZzRWR3R6TVhCRlVHeDZWVFJOVm5kRFptOHZRa1UwWjI1TWRGaFpXbFYyYzBvS2FVSkVlRUZ2U1VKQlVVUlpjMGxrYVZWM1kyaFpNRUpOYlVaVFN5dE1OVFZ5V2xjd1JIWkdOWE5DYlZkMmJVcEVSREJsV1Vwa1ZqaFhiRXRYVlRkU1JncGFXSEZhUjNaSE9UZExOR281ZVZCVVZHZG1lVlo0T1c5dFQyNDNMMnBITW5ORlVXNWljMDloT1Zkb2VYRmxRMHhYUjBSSFlWSXhXVGcxUTJSNlYyTTRDazh5UkRCcE9HUklNMHBQTVdrNFZscHlTMDV1VFZOeGRuaE9Zbmd5SzJweE1EZzVNVVZSYkZveVkxQkpkMHR1U1VkYU5YUlhaRGQyWTB4bFJ6Tm9WemtLV1V0ck1rWmhSVTl0YVRSblowdEtWMFJ0U1hjeVMxSXhWR3huV21sdlZFVnFlVEp5YzFwTVFYVXpUa1ZhU1ZKcFlqUjBPVGx2UnpGYUwxbFFOMlppTXdvMk1uRkJiRmhDWjJZeVpVWkVNV1psU1cxdlExRTFXa3RwU2s1c04ycDJUa0ZtVUc5S01VeFFVVFkzUkVwUVVYZERaMDkzZFhWMWVrSTVRa1JXVm1ReENqZERaM3BCTjFkSlJTdGxia2xPVlhkRlZ6SXdUbTFaWjBaWU9FTlZjV1JFUVc5SlFrRlJSRmc1UW5sSkszRnJXV3RqVFhwR0t6STNhR3BqZVdNMk9XTUtjM1ZGWkhKTVQwUm5WVzlLU0doYVR5dEZjRU54ZVVoaVREZG9kV2hxT1doaWFqbE5VRk5MV0RObVVuQm5VbVFyT0hwbVprVTFWRU54UXpWMVN5OVJaZ3AyZFdwUFp6ZFhSRGwxVUdrNGRETTBNMjEzUTJWVGJsZFhTMHB5Wm5nelRuSktWa292U3pOTVFUWnBURFJ3Tkc1eWNrWkdWams1TW5kdk4wcFhVRnB0Q25WelVXdEdjRzVUT0RJNGNVVXlZM2R5WVRObVRHUnpWR1Z3YjA0M1pISjBXRXQ0UWs0emFtbHJkakJqYkVobGVITk5kMHhTVld4eVRISk1SVTFzVVRBS056VlJZemxFTUZkc1MxaHNkSE5KWkRVMFprbG1lalJaUlVOelYxUlFiMFZYTlhJMGQzUk9NbEZXYlZKS05UUXlZMVJDYTIxdFUzUjRWbTVNWmxSek13bzNUa2xtYlVsRWQyUTVWbkEwT1hZM2FEbE5SbEEzYUhSc1VtcHVXVmh1ZERaYVVVOW1WMDFSYzNwb1F6SnBLMk4yYkZOWFpqVlZSWGh4ZFdVS0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiAwNmVkNjFkM2VmZGIwN2E2YjgwZDM1MTc3OGU0MzYwOGIyNGEzNzRhNzgzYWI4Y2Q0NDM2NzU2OWFmZjhmZjE5NzQwYjBhZjRmNjBmZjdmZDEwYzE3YzFjNGMyNmM4N2Y4MGU2ZjVmZWMwZTMyYzk0OWFiN2RlYjY5YmQzMzkyOQo=\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterUser/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2/listClusterUserCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:51:58 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:40 GMT",
       "server" : "nginx",
-      "content-length" : "13164",
+      "content-length" : "12888",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -827,23 +831,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "a2d3dca7-09fb-456f-ba1e-d95d0e3e506e",
+      "x-ms-correlation-request-id" : "92da32f3-93d6-49d6-be51-3a2446f6af04",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025159Z:a2d3dca7-09fb-456f-ba1e-d95d0e3e506e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021741Z:92da32f3-93d6-49d6-be51-3a2446f6af04",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "da06db74-f55d-4266-83ce-fa3f37a794ec",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376/providers/Microsoft.ContainerService/managedClusters/aks42786938f4/accessProfiles/clusterUser\",\n  \"location\": \"centralus\",\n  \"name\": \"clusterUser\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVJFTkRRWEpEWjBGM1NVSkJaMGxTUVVsRWFqZFlhbVIyYWpaTVJXcEdlVVIxVldGbWNEUjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGNLUkZSRlRFMUJhMGRCTVZWRlFYaE5RMWt5UlhkSWFHTk9UVlJyZUUxRVJUUk5SRWw2VFZSQk1sZG9ZMDVPUkd0NFRVUkZkMDFFU1RCTlZFRXlWMnBCVGdwTlVYTjNRMUZaUkZaUlVVUkZkMHBxV1ZSRFEwRnBTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblNWQkJSRU5EUVdkdlEyZG5TVUpCVFRWS0NtSkhNa2d3Y1RoWk56aExhSE5CUldadU5WSklWVFpGYkd0R1VGcE1VR1Z1TjNCbFlUZE9VRXBYVjJoRVJIQnhNV2M0ZG1RNVVrWjZkMVpFVGpScVJVc0tUMVZaUW1kUmNEaDNTa2xEVVV4d01VcFBlSFpZU0RacVIyTjBSalptSzJZdlMxUlpaRGs0ZURCTU5UVlljSGcyVlRkV01taHBWaTlxVDBWbE0xazFjUXAxYW5WaE0wZEVjRkU1Wm1GRlZVOW1TbEJ5UjFGc2VFdE9SbWsyT0ZCM2NXOXVkM0JvT1M5UWQwUkZaMkpuVjNZeFZtdE9RWGxtYUcxdGQwczJjbUpJQ2t0SGVXcFhObVk0ZFdkcVNHVlBWVm8zUXpKUVRWa3pZa05PZDNaalRuSklUa0ZyUlRSaVVsVkZabkpzYlZsQmQxTjNaWE0yVEdwNE5UZHVXSGg2V2tjS1lrdHJRbTFZZWk5MVUwNXRhM0pOT0dodVUyMVJNR1IwYTAxa2FsSjBaSGN5TUdOM1FrbEtTMkoxT1VZM016TXZhbmxyY2psUU9HNWpieTlsYVRKb1p3bzVNRXR3UzJWTFp6TlBRVVZPU0daNWVXRmxjMk5ITVhNMFZFTk9VV3RQTlU1SmJtZHRTMkZSUzBOU1pXcHBXWEIyVVdjMlVXOTVhR3RVU3psMmRuWndDbEZ3VTAxTGRqSmtUVE5USzJNNGIwSllPVEphVVdnNU1sbGFNVWN6VlVKU05FdHphMkprTUhkUlpIUTBkbUZITVZwTmF6RTBjV3hTVjBJclVGSllXRWtLVVRGT1Nrc3ZXbEpCYTFvMGVXWnBVMk5XYkVkMldYaG1lVTk2TnpaT0wyeGpiSE5PUW1VNE9XVnNaV3RyUXpSSWMwOURkSGRPVTBsMk4wdFZibXc0ZFFwMVVYaG5lVGQxVW1odmRGUjFRWE5IYjNWc1ZWRlBWa3RDV0VwemR6TlNWbXhzYVVsa2MydGtlRUp2Y2tkeWJHWmxTMEZoVVV4eFRtOXdhbEpCVjAwMUNrUm9NVFIzTWpNeGJXTmFOVUpETld4TldWbFhjREpSY2pScFlXcHpkMjlsZGpCd1N6ZE5iMVZVYVd4NWNqVkJjMEoyWlhsUlpHTktkSEZTWlhkdFdsSUtNa3BwUjFKNk1YaFZNak5ET0ZCMWRscEJla1ZDVG5aT09GQktlamxqYWpRclRFdG1SbEpxVUVGblRVSkJRVWRxU1hwQmFFMUJORWRCTVZWa1JIZEZRZ292ZDFGRlFYZEpRM0JFUVZCQ1owNVdTRkpOUWtGbU9FVkNWRUZFUVZGSUwwMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUTBGUlEweEpWamxyQ2pVdmMyaDZOVkkyTDI1Q2MzUTBMM05XVVZBdlUwRmhRVVpTSzFkbGVERm9jMHhNZURGQ1VVVklOSGR3TTJSQ1QwMHhVVWRRYTFaVlZESnJVVVV5TTNnS1JrTm9iVnBGWTBoRVpscFBOeXRLUkd4bGFsbHJORk53Um5ScVoxbDBNV2xGUW1Kd01EYzBSRE5wZDBsMVMzUkJSRTlHVWxKa1YzSnpVR2d2VGxKWWFncEtiM2hLUWxoV0wzUXdNbGxFV1VwcFZHTlFiVVZ3YmxObFRtaE9aSEp0VVRjelYyNXVjVFpsVTFScVZHVkdaemxFTUc1VlVFbFNNbnBUTTJkNE5tVjNDa2d5ZURocVZFZGpSbGQ0YXpoWmNYbFlTRlpwU1RKM1dWUjFMMnBoYWxnMVUwUkliVEV6TDJ0a1lWVnBPV2h1TW1STlkyOWhSRkZqWW1oUU0zVXZZV29LUmpWUmFEQjRkbkZWWjFSeFYyNHphVkIxTlZaclF6ZHVXRTA1U1RKM1FuVTNWbWxUZVU4MGJVeFpNazFKTURSUVp6WnVOa0ZWYW5STlYwMDJVRXBVVHdwRUsxbzVaRVF5ZEZscEx6VjJjbWxpWVVoaVpUQnRjVzR6UTJGWVdsaDFWM001TVVwRllUUXhXVVJwZVZkQ1drdFJUM2xaWlU5aFluTTVSeXM0UTNkQkNtRnRLMjkwWlZadGFqZDFiRWxLSzFKbVJVVnJjekpSY1hCSlpFSk1ZVVJyZVRsNE1YVjBLM0JIWkcxclNtTXpZbnB2T1ROcVRVMVVPV3RJTDJnNVEwa0thaTl0Tm1sYWRYQlBXVUprVW5CRGR6UkJLelpCY2poUVZsb3pibnB3WkM5eU5GaHFjMXBHWldnM1dYcEZTa2xWU2pNM1NVdHROM1ZMTkhab2RFMXNPQW8wZW1SdU5GZHhOemh6VEhocFZrbHdUQzl2ZW5oQ0t5dFFURUpXT1RaNGNrVllkV1Z4YTFkeVQzTnZjRXR6V1VGSmJURnRkVTF5VURKRU9HTlJSbFJhQ214elJXVldTMDlvU2pOUk5HTmxNMmg1VTJOTWMzUlFLMDlxVERGdGJXcFVjbHBVT0RoQk9HbDFVRVJQV1d4TFIyaE1jR3hMWVhSVFdubGhXWFJKTjFBS05TdFFiMkpIV2xwbUsxUlhhRUprTVd3d1dqWXJTRzlXVGs5MU1HTmpZVkJ6UkRnemEyYzlQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zODk0NDZjLTQyZTZjZWNkLmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczQyNzg2OTM4ZjQKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczQyNzg2OTM4ZjQKICAgIHVzZXI6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzIwMzc2X2FrczQyNzg2OTM4ZjQKICBuYW1lOiBha3M0Mjc4NjkzOGY0CmN1cnJlbnQtY29udGV4dDogYWtzNDI3ODY5MzhmNApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzIwMzc2X2FrczQyNzg2OTM4ZjQKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2VkVORFFYVlhaMEYzU1VKQlowbFNRVXgxTldSd0syeDNaV05JYVhZdk16azVaMUZ6TW5OM1JGRlpTa3R2V2tsb2RtTk9RVkZGVEVKUlFYY0tSRlJGVEUxQmEwZEJNVlZGUVhoTlExa3lSWGRJYUdOT1RWUnJlRTFFUlRSTlJFbDZUVlJCTWxkb1kwNU5ha1Y0VFVSRk0wMUVTVEJOVkVFeVYycEJkd3BOVW1OM1JsRlpSRlpSVVV0RmR6VjZaVmhPTUZwWE1EWmlWMFo2WkVkV2VXTjZSVlpOUWsxSFFURlZSVUY0VFUxaVYwWjZaRWRXZVZreWVIQmFWelV3Q2sxSlNVTkpha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRkZSa0ZCVDBOQlp6aEJUVWxKUTBOblMwTkJaMFZCTURKVFVuRkJZVzQyYTNKeGNYcGxTMEpOTVRNS0x6ZHZaVVp5Y1RWdFIwbGFibXBEYlhCS1N6VXZNa1UxZDBWd1VGSkVPVXBKWkcxRVkwMVZWekE0TlhONFlqQlVhSE5PV25kbWRrbHhUMDUwWVUwNVl3cFlUazgwVDFFMlkxSnVZbk52WVRjd05HSTBibEZSTUhkUk5sQk9URVpxUWxWblRGbHRNbUZLUjJGSldYWmpZemRXWTI1dGVHRlZUa0pvU0hjNWRYaEdDbHAyVlc1dmVEbFBPVGx1YlVzMmVURlVSVXR4VEdOcVF6UmhaMjB3WkZRclYwSkpZVVZJWlVvMFJUZDBkSFJ0U0ZSdGEyNVhVR05HVm5GdmR6Z3hlVm9LVm1jeFkwcG5VVk4yVlVGaFFrUkhRVEF2YmxWV1EzQkJXVGMzTUdGalQyeEdWM2xsU2k5dVdGRlVjblphWkZGSmRYUmhVSFl5UW5OMk0zZHBWR3BEZGdwSlQyOWllbmhFYVVKalUzcDRlWGhIWlVWUVRsSnliVFl6ZEVKUVNucFZZMEk1TkVkeVZtZG9lV1pIWldwWE5VbE9TRFJ6YmpGUE5Dc3hkMG92Y0VzdkNsVjJZMFZyUXpSakwxcDRSMGhITVVwVVVHNHhURWxZTjA5Mk5ISnNjRFI2SzFrMldFODRWVXROUTJ0MlIyNTBia1pGTlU5S1lXZDJaWHA1VUZvemRUZ0tZbTVSV0VWU1JqSklUbFpPVDBKdWVtMVJOSEJFT0dJNVFsQldiMG94ZHpOVlZsVXdZa2hPVnpBeWQySnJOSEZTWkVoSFNGWlVhakpHWlc1eFpqWlFNZ3BIT1M5dlVtdEVTemQxZUhGSmJuVTRZWFV5UkhNeFdYazJhRkEyU25oNlpUUnpZaXN5VmxabFVrUlNkVE5YWmpBMVlWWmxObGxhWjJWalRsWk5hSE5qQ25jM1ZGWnFiWFEyVlhSQlZHUkJWRTFPU0RkWlZYVk9NVVJLTURaU1YzWklUMFZZVmpkYWNHNUZOR0pMZFVsMVRIaGtlV0pZYlZrMk9IWkdaSEphZUdNS1pFUklZM3BCWW1vekwwczViR2szYkRaeGR6TnFWMHRvVmxKREsxSlVRbXhXTDJ0aWNrUk5UVGhETlVwS1Rtb3lkVWhpUW5KcWJVOVZjRU4zVDNWNFpRcGtiU3RYZEdoU05FWk9ZMVZFZW1sMFNXdGxTVXBqT0VOQmQwVkJRV0ZOTVUxRVRYZEVaMWxFVmxJd1VFRlJTQzlDUVZGRVFXZFhaMDFDVFVkQk1WVmtDa3BSVVUxTlFXOUhRME56UjBGUlZVWkNkMDFEVFVGM1IwRXhWV1JGZDBWQ0wzZFJRMDFCUVhkRVVWbEtTMjlhU1doMlkwNUJVVVZNUWxGQlJHZG5TVUlLUVVsMVNucDVkbW94UmxORlJqaEJRa0Y1VWpOc2JYUk9NMjVpWld3MVJFZGlha0ZITUdWTVZXRlFSVlJOTWxKeEsyNU5ZbFV6WldwTVFVVlRhMGwzTndwcU1ubHRSM1ZNUzJWc1VHbDJVbFZJZDI5aWExZGtiakF4SzNSQmIyeFBSbEZrVkcxVlIwTklOakJTYlhOTlNEUkpWMFpFTldwc05tZHJkVFJsUmxvMkNrTXpRM1JuUWk4eVNVcENTeXRPYURsdWRtVm5WWHBIWlc1eFNqQnlLMU16UzNGNlYzVkJZVE5NTW0xVWRYSTFkMjVJYkRWUFlXdDZTM1pUZFZFemNuRUtiekJzUVVSMFFYaHhZV3RzVFRoalIycERlVEZMYTJNeVp6azJTVTB4TTJSUUwxbzNiME4zWTBWMmMzQk9iSGhvWjNCd2VXOW5hVUY0V1V0SVNHeERiZ3BWWkZKelZFSkdjV0pvVkU0dlpHMDRhalVyZGt0Q1VHTjNja0pCZUhoa1YwbHZOSFUyYlUxRGEwRnhUM1J5YVd0c09WVkdXbUZMZVRGU2JVWnpiV3hWQ25KMlNra3lSbVUyTVV4WGFISjZlVmxKY21neVdFWldTRmRSTW05UlEzbzNOMUpRYjNGV2VIbDJaRkpzZW5GTFlUbEJTRkozY25kMFVVUXhOVEJQYVVzS1JDOWtTVzFCWmt0VVJURmlNMVJsVDFKa01rWnlOeko0YzBGbUsxazVXbGxCYTJ4dE5VOWtZbXRuVVV4YWJITm1ZVTFMYW5veWMyNWtRV3RVWldGR05RcFVhbEJEYTIxVVFWSk5hM1Z4YjNSYVIwVnJZVXB0YWk4clVsRTNOMHB1U0RZelkxTm9VbUp3Y2xsQlRHdDBlR3cwY2xGbUx6QldiM1J2Ym5oUFRYRndDamx2TkVoQkszTkRkMUZ6T0daUlNFcFpWVFZSVlZRck5EZE1NV2xyU0hwWmVqVjRiR1IxV0doMk5IUkVObEp6Y0RCM1ozWkxUbUpuZUZJNVdqWjFaV3dLWm5Oc2JWazBjVXgzVG1ocVJERk9VWGQ0VGxKcVpWY3JabmR6VFVNNVVrUkpTakJOTVZsT2VHOWpZMjlHTkd4S1VIZHlkbUk0TXl0aFRHMVZZamM1UlFvMlZWRjJiamxNUldkUVVHeFVUVWg1YzNjeVYxZExiMWx0TTFkVFIyZHRNelpaT0dsQmMxWmpVR2Q2WlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCTURKVFVuRkJZVzQyYTNKeGNYcGxTMEpOTVRNdk4yOWxSbkp4TlcxSFNWcHVha050Y0VwTE5TOHlSVFYzUlhCUUNsSkVPVXBKWkcxRVkwMVZWekE0TlhONFlqQlVhSE5PV25kbWRrbHhUMDUwWVUwNVkxaE9UelJQVVRaalVtNWljMjloTnpBMFlqUnVVVkV3ZDFFMlVFNEtURVpxUWxWblRGbHRNbUZLUjJGSldYWmpZemRXWTI1dGVHRlZUa0pvU0hjNWRYaEdXblpWYm05NE9VODVPVzV0U3paNU1WUkZTM0ZNWTJwRE5HRm5iUW93WkZRclYwSkpZVVZJWlVvMFJUZDBkSFJ0U0ZSdGEyNVhVR05HVm5GdmR6Z3hlVnBXWnpGalNtZFJVM1pWUVdGQ1JFZEJNQzl1VlZaRGNFRlpOemN3Q21GalQyeEdWM2xsU2k5dVdGRlVjblphWkZGSmRYUmhVSFl5UW5OMk0zZHBWR3BEZGtsUGIySjZlRVJwUW1OVGVuaDVlRWRsUlZCT1VuSnROak4wUWxBS1NucFZZMEk1TkVkeVZtZG9lV1pIWldwWE5VbE9TRFJ6YmpGUE5Dc3hkMG92Y0VzdlZYWmpSV3RETkdNdlduaEhTRWN4U2xSUWJqRk1TVmczVDNZMGNncHNjRFI2SzFrMldFODRWVXROUTJ0MlIyNTBia1pGTlU5S1lXZDJaWHA1VUZvemRUaGlibEZZUlZKR01raE9WazVQUW01NmJWRTBjRVE0WWpsQ1VGWnZDa294ZHpOVlZsVXdZa2hPVnpBeWQySnJOSEZTWkVoSFNGWlVhakpHWlc1eFpqWlFNa2M1TDI5U2EwUkxOM1Y0Y1VsdWRUaGhkVEpFY3pGWmVUWm9VRFlLU25oNlpUUnpZaXN5VmxabFVrUlNkVE5YWmpBMVlWWmxObGxhWjJWalRsWk5hSE5qZHpkVVZtcHRkRFpWZEVGVVpFRlVUVTVJTjFsVmRVNHhSRW93TmdwU1YzWklUMFZZVmpkYWNHNUZOR0pMZFVsMVRIaGtlV0pZYlZrMk9IWkdaSEphZUdOa1JFaGpla0ZpYWpNdlN6bHNhVGRzTm5GM00ycFhTMmhXVWtNckNsSlVRbXhXTDJ0aWNrUk5UVGhETlVwS1Rtb3lkVWhpUW5KcWJVOVZjRU4zVDNWNFpXUnRLMWQwYUZJMFJrNWpWVVI2YVhSSmEyVkpTbU00UTBGM1JVRUtRVkZMUTBGblJVRjRhMHcyWjFaaVRYZGxaRVowVWs4dk9VMVZiMjFOV0dOV2IwVkhaRXMzT1ZNcmNHaFJUbFZGWTFWeGEzVllOVFJZV1M5c1lsVlFkUXBFVTFGelVuSmlRMDloYzJReGVsUTRlQzk2TTNNM05uQTNURlZsT0ZWcU5EZFVjVkYzTVROcGFtSnVhbTV3TWxSbU1sWTFUVTVqSzBwVGRWSkdVRkJ4Q2xvNFYwSk1TRTVzVGxGcVdUQTFjM0pRTkN0UVlWaFJSMUptUWxCSU1FMXhlVGhyWm1KVlNVZHhSWFY0VG1walNVZFRla1EyY0ZOck5VRlJZVVZGZGxvS0sycDJSRXR2WldOV0wxRnZMMUpsVDJWa1oydFFObGxpYUhkUlFVcEVPR1ptSzBGMVIzbFZNWGRXTUZWalRIUk9jM2x3TVdaYVpXODRSa1UwVldGSGRncHhPWEZrVlcxaFQwSlVhMkZtZGtkb2JrZEpOVmhHV2pKaWJFMXRlbGcwUlZkMU5rRnlaSGhSY1V0elZEVk9VR2xuVlZSTmVWSkZhVk0yYkRaQmNqZDNDa1ZGUVhGWlNtRnRiVUZ6YnpKWFRFWlJlVVp2ZVhkalJuTkxaVGx0T0U1UU5VSmpWRk0wZWxkTFUwVjNXVFp6VDFZek5Fb3hjbEpUUmpCb00wZzVXRFFLT1Vob1VqQTJUR2xxTUhKRk1GTjZkRXBRUTFKNlNscHNZMVozUnpOSk1FaEhRVXgxZFZsSFJ6WktZbUZHUkdOdFdHRmlabFJNZEZwb1lVVkJNWEZWTWdweE9VWjFjR3hqZFRWNE9VRlNjMjV0WVRaT05HRk1kWFZ5YmtFNWJWbFdaRmhyWlVZeU0xbzFaWFI0VjNRMlkybHdkWGhMYzFGdFoyOTRPSE5QVFhGWUNtd3JWVWRrV0haWllrWlBlRE14ZUN0TGFqTnBabVJDYzNkUFRVazJkbFJVZGs5aVVYZHdaeXRzT1dSSFZIQndjak5JZURSclptUnpkbkIyYmpkak1Hd0tOREpFZVdKRGIybEVPWGRCYUVVNGEyZE5kM2RsYWtWcmJqSkhaa05xYTJ0emFHZG5TR2htYVU0emJURnJNMjByZWxWQmFFWnBVeXR4TlhoSVZHbElUZ296YUZwTFRUVlhjazFrYjJkblZ5dDFUVFpSUm14cFR6RlhZbGhLYVVKQ1dGcHZWVW93V1RnNVQwOU9kbTF5WWpSUFIwVkRaMmRGUWtGUVdtY3pkWFpwQ21welZtcFJLMlJtVkhWQ1VIZ3pMMnNyZEZsS1lVNHdSSGRvWVRoNlJHUlVNMGxzWmtvM1lUYzBRMFJ6T1Rka1NuYzNUMncxV0dGMk0wVjZjVXBvUm1FS1JteHNaRWhZT0VkMWFqQjFOR0ZLWjJSSlZrWlJjVEpRVlVsSlNtcDJkSEkyYUVJNE9Fb3hVekpRTVhWeVFURlZOVXN6ZFNzeFNXSjJSMFZIWm1zelJBcHllWHAwVlRsU1IyaFRVV2xUVDBKM056WTNabk41ZVZwTFRrOXBWRlpSZVVOWk4wWkhVbEkyZFN0R2FscEZjazVSVlhWbmVqTjBiRTVDVUZveVQwcGhDbkZOWmtNMVdWSjJSa3N6T0RBd1NXTmxaV3B1UVc5NVFrcHJLME5SV0dGRVlXTkVTRXRqU0RnNVUxaDVPR2RpTHpsVlJqUjJjVFEzTjFsdVF6VlZlV0VLTWxKUFZUZFZLMVpRUkU1Qk9YazBZM1ZCTnpBd2NucHNSR2hoV1doU2VFNVRNRXRuVUZGUldGYzFkV1prTjNGTGIydEtUMlZpUlVRNWJYZFNURWhxVHdwNVoza3pSMVpTY2tKNlMzaDFLMnREWjJkRlFrRk9kV3czTkZWbFoydFBWRWhQTkdoWFZrbzVSamQ2T0hZdk5XaHNhak5RUms0MmVYUTJZWE0xSzFKVENpczViVGhCVm0xUVVVazRkbWMyVDI5MGFHMVRjRk5WT0dOTU5XdG1hWEIyT1ZOdWJsWmlOa1ZHTDBvck1rWnBORmN2Y2taeFMyUlZia0o2UWtaeGIxY0tPRlV3Wm1nd0szZHdaamxMVG1sNGNXOUxMM1ZCWlU4MlRFbzJhbU5uY2tGamNrOHZjblExY201SU5VUnRaRFJ1VTFSak9HMTJiMlJwWTJOdVpVaDVRZ3BvYkRWVloyY3dObVpoUTJNd00zUkZaR1ZKWm1kcU5YZFVOV1paUWpoR1lsQnNSelZtUm1ObWNVWm9VV0pNYUhsRWJUZDBXbTkzUkhsYVJHZHRabmd6Q2tKSGRYUTJkVVE0YTJ0RVNuVndNek5GY3pRdlVUTTBaR1ZFYVZWMVFXNVZlR1JtT1VveFRDdHhOM1ppTDJWeGNrWldlVk16VFZOa01qaGtSakJDTmxZS2QyVkpPV2xJVVZWTFl6aFdZMFpuZVZSWFUwOVVLMU5oYUcxd05EZFZTazVCUVZOWWNsZEpLMGRRWTBOblowVkNRVTVzWnpaUE5sbHhlakIxT0habFR3cFhUWEZEZFZaT00xWllWa3BSYUU1WGQwbFdUazlMVmsxUldsZFhkR3BTT1VkVFoxUjZRa0ZWWW1remQwaHJRVlZ6TjNaT1JEVTVXbkU0VWxjMmNrcHlDak5wUVdwWlFVeHFUbGwwYzJFMFRUQnZiVlJLVTBSVkszQnVjVGR6V2xGMFVqZFNOMVpEVWtSR1lYbzRORkpOTVRBMFUweDBValp3YlRoS05EbDJRMmNLT0RsSVNYbHBTREJ2ZUZSWk0wZzFjRGtyUzJGSVlqUXJhemMwTmpKdlJDdE9VWGxOY0VNeE0xbGlaak5tTTJsM09YcDZXV2haY0ZwVlVHUklWbnBtT0FwNFprMXZNR05DVUROaFVVaFNia1oyWkdKNlRFRlVWWFZvZWpCSGRrTnZha3BMZWtJMlNtTlRaVWhMTW5SUk5raFpNMHRpTW1KSk5FbFlWWE5tYVVWekNsYzNkMmhCY2xoV2MzWlFTRkZNVWxoTFNrZzFTMlZEY0hSa1FtOUVjekozVTJsNFNtazVjWHBtUzNkcFJIazJSMlkwU1dwMVQyZDVSVFJWWVdVMlprY0tPSE5tWjJ4NGEwTm5aMFZCVXpBdldFVTFZa1phV0ZGbmRrVnRNQzlqUzJ0cVFXeENjak5CTkdWd1RIaG1abHBpV1VGMmVrdDFaVVpOVkM4d1YyOW1lUXAzSzFkMmVHdE1TSGhZWW5od2VGaFdUbTlNZDJVME5rNTVhMDV0Y3k4NVNUQnlNMHBaYjI4NFFqTXdWV1ZsVGxvM09GbEtRbTFNT1dNNGN6SnpkekZJQ25KWlVEbHNWR04xVWpSU1pFa3pPRzVaTTBZMVdHUlNhM1k1YzJWck1tSnJZbkZ4ZUV4SGJtVkJaRWRIT1daSFFURXdaR2xYV2xwNmQzYzFTVEZWTlZRS01uVnNTek5tTkRSVFZVMTVabXRSTWtaclRtUlVWMEZEZFhwVVZsQkhOQzlaTmtOWU1YQndUVGx3TTNoNGJIQmhSalZJWWxkeFVsbFpTemwxVmtwNGJBcGlWVGs1TjBWSVYwMWtLMmhRWWtoUVJXUTVNRkoyUzNOeU5GVXJiMWxrZFhwUFppdGFVMDF4U0U5aVExTmhkM2wxYkROdGIxVlpTMEkwS3k5d1RWWjRDa2hIT0cxaFUyTXJVVUprU0hJMFQwbFRVMDlVWm0xTk1tVldlV3RrTkZsQ1QzZExRMEZSUVdFMFpWTm9MMVkzWTI1SmNFTkhZMnhEU2s1Qk1tbHhhSE1LTUhCeU5UZDFaM1pqT0N0SFRFNTZXUzlrT1daVVZrdFdjak5GZDFSclpIbGhkMmxUTnpaeWRHSm9ja1V2ZDBod1dXZFVjR0UyZGpkNVRsQmlLMnhJYXdwd1V6WkJkVFpUVjFCcmJFSmtiaTkyZUROc01sYzNjM05GWlRaM0swdHpjVTV0UkdjelJXeFNiMGRoSzFBeGFtNVhkR1ZWZFRkT01uaFlUbFJ3YVhwRENtcHBaWEF2Vm1kVlNXSmhZek41TTNWaE5FeEJVRWgwYmtwWFRUSTFhMGsyZWxNeVZGZEZhRW94VmxaV1FqVkNiamN2VkZOTWNrRkJhVUUzUkhSWlVrd0tWV2gyYUhkS05XVkJlakJJU21wTFZUZHpPSHBvTXpKNWN6aERWRXRJVUM5YVJESm5iRXRvTnk4eVIwRm1NREEwYjNkeGIzQXhSVzlTZFd0MWVIQTNVZ3BMV1hsV2VXVkJjWEpyZDAxbGFXOWhiVzgzTWtONWRrODJZVmt2TDJkS1kyUnpSRlZJZFVWTVZuWm9TVmhFZEhFeVkwMU1TbEkyUTJST1dVNEtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogSFZqS0YySmpzY25qeU5pZDAzZFFHeDNYZXF3bTgwVkhncDZ2bmhic3ZDd0sxSlVXZTVNbEZmM2xLdjhNTkt5SFRIOThXV01aRE4xRFplck4yTjJmb1U1dWFxaG1yZG40SXVMTmRQRGZJRDlCSkppQ2VtMGRvZ2pQQXl5aTRFMzcK\"\n  }\n }"
+      "x-ms-request-id" : "f9fa06b6-92db-4d3e-a947-9cac193cd1ae",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterUser\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSU204NVJXMUtlRWx1YUVOQ1QxQXlkRzloZUdGSFZFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5WRlV6VFdwQ1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTlJHTjVUVVp2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSUkNsZDNkeXRJZVZGWVNVdFhSeXRuTjFWa05GUjNaRFpJYjB4c1NITlFTSGw1TTA5RE5tUkhjRzlhYkVSQ1MyMHpiemRWY3pWMlV5dHVRMEpMV1VnNE1EUUtlbEJQYWxkT2RraExVVWR5ZVRsd1pFcE9hVXhJY1ZGbWMwRkxZMjlRZUhsRlFqZDFka0pyTm00MmFreHBVakJYVldOV1NrOHlhVXBCTVVseVNqSTFiUXB0VUdWeWF6SllRMDFLVDBGWlQwTjBhM0ZLVkZsNFVFMXJLMVYzVkd0V1lrRm9WbUkwWWtKYWNtOURjMUJ6YVVSb09VdEJiV05EV0U1M1dYbHFZVWQxQ2xCSmFTdEVTMnBYU1RkdWJIcFZSWGxSVVVod2JrVk5UaTk1Vm5ab1QySlpiazk2WkZwNU5VbHdUSHB2VEhRdlJpOXViR3QzUmtkWlpubHNVVGQ0WlVVS2JEbDFZMUk1Y0RWNk9HUlRiRTlFUkZOc1kyTXdjWEJtVEZoV2JYcFpWbEpIYTNZeFMyeEdXalJxSzNSYVpGUlBSVklyTVN0aWNFTnlORUY0TlRGTFdRb3ZSbk5vVVVoUVEzTkpTVWMwUTNaTGQySlRZM1oyYjBSWk1rcEtSM1pVTWpOUU1Hd3hhblZHZFdsMGFpdEhSVkJXVVhONVNFZEZZMlZ4U2pNMkwxVnpDbFIyUXpkR1UybHVkbEZtTjI4NGMzYzRjMkpsT1dSblVsSkxPRFpCU0dkeFoyUnJNVEEyVkdKbVFWbzBkRnB5WVVOU1drOHlOWEpRU2pZd2FYZEhXVTRLYmtGM1dIQTFlakkxZVdOQk5FOUdXRk41WmxSbGJFbElha2xZYTNwQlZIWklNMWRaVFhnNVp6QnhVMVEyWmpsa09UbFdSRUptYVRJMllsWm1kemR6UkFwRFpuazVZakp0UjNkM2FrTnNRMVZsZEhwWmFtdHVNV05EWVZRd05URXpSMU5NVEV0WGRrRjFObVV2UTBaM2NEaDBRWG8yZUVwUmVVSm9TbVJxWlU5UkNrcHJiMlEyWjBoblpqZFhkakF5VTJGaVVFRkpWV2RyTWxWYU5rRmtORGt2YkZGbWFVUm1aMnhuVlVGMVVETXZhVmx6UzNkaFMxaHVkVU5NWWpSTlVGUUtkazVUYlZWWlJYZFlaemx2Y2twV1NqTXpNR05SVjNGRFFWRnNVbTUzTTBvd09WTkphWEJaV21oUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRkJhR0ZGQ2xsTFdua3hWVk0zTTNvcmNVWnFjbW92WlZSa1YzQm9SV1p1WVhsRVVIUkhUbnBtYkRsa1MwOU5SRXd6VlVkdWNFeEhNRTkwVXpOdFVXZHJZbmR3Y2lzS1dEWlpZbkZIWkZaSk5UTXpkVkZrTTJWV1NqSlRiVzFtUW5WeFNVOTBLMUpQTmpsUmJsbEJiMVIwUmt4eGNEVkRPVVpaU0Zvd2FHTndSamhvWWpCUWFncE1Sa0Z4ZG0xelozZ3JSRzk2WVhaME9UbDFkRVJVVEZwdlpIcEpWRVV3WVdSbUwwWkthSFkwZDFoT01sQTBRelpZWVZWQlFVbG9SblF4WTNGSE9UbEtDakZDTTNsVVNXVTVlVEJwUldaeU5XVXpTRFI1U2xOdWRVdzFMMVI0T0hOQ1QyNXZhMlJzZHprMlRtTmthWEJ5V2xSTmNrZFZhREZ5YUhKcmRsSllSMWNLVWpWaloxbGFWbXRoVm5WUFkxUmlWWGRPTkdvNVQyeFlMM2xTVms1eFIyWkxTREppUlhsNmRHdGFibEZCVjJkT2RrMVNkR3R6YW1odmRtWjZUSFV2YVFwMFZFNDFhakJhZEV0S2RYSTVlRVJ2U1RCMGJXMTBjM0kwTTJFelkyTnBLMnA0ZUVkMmJHTlVOVkp6VlUwNVdYQnRiMUJZYTJkM00xZEVWMUpSU3poV0NtdFJlbTlWYVdobFNXTnZlbmxpWVdwMFJXMTZZVVJxVVhkTlpXczVTa2t4YlhCWFUxRkpiSEF2TkRWMmQyZG9aR2MxY21jMk5tdDRSRlo1UTJaMlN5c0tOR3RoWjBJME9VTlpVbFZuWW1acWIxWmFjak5sUVV0bVlVbE1lVWxyUjIxMWMzbG9ZMGh3TUZGMFRUVlpSSEZhWWsxbk9XUmhOMHB3VFdjd04xSnZkQXBuWkM5NGVVSTNWV2QzUTAwMldteG1ZV1JuYzJrNWNtOVRTamhNU0hweFJVWnZVbEpFZEZSWVRuTmxNbHBtVlhNMVJtWTVla0p1Y0RCUGRqZFROV3M0Q205dVJHaEJWV2RIWjBaVlVpOVZUbGRYVmtnMlkycEZjbHBvVVRoMlIwZFhORzR6VGtsVU9VMTNXRkpqVURKNk1TdE9UbWczT1hsc2JFdElWM0ZYYm1vS1dGTm1TakpUTVRCV01qTmhXRGhDYnpGVVZXeEVXbnBNUjFCMlZGaFFRV3hEYTFNM1psUnZQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vbXAxZG5zOTQ1MTFkLTNkMjJhZTQ2LmhjcC5jZW50cmFsdXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczY2ODQzMjgyZTIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczY2ODQzMjgyZTIKICAgIHVzZXI6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzQ5OTcxX2FrczY2ODQzMjgyZTIKICBuYW1lOiBha3M2Njg0MzI4MmUyCmN1cnJlbnQtY29udGV4dDogYWtzNjY4NDMyODJlMgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJVc2VyX2phdmFhY3NyZzQ5OTcxX2FrczY2ODQzMjgyZTIKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJSMk5oUlhveFVYUkNSMWgwYkc1bWVFUnpiMlE0YWtGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNVRVUkJlazFxV1hkTlZGVXpUV3BDWVVaM01IbE5ha0Y2VFdwWmQwMXFRVE5OYWtKaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJsTm05UE4xVjZOa2RCUms5S1JGVjVVMGR6UTBzS1ZtSm1kVGhzZFdOS05IWXpla1JOWmpVMGRYUjBTbWQzT0RCalpYaDZLMk41UWpWNEx6Sm5NRE4yVUZOU05rdFlWVmtyWjBzd2JtMWhWbUZUYWxOT1NncHhTU3N6ZEd4UmFDOVVWV05OU1VsMFlWQk1Wa3cyUm5Od1NDdDJMemxoV1Zoa04wNVZPRmRCUW1sWVQzTlBhME5NUjBOc2VYQlhkVVZHY1hsb09VcEhDams0Tm10Q1VIRndhVXBvVjJaTVRsbHlVVk0xUzAxMlQxWk5aek0wVHpOeVdsRXZja2RCYlZjMlRGTTRUbkYwY0VoRlRVbE1TV2t6YVZCM01VTndhVWtLWkhrd1kybGxNWEF4SzAxcGFtcHNhazFuV2tveVUyOTBNM1E1TVRsWWNHbEhialIyUjI1NFVEZFJVVk12UzNkSFEwOWlNR2RrUmxCeE5ubGhSVmxHVmdwM1N6ZE9ja0pvYjNkc1ZVaFVlV3hIVjJwU2RtNTZValZJYnpSVWIxSTNVek5sT0VZM1MzWjNVemROT1RRNVYyRk1jREZRTW5abU5HbEZheTlCT1RKc0NrMVNLMEUwVkhKemJsaEZVemhPUlVrdmRqSk5ORXBxVkVsYU9IWmFSbVpSTDBOeFEwY3diVVpxVFhaUVRFMUZTbEEwWTFNMU5GVTBaRmhsVUZScmFIQUtjSHBOWnpGQ0syWXdUMjlFVDFocldFWkNjMWRQSzJ3MFJISTROQ3RMUzFkbGFXMUhNRXRQZVZsTk1pOVhTbkppV2xndmJsVlliWEExVW5SVVNWQk5ad295T1V0YVpIVnNZbmxsUjBoUFQwZGlSemhtV1daRVdHSklOekpOTWpCblYzaHZZWEZDWXlzMWQySnpVRXN5TUZacE5HVXJhV0l5Y25KeVNEaFZTM1JhQ21sNVZHUnJOa2wyU0RSNlRYWndkSEJKVW1oM1J6azRNbGhLUVVGRmFsUnpielZqYWtFNU1sWkRUVXA0VEdaMlFYWkhheTg1ZG13d01FVjVNVFZUVkhJS05YUnhZVzFoV2tWTWRVeHlURlpEV0ZGV2FrZGxjRUpuY1cxb0syOXRVa0pTUkc0NWRsWnRhRVZ3VDJ4U04xcGxTMGhLVWpGcGFsVnFSbUl6YW1wSlNRcHBielphY0hoTGJXbDRRbXMyTTJGSFFXUjRXV1YzU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLZUhGM05YRkNSRlZCVG1aamFUbDJWbE5pVWl0dVVUVndOMEZuWm14NlZEUm5lRVZtTUdOVVQwUmFabEpSSzJ3eVJrb3pUa1kxYWpaWWMzaFJTSEZGUWdwRFptd3pXRlZoY0hFelMwdHVNbEZPUjJGVVlsVkRSSGxGVUZCeU1VeG5iM1YzZVd0alNtdFRSbVJOUVVOaFJsaGFhelk1YUd0dlptVklhMFpuVkVNeENqZFNOWEo1YkhacWVFTklXRkI2VFZVMEszZHNRa05zWkUxcmMxQnlLM2haU0RWUmJGTkdTRlpKZFRrMVREWnVOMnhPT1dsSkwwNXpjVTlUYTA1clZrTUthbmRsT0ZOcVJuWlhhbWhFT1hJdlFrVkJaVTFET0dOWFNtcG5iVlZNWWtGc09YcGhlblF4VURGSVNISklXbGRUVDJ3M04ycDRURGxyTjBjelFtMXRZd3BuSzFWWldHaHZhM2h1Y1haQ01sVnhXbmxxV2xseWQxVnFRbGRqYWtwSmJrRkxNSGsyVUhORVRteGhhSE4xZGtZcmFEbHBXVUZVT1ZVNFltWjVjWFZtQ25sSlNFUlpSVmgxU2tneWVsRkJlRXB5ZVZsT2JXbGhObGxqU1V3eU9IWlVXV2xGVlZCMWR5OXJRMFpTT1VWNVFXOXNlRkpKUzNaR2JtVktaVnBEVG5NS1RYTk1Za29yVkRWM05HTXlWa3gyVERKWVMxVnpZMkppZW1VMk1VSlBSakpFU25CWVNHbEZRM1ZEVVRsTlIxbzFaMjFvUm10U2JtMVFWa3Q1VnpWNFZ3cE9kMmQ2Y2tsUlpqRjJlbkJyWms5U1psTm1URWN3VDJ3NWVIUXZTWGhrZWxWMVEwOXBjems1Y1U1aWJrSldjbk41U0VKTFlVRmhaazlyZUhCbWJHNTVDamhaYWtkWGQxSXJiM3BKTlZGcWJIQXdjVkptUkRobVdrVjZabVJaYTJGb1Z6STJWRXhWTTB4YVdrOUZkWEJIZGtWeFpHNWlTMnhzT1RZemMxZDFUSGdLWWxwaWIyUnVMMnhxVERNNFlrdHFSMk16VlhKMFFuUTNiakJ1YUcxNEswRnhabUZuU0dSRVpYSjROVGRPWWpSNmF6TkpUMG95YjJ3dk5XUmlkM0UyY3dwblozVkliSGRGVldZeVdtRlBRME5EVlhZeFUzTkpSekZtVkdVeE1teEVkVVY1VFdGVVJFTjNVM1JaUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCTTNWeFJIVXhUU3RvWjBKVWFWRXhUV3RvY2tGcGJGY3pOM1pLWW01RFpVdzVPSGQ2U0N0bFRISmlVMWxOVUU1SUNraHpZeTl1VFdkbFkyWTViMDVPTjNvd2EyVnBiREZIVUc5RGRFbzFiV3hYYTI4d2FsTmhhVkIwTjFwVlNXWXdNVWhFUTBOTVYycDVNVk1yYUdKTFVpOEtjaTh2VjIxR00yVjZWbEJHWjBGWmJIcHlSSEJCYVhobmNHTnhWbkpvUW1GemIyWlRVblptVDNCQlZEWnhXV2xaVm01NWVsZExNRVYxVTJwTWVteFVTUXBPSzBSME5qSlZVRFo0WjBwc2RXa3dka1JoY21GU2VFUkRRM2xKZERScU9FNVJjVmxwU0dOMFNFbHVkR0ZrWm1wSmJ6UTFXWHBKUjFOa2EzRk1aRGRtQ21SbVZqWlphSEFyVEhod09GUXJNRVZGZG5selFtZHFiVGxKU0ZKVU5uVnpiV2hIUWxaalEzVjZZWGRaWVUxS1ZrSXdPSEJTYkc4d1lqVTRNR1ZTTms4S1JUWkZaVEIwTTNaQ1pYbHlPRVYxZWxCbFVGWnRhVFprVkRseU15dEphRXBRZDFCa2NGUkZabWRQUlRZM1NqRjRSWFpFVWtOUU56bHFUME5aTUhsSFpncE1NbEpZTUZCM2NXZG9kRXBvV1hwTWVubDZRa05VSzBoRmRXVkdUMGhXTTJvd05VbGhZV042U1U1UlptNDVSSEZCZW13MVJuaFJZa1pxZG5CbFFUWXZDazlRYVdsc2JtOXdhSFJEYW5OdFJFNTJNV2xoTWpKV0x6VXhSalZ4WlZWaVZYbEVla2xPZGxOdFdHSndWemh1YUdoNmFtaHRlSFpJTWtoM01USjRLemtLYWs1MFNVWnpZVWR4WjFoUWRXTkhOMFI1ZEhSR1dYVklkbTl0T1hFMk5uZ3ZSa055VjFsemF6TmFUMmxNZUN0TmVrdzJZbUZUUlZsalFuWm1UbXg1VVFwQlFra3dOMHRQV0VsM1VHUnNVV3BEWTFNek4zZE1lSEJRTDJJMVpFNUNUWFJsVldzMksySmhiWEJ0YlZKRE4yazJlVEZSYkRCR1dYaHVjVkZaUzNCdkNtWnhTbXRSVlZFMUwySXhXbTlTUzFSd1ZXVXlXR2xvZVZWa1dXOHhTWGhYT1RRMGVVTkpjVTl0WVdOVGNHOXpVVnBQZERKb1owaGpWMGh6UTBGM1JVRUtRVkZMUTBGblFtMTVLMHN2Y1dReU1WVmpWWG9yUjNkT1NFVlZZVUptYkhsUFZsWkNjRFJOUjFoTFdtVXlhRzk0Ylc5NGMxWnRUeTl5T0dGSUswVnJRZ28zVUZGVVNGcFdNbkpSTkhac1lUaFVMelpLZFc1TWEwNXJRVkp5TTFVeVdsQklNa1I0ZHpaTk1URnVVWE4zY2pSblMxTkRVVEJIVnpKbVdVOUJXWFpVQ2xOQlVsWjVNeTh6TVhWRk9ETldXV05ZYkZjd1JsWnhaRFZqUWpCa1lWcFlVVTk1VHpkaGVrTm9XRXd6VHpaS2JpdEpXWHAxYVd0NWFUUnNjaXRuYW1vS1RYZDVTa05RY2k5eFNEVllWa2M0WXk4NWVEQk9jbTFJYUVWR1pTOVJXbE50VGtKbk9VOTFUR0psWWswNVlUWnpjek5oWkM5S09Ib3JSMWhrWnpkWldRbzFjUzlaT0RoWWFrMDFNMjlyYjFwbGVuUmlSbFpNWldSMlQwUldkVXQwYW5OVE56UmpSbFpvY2pSSGNreGpTSE5xTlVKV1NXMUJSMk5XUTFSclZVTXJDbXBMZFd4bWJVNUVPRk5NTlc1UVJubGtPVzVQVWtweWVXTnJablJJZUhwclNtdGFVMVp3TUV4WWIyeFZhRkJoT1ZBMmRpdHZLMmd4VjJ3NE9XVTNjVVlLV21vMk0zRjBkblp0UVdoM00zZHpVR1p3U1ZZM1UyMVBOMVkzUjA1bU4yZEhMMFJOV1RnelFWQmlRM2Q2VWtaVFZqWkpjMk5EVFdSQk9WVndXVTFPVGdwNU0yODBNbGsyU0hSeGJtWnphRkZvWjJsM2RrRlpUazVRVldGaE9WRk9PREJPTDI5b2RrZFlSSEp5S3pSUlNteFdSMjFpZW1GRFdXUTBjRkV6Y0RkSENsbENVRE5HTVVsUE1WVTFSbGcwTVdsQ09IVkpVVWxLVkZocVRrVlVSalZKZEROUk1FbDZRMDVzUTFJclp6UXZSaTl1U2t4NmNsUnRZeTl2WlZwQmJWVUtkaXQxWmpreVUxRlhla2hhWVRkd2NHODBZMkY0TDFFeVZ6RlZhREZVZUVzMVNUaE9VV2xVY2poM0wwSlljM04xTnpJcmFHcHpTelIyVHpVdk5WWkZVQXB1VDB0WlZ5dExhMDlJWjJvMGVYQjRSMnQ1YkZKcU5WRnRlazVsTDBoWFZXdHNTRTkwWlhZNVltb3haMkZIYlZKM1VVdERRVkZGUVRSdUt5czRRWFF5Q21GYWVFdGlTbFkxU1VJdlNubEhOaTlKWjNZeVVrSkdNbXR1VWpObmQzTk9jMEUwTmsxSGJGRnZkR1p5UjNocFZGVk5NRFV4VjFwbVIxSkNOamRHVTNJS2QxWlJSbWhLWkZWb1p6azVLMXBOVFU5dk4zaFNla3AxVTBWaWEyRjFUekpPWWtSV1RHOUxhMFZKTTNGb09HTkNPRE5hWjJjM2RWWTJTekJNVkdwdmNncFRZa2hDVUhWak1sbFJWMmhTWmpsaWVHMUtVVTlLVTJac09WbEhRbkZLY1c5d1ZHd3hSa280WnpZdlVGSTRUR1JKV2twbk9WSlBhbTFqY1ZBeGQzRk1DbXBtVERoTVNrSmxaMDVNZFhSaFJrRmxRbk5ZVG0xQ1VYcHBkMWN2YXpaNUsxTndObXB0TURodVYydDFibXBrVjBKdVYwUkdja2wxWmtoTVFUWTRVbWtLTldOM2RrTXJPWE5tUkdWYVdETlVhamgzTTNCWldYaEtXSFpaZFV0RmJqWjFjbmhyWWtwNU9VMUNVRTV4WTNJeFRrODJheXN4YXpWVmFYRnFhblZCTUFwVFRVTklMMUpwVmtaYVJrMHdVVXREUVZGRlFTc3ZUazVLSzJKak9GbDFUREJqVW1VclltdzBNV3hJYm1rMVIxZERjMVo1YzNSU2IxWXlVa2xNVWxKbENsVlFLMEZEUmtGWU5FaG5lRFJaWjBjMlJrNU5TVTlPT1dOV1ZHVndSbWxzWW1sRFMxUTVSMmRoY1M4ME5tUlBVbEo2UzJSeWRsVklTa0ZxVldOWFVVY0tRbVJQYlRCeGMwdGpTMUJpVG1aMWFGSnBaM042TW01eFRuZExlWFpRZW5GWldFRnpUbkJ6VUhVeFFWQllOVGhPVmxwUVpERnlaVU53YVc5a1VFVXZkZ29yTXpSM2JqTlpNRXRxZEZKd1NXZE9SVVJqYTBoWWNtSkRPWEJZU0dsbmRUQXpVSFoyVmk5T1YwZHdZMnBHWWtoT1RFMW9URmRWUTFkcWNFUkpSRFJQQ2pKbVQyUXhNMFZPTDJseE1teDVhMjloU1dsbFVXVnZNbUZMUWpCVGNqbGxTMFJ1ZUhaaVFVeFpla0ZWVldoUFRtRmFUekJpT1ZsMFFUVlhZMkpoZEhnS1RuSXZaVFprYTBWUWEyRmFVVGhLVkVWaGRIZGFjbWhoY1VzcmNUZG9USEExTHpFNVNWbHZlbWwzUzBOQlVVSlRhVzVGTDNONk1uTXdVWE5EVGxKeFZ3cEVWaXRSYW0xT1V5dG1OemswVlhSUWNHVm1hblJ2VWk5amVpOWlXWEJZUkUxdFNqUldiVlpvU0dSclJXNXlSSEpTYldzeFpFMXRLM2N5Y21KWVptRnpDbWRFY2s1V04zZDFTSFZrYjNCalZYZDVOM293UVhoWWEzcFNUbnBTY1V0YVkyTTFWazl5TTBsU2IzZ3piRlZZVmt4RVMyaHBSM000UTA4MEsybFRNekFLTHpSTk9VdG5hamcyT1d0SFRsbDBVRmgxZVVaUlJ6QlNORXRqT0hvck5sZFpkSGh5TnpKU09HeHZZVVUyVjNCSFdXdzBNalZLTTJzeFptSXlSMjl4UmdvNFpHbFRSV3BwV0ZSSVFWTklaR3d3ZFZCaFRVdEpkbkZhTkU5UlNXUnFhMGRISzI1emMzcEVkamxHVFRGU1VrSjJLMUF3VWpOWmRTOXNSSEY2V1RkQkNsZGtZVzU0WTFwSlZHWnhUakZRZW5OQlZsUnBNRGh5ZFdkRVkzTnhXbGc0Vkd0ek1YQkZVR3g2VlRSTlZuZERabTh2UWtVMFoyNU1kRmhaV2xWMmMwb0thVUpFZUVGdlNVSkJVVVJaYzBsa2FWVjNZMmhaTUVKTmJVWlRTeXRNTlRWeVdsY3dSSFpHTlhOQ2JWZDJiVXBFUkRCbFdVcGtWamhYYkV0WFZUZFNSZ3BhV0hGYVIzWkhPVGRMTkdvNWVWQlVWR2RtZVZaNE9XOXRUMjQzTDJwSE1uTkZVVzVpYzA5aE9WZG9lWEZsUTB4WFIwUkhZVkl4V1RnMVEyUjZWMk00Q2s4eVJEQnBPR1JJTTBwUE1XazRWbHB5UzA1dVRWTnhkbmhPWW5neUsycHhNRGc1TVVWUmJGb3lZMUJKZDB0dVNVZGFOWFJYWkRkMlkweGxSek5vVnprS1dVdHJNa1poUlU5dGFUUm5aMHRLVjBSdFNYY3lTMUl4Vkd4bldtbHZWRVZxZVRKeWMxcE1RWFV6VGtWYVNWSnBZalIwT1RsdlJ6RmFMMWxRTjJaaU13bzJNbkZCYkZoQ1oyWXlaVVpFTVdabFNXMXZRMUUxV2t0cFNrNXNOMnAyVGtGbVVHOUtNVXhRVVRZM1JFcFFVWGREWjA5M2RYVjFla0k1UWtSV1ZtUXhDamREWjNwQk4xZEpSU3RsYmtsT1ZYZEZWekl3VG0xWlowWllPRU5WY1dSRVFXOUpRa0ZSUkZnNVFubEpLM0ZyV1d0alRYcEdLekkzYUdwamVXTTJPV01LYzNWRlpISk1UMFJuVlc5S1NHaGFUeXRGY0VOeGVVaGlURGRvZFdocU9XaGlhamxOVUZOTFdETm1VbkJuVW1Rck9IcG1aa1UxVkVOeFF6VjFTeTlSWmdwMmRXcFBaemRYUkRsMVVHazRkRE0wTTIxM1EyVlRibGRYUzBweVpuZ3pUbkpLVmtvdlN6Tk1RVFpwVERSd05HNXlja1pHVmprNU1uZHZOMHBYVUZwdENuVnpVV3RHY0c1VE9ESTRjVVV5WTNkeVlUTm1UR1J6VkdWd2IwNDNaSEowV0V0NFFrNHphbWxyZGpCamJFaGxlSE5OZDB4U1ZXeHlUSEpNUlUxc1VUQUtOelZSWXpsRU1GZHNTMWhzZEhOSlpEVTBaa2xtZWpSWlJVTnpWMVJRYjBWWE5YSTBkM1JPTWxGV2JWSktOVFF5WTFSQ2EyMXRVM1I0Vm01TVpsUnpNd28zVGtsbWJVbEVkMlE1Vm5BME9YWTNhRGxOUmxBM2FIUnNVbXB1V1ZodWREWmFVVTltVjAxUmMzcG9RekpwSzJOMmJGTlhaalZWUlhoeGRXVUtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogNjY0N2Y2ZTE5OTI2Nzk0Nzc4ZmRmNDE0NDcwODgxYjg0MDMyM2Q4NGMxNWQ4ZWM4YmJmMzhlNjA3NmJkYjQ0Y2QzOGMwZjQ1NGZlODdkNTI2OTM0YjU0NjQ0ZTBhNTE0MmVhNzc4YmEyODRlNTllZDgzZjBiNjQyMDI5Yjg3MjEK\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "DELETE",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg20376?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:f82fa839f6b46fd84edc56e01cf7c8c6d4faaa2190534aff5c1d17095f0a3c13 Java:1.8.0_221 (ResourceManagementClient, 2019-08-01)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Fri, 18 Oct 2019 02:52:05 GMT",
+      "date" : "Thu, 26 Mar 2020 02:17:46 GMT",
       "content-length" : "0",
       "expires" : "-1",
       "x-ms-ratelimit-remaining-subscription-deletes" : "14999",
@@ -851,14 +856,15 @@
       "StatusCode" : "202",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d04abec3-93ad-4b42-8def-9ed58992d57c",
+      "x-ms-correlation-request-id" : "5c208f79-9390-41a2-a883-cf8e7d5a7b84",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191018T025206Z:d04abec3-93ad-4b42-8def-9ed58992d57c",
-      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1KQVZBQUNTUkcyMDM3Ni1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2019-08-01",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T021746Z:5c208f79-9390-41a2-a883-cf8e7d5a7b84",
+      "connection" : "keep-alive",
+      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1KQVZBQUNTUkc0OTk3MS1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2019-08-01",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "d04abec3-93ad-4b42-8def-9ed58992d57c",
+      "x-ms-request-id" : "5c208f79-9390-41a2-a883-cf8e7d5a7b84",
       "Body" : ""
     }
   } ],
-  "variables" : [ "javaacsrg20376", "784d0a5a-32e6-47ed-a6ed-87f1eeab522b", "aks42786938f4", "dns89446c", "ap014819f", "839ebe14-cac7-4be7-99b6-f81d39606634" ]
+  "variables" : [ "javaacsrg49971", "9108f0c7-2484-413c-b91d-699c6edc9bef", "aks66843282e2", "dns94511d", "ap0470064", "2e09186b-3cc1-48be-8c82-67f4d1728a9d" ]
 }

--- a/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
+++ b/azure/src/test/java/com/microsoft/azure/management/AzureTests.java
@@ -1117,10 +1117,8 @@ public class AzureTests extends TestBase {
 
     @Test
     public void testKubernetesCluster() throws Exception {
-        if (isPlaybackMode()) {
-            new TestKubernetesCluster()
-                .runTest(azure.kubernetesClusters(), azure.resourceGroups());
-        }
+        new TestKubernetesCluster()
+            .runTest(azure.kubernetesClusters(), azure.resourceGroups());
     }
 
     @Test

--- a/azure/src/test/resources/session-records/testKubernetesCluster.json
+++ b/azure/src/test/resources/session-records/testKubernetesCluster.json
@@ -3,12 +3,12 @@
     "Method" : "GET",
     "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ResourceManagementClient, 2019-08-01)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:05 GMT",
-      "content-length" : "9542",
+      "date" : "Thu, 26 Mar 2020 02:23:03 GMT",
+      "content-length" : "28180",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
@@ -16,23 +16,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c28fa0b9-5b61-4144-8c37-cf6e10897b53",
+      "x-ms-correlation-request-id" : "51242db1-d071-4ea4-b239-d42aa16bdbc5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044706Z:c28fa0b9-5b61-4144-8c37-cf6e10897b53",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:51242db1-d071-4ea4-b239-d42aa16bdbc5",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c28fa0b9-5b61-4144-8c37-cf6e10897b53",
-      "Body" : "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/a1-test-sql\",\"name\":\"a1-test-sql\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice\",\"name\":\"cleanupservice\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"What Is Cleanup Service\":\"https://aka.ms/WhatIsCleanupService\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS\",\"name\":\"Default-Storage-EastUS\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/flksjerlk\",\"name\":\"flksjerlk\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg00a720985\",\"name\":\"javacsmrg00a720985\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-14T04:00:10.646Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg236403\",\"name\":\"javacsmrg236403\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2019-10-14T11:02:54.588Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javanwmrg99069\",\"name\":\"javanwmrg99069\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-22T13:58:07.238Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jmonitor_4c473300\",\"name\":\"jmonitor_4c473300\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG\",\"name\":\"NetworkWatcherRG\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_71a38597006e\",\"name\":\"rg1nemv_71a38597006e\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Deleting\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_8fd8947481be\",\"name\":\"rg1nemv_8fd8947481be\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-20T09:05:08.132Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_c7b25576b432\",\"name\":\"rg1nemv_c7b25576b432\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_d1f10904c5be\",\"name\":\"rg1nemv_d1f10904c5be\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-15T01:16:28.865Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg234085226f\",\"name\":\"rg234085226f\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg46678\",\"name\":\"rg46678\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"northcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg760944107c\",\"name\":\"rg760944107c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-18T15:39:39.272Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu\",\"name\":\"rg-weidxu\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr268020\",\"name\":\"rgacr268020\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-20T00:35:46.559Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr742334\",\"name\":\"rgacr742334\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-20T07:24:04.907Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3e83753426e8ff29\",\"name\":\"rgcomv3e83753426e8ff29\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv68a360842c14044e\",\"name\":\"rgcomv68a360842c14044e\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv92407708\",\"name\":\"rgcomv92407708\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvd73932032d4ac980\",\"name\":\"rgcomvd73932032d4ac980\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcosmosdb13d02156d\",\"name\":\"rgcosmosdb13d02156d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-18T03:03:09.151Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7ac76366e9bd0\",\"name\":\"rgnemv7ac76366e9bd0\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_58319828ee1d\",\"name\":\"rgnemv_58319828ee1d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T01:25:18.262Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5f3215901ad6\",\"name\":\"rgnemv_5f3215901ad6\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T08:42:59.358Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_897291520e41\",\"name\":\"rgnemv_897291520e41\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_dd9490362951\",\"name\":\"rgnemv_dd9490362951\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T01:47:59.969Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib40963937438423\",\"name\":\"rgrsdsib40963937438423\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-21T05:49:13.502Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgvmdeb62\",\"name\":\"rgvmdeb62\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"japaneast\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/skjehr\",\"name\":\"skjehr\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql275957group\",\"name\":\"sql275957group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"centralindia\",\"tags\":{\"date\":\"2019-10-20T00:34:51.146Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi\",\"name\":\"tanyi\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi1\",\"name\":\"tanyi1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tytest\",\"name\":\"tytest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}}]}"
+      "x-ms-request-id" : "51242db1-d071-4ea4-b239-d42aa16bdbc5",
+      "Body" : "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e\",\"name\":\"rg34769e\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westeurope\",\"tags\":{\"date\":\"2020-02-02T22:21:58.047Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439\",\"name\":\"fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westeurope\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e/providers/Microsoft.BatchAI/workspaces/ws791482/fileservers/fsac75112743\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG\",\"name\":\"NetworkWatcherRG\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"northcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-3\",\"name\":\"rgjavatest42883-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.975Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-1\",\"name\":\"rgjavatest42883-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.973Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-2\",\"name\":\"rgjavatest42883-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.305Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest95218-1\",\"name\":\"rgjavatest95218-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:55.038Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-3\",\"name\":\"rgjavatest30297-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:48.645Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-2\",\"name\":\"rgjavatest30297-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:47.803Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-1\",\"name\":\"rgjavatest30297-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:48.648Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-2\",\"name\":\"rgjavatest77313-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:35.556Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-3\",\"name\":\"rgjavatest77313-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:34.892Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-1\",\"name\":\"rgjavatest77313-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:35.559Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-3\",\"name\":\"rgjavatest69549-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:49.627Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-1\",\"name\":\"rgjavatest69549-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:48.986Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-2\",\"name\":\"rgjavatest69549-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:49.624Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest01484-3\",\"name\":\"rgjavatest01484-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:44:14.719Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest96126-3\",\"name\":\"rgjavatest96126-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:48:34.599Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-2\",\"name\":\"rgjavatest70435-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.905Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-3\",\"name\":\"rgjavatest70435-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.315Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-1\",\"name\":\"rgjavatest70435-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.901Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest29091-3\",\"name\":\"rgjavatest29091-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:59.088Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest54227-3\",\"name\":\"rgjavatest54227-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:50:30.567Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest63101-3\",\"name\":\"rgjavatest63101-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:51:39.450Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest39873-3\",\"name\":\"rgjavatest39873-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:04:17.385Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest75563-3\",\"name\":\"rgjavatest75563-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:05:22.611Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest74601-3\",\"name\":\"rgjavatest74601-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:06:58.328Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_javaacsrg49971_aks66843282e2_centralus\",\"name\":\"MC_javaacsrg49971_aks66843282e2_centralus\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"centralus\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\"tags\":{\"tag2\":\"value2\",\"tag3\":\"value3\"},\"properties\":{\"provisioningState\":\"Deleting\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu\",\"name\":\"rg-weidxu\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv5c0980081f258\",\"name\":\"rgnemv5c0980081f258\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-16T13:06:08.375Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7e411787b902d\",\"name\":\"rgnemv7e411787b902d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-17T01:50:42.288Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87437bgroup\",\"name\":\"as87437bgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T05:10:08.055Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks62487fgroup\",\"name\":\"aks62487fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T05:10:56.938Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfwb150680176\",\"name\":\"rgrssdfwb150680176\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.680Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql87e85417fca\",\"name\":\"rgsql87e85417fca\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:41.971Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdepd1e9415070\",\"name\":\"rgrssdepd1e9415070\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.370Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib6926960a8\",\"name\":\"rgrsdsib6926960a8\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:46.199Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfw5158486360\",\"name\":\"rgrssdfw5158486360\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.699Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql811193190a3\",\"name\":\"rgsql811193190a3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:53.251Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdre485555594a\",\"name\":\"rgrssdre485555594a\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:56.746Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdrec906822537\",\"name\":\"rgrssdrec906822537\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T07:27:37.065Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql686003036f7\",\"name\":\"rgsql686003036f7\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T07:31:08.979Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as40238fgroup\",\"name\":\"as40238fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T04:48:10.412Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as059417group\",\"name\":\"as059417group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T04:59:41.876Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as52157fgroup\",\"name\":\"as52157fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T05:02:11.952Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as26384agroup\",\"name\":\"as26384agroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T05:08:25.576Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4c11524863308cbc\",\"name\":\"rgsql4c11524863308cbc\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T06:07:01.265Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4195605300031760\",\"name\":\"rgsql4195605300031760\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T07:43:34.714Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as80484cgroup\",\"name\":\"as80484cgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:24:18.017Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87545cgroup\",\"name\":\"as87545cgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:25:28.937Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as335697group\",\"name\":\"as335697group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:26:27.740Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as22948dgroup\",\"name\":\"as22948dgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:27:47.202Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as11517bgroup\",\"name\":\"as11517bgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:29:35.732Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as906189group\",\"name\":\"as906189group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T05:23:17.655Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971\",\"name\":\"javaacsrg49971\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-26T02:07:02.615Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Deleting\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chuxitest\",\"name\":\"chuxitest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_05d666493318\",\"name\":\"rg1nemv_05d666493318\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T05:46:06.683636Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_be452811f671\",\"name\":\"rg1nemv_be452811f671\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T06:02:06.673752600Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_6784645828e2\",\"name\":\"rg1nemv_6784645828e2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T06:30:34.285231100Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_692871535b3c\",\"name\":\"rg1nemv_692871535b3c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T08:35:48.777588500Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_1c436623a98b\",\"name\":\"rg1nemv_1c436623a98b\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T02:45:43.967864Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_43f60981a7e5\",\"name\":\"rg1nemv_43f60981a7e5\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T07:40:40.916943900Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_0d004902eead\",\"name\":\"rg1nemv_0d004902eead\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T07:49:23.458515400Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_15273952f18b\",\"name\":\"rg1nemv_15273952f18b\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-23T02:22:14.658635500Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ddbRg351\",\"name\":\"ddbRg351\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512\",\"name\":\"fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080/providers/Microsoft.BatchAI/workspaces/ws19469042/fileservers/fs01830076bd\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca\",\"name\":\"fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621/providers/Microsoft.BatchAI/workspaces/ws83e92445/fileservers/fs96068763d3\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-ae130410-4a26-4259-b84f-d5543899e342\",\"name\":\"fileserverrg-ae130410-4a26-4259-b84f-d5543899e342\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621/providers/Microsoft.BatchAI/workspaces/ws7bc05795/fileservers/fsf183444223\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d\",\"name\":\"fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821/providers/Microsoft.BatchAI/workspaces/wsd9f66131/fileservers/fs00b9380944\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-2d782770-0242-41f1-84bf-54426c283420\",\"name\":\"fileserverrg-2d782770-0242-41f1-84bf-54426c283420\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768/providers/Microsoft.BatchAI/workspaces/ws94f33589/fileservers/fs00622717a5\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c\",\"name\":\"fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337/providers/Microsoft.BatchAI/workspaces/wsdc779969/fileservers/fs383444862f\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f\",\"name\":\"fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294/providers/Microsoft.BatchAI/workspaces/wsc8d80975/fileservers/fs1b76451406\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c\",\"name\":\"fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039/providers/Microsoft.BatchAI/workspaces/ws85e68734/fileservers/fs27944980f0\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ty\",\"name\":\"ty\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southeastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg16682\",\"name\":\"javacsmrg16682\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"tags\":{\"date\":\"2020-03-25T07:14:43.646043100Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice\",\"name\":\"cleanupservice\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lenatest\",\"name\":\"lenatest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgac6642161bef4\",\"name\":\"rgac6642161bef4\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg76a43058c8\",\"name\":\"rg76a43058c8\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2019-12-21T05:08:00.974Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi\",\"name\":\"tanyi\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azfluent\",\"name\":\"azfluent\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080\",\"name\":\"rg24353080\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821\",\"name\":\"rg79d65821\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621\",\"name\":\"rge0b12621\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768\",\"name\":\"rgbba97768\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039\",\"name\":\"rgdac67039\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621\",\"name\":\"rg6cd48621\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337\",\"name\":\"rg41d32337\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294\",\"name\":\"rg78983294\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}}]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/a1-test-sql/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:03 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -41,23 +42,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "608d6c95-adaf-4bfc-bc38-c0eed200d806",
+      "x-ms-correlation-request-id" : "a65b7a09-b9bb-4db7-a17a-a1292dd8ce92",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:608d6c95-adaf-4bfc-bc38-c0eed200d806",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:a65b7a09-b9bb-4db7-a17a-a1292dd8ce92",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "608d6c95-adaf-4bfc-bc38-c0eed200d806",
+      "x-ms-request-id" : "a65b7a09-b9bb-4db7-a17a-a1292dd8ce92",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -66,23 +68,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "8224aabb-9a7c-4a27-86df-8f8ab2262194",
+      "x-ms-correlation-request-id" : "f0210c87-210f-41be-a017-a529e421e317",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:8224aabb-9a7c-4a27-86df-8f8ab2262194",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:f0210c87-210f-41be-a017-a529e421e317",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8224aabb-9a7c-4a27-86df-8f8ab2262194",
+      "x-ms-request-id" : "f0210c87-210f-41be-a017-a529e421e317",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -91,23 +94,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "cbb94c8e-3c84-4956-be0d-0b7d3c81b987",
+      "x-ms-correlation-request-id" : "e18a6538-5786-4cd4-a266-b33f319f87aa",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:cbb94c8e-3c84-4956-be0d-0b7d3c81b987",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:e18a6538-5786-4cd4-a266-b33f319f87aa",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "cbb94c8e-3c84-4956-be0d-0b7d3c81b987",
+      "x-ms-request-id" : "e18a6538-5786-4cd4-a266-b33f319f87aa",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/flksjerlk/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -116,23 +120,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ee87ff28-7644-414e-9ceb-bf356e1ad7a1",
+      "x-ms-correlation-request-id" : "e9418e93-5f18-4f59-8690-cc43fad443fd",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:ee87ff28-7644-414e-9ceb-bf356e1ad7a1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:e9418e93-5f18-4f59-8690-cc43fad443fd",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ee87ff28-7644-414e-9ceb-bf356e1ad7a1",
+      "x-ms-request-id" : "e9418e93-5f18-4f59-8690-cc43fad443fd",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg00a720985/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -141,23 +146,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6f25daa6-d5e5-4095-9552-81ba2bd968e7",
+      "x-ms-correlation-request-id" : "78c07a3d-b036-4e0a-b415-7cbd66d09ca2",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:6f25daa6-d5e5-4095-9552-81ba2bd968e7",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022304Z:78c07a3d-b036-4e0a-b415-7cbd66d09ca2",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6f25daa6-d5e5-4095-9552-81ba2bd968e7",
+      "x-ms-request-id" : "78c07a3d-b036-4e0a-b415-7cbd66d09ca2",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg236403/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -166,23 +172,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "60d7aff5-b718-410c-94c7-dc31423d7c15",
+      "x-ms-correlation-request-id" : "598ef024-5479-441c-8267-25d1d0c39a61",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:60d7aff5-b718-410c-94c7-dc31423d7c15",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:598ef024-5479-441c-8267-25d1d0c39a61",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "60d7aff5-b718-410c-94c7-dc31423d7c15",
+      "x-ms-request-id" : "598ef024-5479-441c-8267-25d1d0c39a61",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javanwmrg99069/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest95218-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -191,23 +198,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "65d5b0f1-1b50-48b2-bf1e-750d010dff0d",
+      "x-ms-correlation-request-id" : "476f0c6c-4e42-4f10-8b4f-ea8f93605b71",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:65d5b0f1-1b50-48b2-bf1e-750d010dff0d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:476f0c6c-4e42-4f10-8b4f-ea8f93605b71",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "65d5b0f1-1b50-48b2-bf1e-750d010dff0d",
+      "x-ms-request-id" : "476f0c6c-4e42-4f10-8b4f-ea8f93605b71",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jmonitor_4c473300/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -216,23 +224,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "581e6b06-ef93-4c92-958d-8b4bbd16160b",
+      "x-ms-correlation-request-id" : "dbbc5a5e-f391-4c62-97bb-2ae628a7bc84",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:581e6b06-ef93-4c92-958d-8b4bbd16160b",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:dbbc5a5e-f391-4c62-97bb-2ae628a7bc84",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "581e6b06-ef93-4c92-958d-8b4bbd16160b",
+      "x-ms-request-id" : "dbbc5a5e-f391-4c62-97bb-2ae628a7bc84",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:04 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -241,23 +250,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "36280f34-7b28-4472-874c-6bfb2f244afc",
+      "x-ms-correlation-request-id" : "fb5321c9-1885-4a99-81dd-d46b8abc2317",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:36280f34-7b28-4472-874c-6bfb2f244afc",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:fb5321c9-1885-4a99-81dd-d46b8abc2317",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "36280f34-7b28-4472-874c-6bfb2f244afc",
+      "x-ms-request-id" : "fb5321c9-1885-4a99-81dd-d46b8abc2317",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_71a38597006e/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -266,23 +276,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "4471b971-c124-4215-8203-cd7486bbb604",
+      "x-ms-correlation-request-id" : "d24de7a9-383c-4b39-bda6-1adff62ba23b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:4471b971-c124-4215-8203-cd7486bbb604",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:d24de7a9-383c-4b39-bda6-1adff62ba23b",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "4471b971-c124-4215-8203-cd7486bbb604",
+      "x-ms-request-id" : "d24de7a9-383c-4b39-bda6-1adff62ba23b",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_8fd8947481be/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -291,23 +302,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "adf385ad-1787-49e7-b1de-5da42a50674d",
+      "x-ms-correlation-request-id" : "c9e53276-4b72-43d6-b858-4ab8e69f35f5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:adf385ad-1787-49e7-b1de-5da42a50674d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:c9e53276-4b72-43d6-b858-4ab8e69f35f5",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "adf385ad-1787-49e7-b1de-5da42a50674d",
+      "x-ms-request-id" : "c9e53276-4b72-43d6-b858-4ab8e69f35f5",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_c7b25576b432/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -316,23 +328,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e7621200-74fb-4b6d-929f-c1c6435de410",
+      "x-ms-correlation-request-id" : "66a44f52-3f67-4366-9669-cce547a20675",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044707Z:e7621200-74fb-4b6d-929f-c1c6435de410",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022305Z:66a44f52-3f67-4366-9669-cce547a20675",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e7621200-74fb-4b6d-929f-c1c6435de410",
+      "x-ms-request-id" : "66a44f52-3f67-4366-9669-cce547a20675",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_d1f10904c5be/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -341,23 +354,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "76aae638-2f39-4c67-a413-4c487d615756",
+      "x-ms-correlation-request-id" : "d24fa2f1-f648-4019-ab26-34cb32a30d64",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:76aae638-2f39-4c67-a413-4c487d615756",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:d24fa2f1-f648-4019-ab26-34cb32a30d64",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "76aae638-2f39-4c67-a413-4c487d615756",
+      "x-ms-request-id" : "d24fa2f1-f648-4019-ab26-34cb32a30d64",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg234085226f/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -366,23 +380,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "f2316786-90f9-4c91-bce5-17251224676b",
+      "x-ms-correlation-request-id" : "abe87799-a0eb-4975-bbdf-39a570ba8e25",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:f2316786-90f9-4c91-bce5-17251224676b",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:abe87799-a0eb-4975-bbdf-39a570ba8e25",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f2316786-90f9-4c91-bce5-17251224676b",
+      "x-ms-request-id" : "abe87799-a0eb-4975-bbdf-39a570ba8e25",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg46678/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -391,23 +406,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0cc0605c-c22c-4a2c-ba1d-456e819e5910",
+      "x-ms-correlation-request-id" : "8720508a-eb27-404d-8b5e-420dd5b8bb8a",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:0cc0605c-c22c-4a2c-ba1d-456e819e5910",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:8720508a-eb27-404d-8b5e-420dd5b8bb8a",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "0cc0605c-c22c-4a2c-ba1d-456e819e5910",
+      "x-ms-request-id" : "8720508a-eb27-404d-8b5e-420dd5b8bb8a",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg760944107c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:05 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -416,23 +432,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ced8c800-5be8-4004-9c40-38c6fdaaaf53",
+      "x-ms-correlation-request-id" : "41f63b0b-c87d-4bd2-86ab-3c1180e5076b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:ced8c800-5be8-4004-9c40-38c6fdaaaf53",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:41f63b0b-c87d-4bd2-86ab-3c1180e5076b",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ced8c800-5be8-4004-9c40-38c6fdaaaf53",
+      "x-ms-request-id" : "41f63b0b-c87d-4bd2-86ab-3c1180e5076b",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest01484-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -441,23 +458,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "abeda7c0-a2d1-4910-aa4a-6d96699aba6e",
+      "x-ms-correlation-request-id" : "0233be9e-94c9-4114-8b4a-2654d0ea5768",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:abeda7c0-a2d1-4910-aa4a-6d96699aba6e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:0233be9e-94c9-4114-8b4a-2654d0ea5768",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "abeda7c0-a2d1-4910-aa4a-6d96699aba6e",
+      "x-ms-request-id" : "0233be9e-94c9-4114-8b4a-2654d0ea5768",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr268020/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest96126-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -466,23 +484,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2664b45e-214a-49a7-a014-36f8d8242b74",
+      "x-ms-correlation-request-id" : "97718dc4-1148-4a7b-a97f-939f8e55fcce",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:2664b45e-214a-49a7-a014-36f8d8242b74",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:97718dc4-1148-4a7b-a97f-939f8e55fcce",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2664b45e-214a-49a7-a014-36f8d8242b74",
+      "x-ms-request-id" : "97718dc4-1148-4a7b-a97f-939f8e55fcce",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr742334/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -491,23 +510,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "eb104db7-bd47-4fae-9c05-e3952d838de6",
+      "x-ms-correlation-request-id" : "d49f6a70-da75-4277-aeee-c1cb8738af6b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:eb104db7-bd47-4fae-9c05-e3952d838de6",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:d49f6a70-da75-4277-aeee-c1cb8738af6b",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "eb104db7-bd47-4fae-9c05-e3952d838de6",
+      "x-ms-request-id" : "d49f6a70-da75-4277-aeee-c1cb8738af6b",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3e83753426e8ff29/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -516,23 +536,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9eec621b-ca97-4f22-aad3-354c5fc068cb",
+      "x-ms-correlation-request-id" : "22f3fe01-2a19-4c7c-8b5e-c4a80e7c9159",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:9eec621b-ca97-4f22-aad3-354c5fc068cb",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022306Z:22f3fe01-2a19-4c7c-8b5e-c4a80e7c9159",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9eec621b-ca97-4f22-aad3-354c5fc068cb",
+      "x-ms-request-id" : "22f3fe01-2a19-4c7c-8b5e-c4a80e7c9159",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv68a360842c14044e/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -541,23 +562,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "10166869-a42e-436a-a4dd-eea329aebc38",
+      "x-ms-correlation-request-id" : "ce65f3f4-803c-430d-adbe-f0cb163ff51c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:10166869-a42e-436a-a4dd-eea329aebc38",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:ce65f3f4-803c-430d-adbe-f0cb163ff51c",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "10166869-a42e-436a-a4dd-eea329aebc38",
+      "x-ms-request-id" : "ce65f3f4-803c-430d-adbe-f0cb163ff51c",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv92407708/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest29091-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -566,23 +588,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5d208064-3869-43f8-a5af-7e2776be05e4",
+      "x-ms-correlation-request-id" : "4eea1033-f5a8-40fb-b80e-8df19a918660",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:5d208064-3869-43f8-a5af-7e2776be05e4",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:4eea1033-f5a8-40fb-b80e-8df19a918660",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5d208064-3869-43f8-a5af-7e2776be05e4",
+      "x-ms-request-id" : "4eea1033-f5a8-40fb-b80e-8df19a918660",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvd73932032d4ac980/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest54227-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:07 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -591,23 +614,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "44429e48-f3a7-458f-ad01-1082f46f22d2",
+      "x-ms-correlation-request-id" : "b1055c8f-1584-48d2-97b3-90fe9b6c8dd8",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:44429e48-f3a7-458f-ad01-1082f46f22d2",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:b1055c8f-1584-48d2-97b3-90fe9b6c8dd8",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "44429e48-f3a7-458f-ad01-1082f46f22d2",
+      "x-ms-request-id" : "b1055c8f-1584-48d2-97b3-90fe9b6c8dd8",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcosmosdb13d02156d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest63101-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:06 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -616,23 +640,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c3bda7a3-1eb5-4f36-9dc9-80f4143bdd95",
+      "x-ms-correlation-request-id" : "7dd7ccf2-75ae-4d1f-8ee0-77ab6ed986e5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044708Z:c3bda7a3-1eb5-4f36-9dc9-80f4143bdd95",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:7dd7ccf2-75ae-4d1f-8ee0-77ab6ed986e5",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c3bda7a3-1eb5-4f36-9dc9-80f4143bdd95",
+      "x-ms-request-id" : "7dd7ccf2-75ae-4d1f-8ee0-77ab6ed986e5",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7ac76366e9bd0/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest39873-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -641,23 +666,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ad995a67-000d-4fe9-a4c9-27679f42d590",
+      "x-ms-correlation-request-id" : "8109353a-e2a8-4298-963d-43b450bfb91c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:ad995a67-000d-4fe9-a4c9-27679f42d590",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:8109353a-e2a8-4298-963d-43b450bfb91c",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ad995a67-000d-4fe9-a4c9-27679f42d590",
+      "x-ms-request-id" : "8109353a-e2a8-4298-963d-43b450bfb91c",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_58319828ee1d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest75563-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -666,23 +692,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "750ef13b-adee-4d38-a33c-8dd59771d16c",
+      "x-ms-correlation-request-id" : "5a29d0fc-300a-49ea-8b8e-b4c7f50839d3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:750ef13b-adee-4d38-a33c-8dd59771d16c",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:5a29d0fc-300a-49ea-8b8e-b4c7f50839d3",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "750ef13b-adee-4d38-a33c-8dd59771d16c",
+      "x-ms-request-id" : "5a29d0fc-300a-49ea-8b8e-b4c7f50839d3",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5f3215901ad6/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest74601-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -691,23 +718,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9fa12776-2779-49de-bbb2-767b0b6afd0d",
+      "x-ms-correlation-request-id" : "44a9817a-ca36-4b59-8d0c-ccb8cb5f26c7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:9fa12776-2779-49de-bbb2-767b0b6afd0d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022307Z:44a9817a-ca36-4b59-8d0c-ccb8cb5f26c7",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9fa12776-2779-49de-bbb2-767b0b6afd0d",
+      "x-ms-request-id" : "44a9817a-ca36-4b59-8d0c-ccb8cb5f26c7",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_897291520e41/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_javaacsrg49971_aks66843282e2_centralus/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -716,23 +744,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c3e45817-d759-4085-8540-78a815788e70",
+      "x-ms-correlation-request-id" : "bed61f96-099a-4a48-8126-79c3f9d4cb8f",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:c3e45817-d759-4085-8540-78a815788e70",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:bed61f96-099a-4a48-8126-79c3f9d4cb8f",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c3e45817-d759-4085-8540-78a815788e70",
+      "x-ms-request-id" : "bed61f96-099a-4a48-8126-79c3f9d4cb8f",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_dd9490362951/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -741,23 +770,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "dfb06d5d-89c4-41b5-9ebc-ba7be8e8af47",
+      "x-ms-correlation-request-id" : "eced026d-20ac-42f5-8f91-983899c599a7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:dfb06d5d-89c4-41b5-9ebc-ba7be8e8af47",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:eced026d-20ac-42f5-8f91-983899c599a7",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "dfb06d5d-89c4-41b5-9ebc-ba7be8e8af47",
+      "x-ms-request-id" : "eced026d-20ac-42f5-8f91-983899c599a7",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib40963937438423/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv5c0980081f258/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -766,23 +796,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1fbfc8c4-027c-45fd-8a32-e94e727b8072",
+      "x-ms-correlation-request-id" : "7350d585-fe6c-4007-88f9-abe230b0d0a7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:1fbfc8c4-027c-45fd-8a32-e94e727b8072",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:7350d585-fe6c-4007-88f9-abe230b0d0a7",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1fbfc8c4-027c-45fd-8a32-e94e727b8072",
+      "x-ms-request-id" : "7350d585-fe6c-4007-88f9-abe230b0d0a7",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgvmdeb62/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7e411787b902d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:07 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -791,23 +822,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1f7b9ffb-6983-448d-b4ce-55acbfa17d45",
+      "x-ms-correlation-request-id" : "0913e3a9-4739-4155-8ff5-28cae1538297",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:1f7b9ffb-6983-448d-b4ce-55acbfa17d45",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:0913e3a9-4739-4155-8ff5-28cae1538297",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1f7b9ffb-6983-448d-b4ce-55acbfa17d45",
+      "x-ms-request-id" : "0913e3a9-4739-4155-8ff5-28cae1538297",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/skjehr/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87437bgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -816,23 +848,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "3ec8befb-3d35-4b6e-af69-f0e6b37e64a7",
+      "x-ms-correlation-request-id" : "1794fb9b-0a58-4ec7-9ece-eda2328d4966",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044709Z:3ec8befb-3d35-4b6e-af69-f0e6b37e64a7",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:1794fb9b-0a58-4ec7-9ece-eda2328d4966",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3ec8befb-3d35-4b6e-af69-f0e6b37e64a7",
+      "x-ms-request-id" : "1794fb9b-0a58-4ec7-9ece-eda2328d4966",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql275957group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks62487fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -841,23 +874,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1b2715cc-9895-49c5-976e-25bc92068aa9",
+      "x-ms-correlation-request-id" : "c5c39604-3a0a-4833-ba5d-de65c252bac3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044710Z:1b2715cc-9895-49c5-976e-25bc92068aa9",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:c5c39604-3a0a-4833-ba5d-de65c252bac3",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1b2715cc-9895-49c5-976e-25bc92068aa9",
+      "x-ms-request-id" : "c5c39604-3a0a-4833-ba5d-de65c252bac3",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfwb150680176/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -866,23 +900,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "136c1bef-297e-4780-b183-e1e4ca22b37e",
+      "x-ms-correlation-request-id" : "ac1b0de0-994c-4928-84e6-6e519688f9c7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044710Z:136c1bef-297e-4780-b183-e1e4ca22b37e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022308Z:ac1b0de0-994c-4928-84e6-6e519688f9c7",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "136c1bef-297e-4780-b183-e1e4ca22b37e",
+      "x-ms-request-id" : "ac1b0de0-994c-4928-84e6-6e519688f9c7",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql87e85417fca/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -891,23 +926,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "a04cb6e9-02da-4a63-8b80-8224d4948f41",
+      "x-ms-correlation-request-id" : "7ca6f432-6848-4cfa-b6e4-6763ed9cd523",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044710Z:a04cb6e9-02da-4a63-8b80-8224d4948f41",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:7ca6f432-6848-4cfa-b6e4-6763ed9cd523",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "a04cb6e9-02da-4a63-8b80-8224d4948f41",
+      "x-ms-request-id" : "7ca6f432-6848-4cfa-b6e4-6763ed9cd523",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tytest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdepd1e9415070/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:09 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -916,542 +952,494 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "55913e9d-be5e-4653-8e71-d1d313dcd358",
+      "x-ms-correlation-request-id" : "4c7259f5-7d58-4494-8c91-50bb6d614990",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044710Z:55913e9d-be5e-4653-8e71-d1d313dcd358",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:4c7259f5-7d58-4494-8c91-50bb6d614990",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "55913e9d-be5e-4653-8e71-d1d313dcd358",
+      "x-ms-request-id" : "4c7259f5-7d58-4494-8c91-50bb6d614990",
       "Body" : "{\"value\":[]}"
     }
   }, {
-    "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ResourceManagementClient, 2019-08-01)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:13 GMT",
-      "content-length" : "309",
-      "expires" : "-1",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1199",
-      "retry-after" : "0",
-      "StatusCode" : "201",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c9f913b5-266b-4e71-bc03-94ca49c7743f",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044714Z:c9f913b5-266b-4e71-bc03-94ca49c7743f",
-      "content-type" : "application/json; charset=utf-8",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "c9f913b5-266b-4e71-bc03-94ca49c7743f",
-      "Body" : "{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group\",\"name\":\"aks758999group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-23T04:47:10.449Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}}"
-    }
-  }, {
-    "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:20 GMT",
-      "content-length" : "1741",
-      "server" : "nginx",
-      "expires" : "-1",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1198",
-      "retry-after" : "0",
-      "StatusCode" : "201",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "b6295cc4-99b9-426c-915e-f86033ed4912",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044721Z:b6295cc4-99b9-426c-915e-f86033ed4912",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "380b0fb0-5e6f-484f-bce2-2b08d41932a0",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
-      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31"
-    }
-  }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib6926960a8/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:21 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11962",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "78579d8a-6b02-4d5d-b6d3-aca2b2a7e0d5",
+      "x-ms-correlation-request-id" : "61dea2d8-6852-4ea5-8b4d-b7d4aab445c7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044722Z:78579d8a-6b02-4d5d-b6d3-aca2b2a7e0d5",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:61dea2d8-6852-4ea5-8b4d-b7d4aab445c7",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7d487ea2-8468-40d4-8c40-1c5da6f1ce40",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "61dea2d8-6852-4ea5-8b4d-b7d4aab445c7",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfw5158486360/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:47:52 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:08 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11961",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1a718e2f-0ef5-472c-a2fc-0cef0fd5cf07",
+      "x-ms-correlation-request-id" : "5b04881c-4dcb-4d50-a508-49ef57df65e1",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044752Z:1a718e2f-0ef5-472c-a2fc-0cef0fd5cf07",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:5b04881c-4dcb-4d50-a508-49ef57df65e1",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6aaddd8a-c73c-49da-b16a-c9d74fa27507",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "5b04881c-4dcb-4d50-a508-49ef57df65e1",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql811193190a3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:48:22 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11960",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "edc2cec7-73f7-4cac-bcb8-54848a502f4d",
+      "x-ms-correlation-request-id" : "2209db5b-1847-4dac-82ae-148d33a831f0",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044822Z:edc2cec7-73f7-4cac-bcb8-54848a502f4d",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:2209db5b-1847-4dac-82ae-148d33a831f0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8991295a-169b-461c-a078-898039fc8b56",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "2209db5b-1847-4dac-82ae-148d33a831f0",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdre485555594a/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:48:53 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11959",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "98e71361-ba63-40df-b1c4-24296cfdf77d",
+      "x-ms-correlation-request-id" : "9329383f-215e-415a-88d7-2fbf8a9a090f",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044853Z:98e71361-ba63-40df-b1c4-24296cfdf77d",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:9329383f-215e-415a-88d7-2fbf8a9a090f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "57aaddf7-f5f2-4d5d-842c-115324fadf07",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "9329383f-215e-415a-88d7-2fbf8a9a090f",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdrec906822537/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:49:23 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11958",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "66ae5b14-70b5-4d57-b71e-509cf73614da",
+      "x-ms-correlation-request-id" : "4a06cb6f-b192-491d-8194-a2f485aafe51",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044924Z:66ae5b14-70b5-4d57-b71e-509cf73614da",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:4a06cb6f-b192-491d-8194-a2f485aafe51",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e65c5636-5f6d-4c49-8e5a-610276374a22",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "4a06cb6f-b192-491d-8194-a2f485aafe51",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql686003036f7/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:49:53 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11957",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "61614818-5853-4ba8-9bd1-8c1c7998ec77",
+      "x-ms-correlation-request-id" : "dd5e2021-729a-45b3-8b50-2c30662fcc9b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T044954Z:61614818-5853-4ba8-9bd1-8c1c7998ec77",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022309Z:dd5e2021-729a-45b3-8b50-2c30662fcc9b",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "678b26a6-a547-4b79-9e4d-d70cbaf959ae",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "dd5e2021-729a-45b3-8b50-2c30662fcc9b",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as40238fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:50:24 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11956",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "4bf758b1-11d4-4152-b245-ddbd467ce5b1",
+      "x-ms-correlation-request-id" : "3b52a416-967c-4468-b4de-65259e976821",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045024Z:4bf758b1-11d4-4152-b245-ddbd467ce5b1",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:3b52a416-967c-4468-b4de-65259e976821",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "618480cc-53e2-4f97-8522-029c758b6d23",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "3b52a416-967c-4468-b4de-65259e976821",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as059417group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:50:54 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11955",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "15b976d1-c4fe-4dae-bbb5-f785fd2680f3",
+      "x-ms-correlation-request-id" : "73d92497-591d-49f8-b6c9-21a7e2c1755e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045055Z:15b976d1-c4fe-4dae-bbb5-f785fd2680f3",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:73d92497-591d-49f8-b6c9-21a7e2c1755e",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "065f0ed1-201e-4af6-a937-a82ef3fecdcb",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "73d92497-591d-49f8-b6c9-21a7e2c1755e",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as52157fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:51:25 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11954",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ba985aa9-a100-494c-bea6-0809fec76052",
+      "x-ms-correlation-request-id" : "7353e8d5-ee99-4599-9c9f-e9de99add425",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045126Z:ba985aa9-a100-494c-bea6-0809fec76052",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:7353e8d5-ee99-4599-9c9f-e9de99add425",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "547be597-7dc3-41bd-a622-6f25bb47d053",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "7353e8d5-ee99-4599-9c9f-e9de99add425",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as26384agroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:51:56 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:09 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11953",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2186a533-d3d0-419e-b3c6-e7b405df2aeb",
+      "x-ms-correlation-request-id" : "b25f6158-b4bd-463e-b992-b4865e3f623f",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045156Z:2186a533-d3d0-419e-b3c6-e7b405df2aeb",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:b25f6158-b4bd-463e-b992-b4865e3f623f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "594de4c7-0f37-47da-9c49-31348c28c1f9",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "b25f6158-b4bd-463e-b992-b4865e3f623f",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4c11524863308cbc/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:52:26 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11952",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6baa2b02-7f01-4716-a4d5-808027b221e3",
+      "x-ms-correlation-request-id" : "798d2d5f-0c80-4d55-bc4a-5bf3d70a4bc1",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045226Z:6baa2b02-7f01-4716-a4d5-808027b221e3",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:798d2d5f-0c80-4d55-bc4a-5bf3d70a4bc1",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8cf8e953-2c42-470b-8531-c680a495fc7b",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "798d2d5f-0c80-4d55-bc4a-5bf3d70a4bc1",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4195605300031760/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:52:56 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11951",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1a679872-00d2-4e55-b7d2-661cfdce0a7d",
+      "x-ms-correlation-request-id" : "ae3a0d88-4df4-47fe-9591-ce7b90c28eec",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045257Z:1a679872-00d2-4e55-b7d2-661cfdce0a7d",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:ae3a0d88-4df4-47fe-9591-ce7b90c28eec",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "41545d55-d95d-4a6c-ae74-0ef91afda388",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "ae3a0d88-4df4-47fe-9591-ce7b90c28eec",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as80484cgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:53:28 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11950",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ff9df1ae-e7af-41f6-99e8-6af49cc9f994",
+      "x-ms-correlation-request-id" : "7943090e-5cee-417b-8724-4b5e3760e8af",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045328Z:ff9df1ae-e7af-41f6-99e8-6af49cc9f994",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022310Z:7943090e-5cee-417b-8724-4b5e3760e8af",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5bd97993-108e-40cc-b223-33b191b9b358",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "7943090e-5cee-417b-8724-4b5e3760e8af",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87545cgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:53:58 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11949",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "bc32c89b-0f5a-4b23-9ced-29196c612d41",
+      "x-ms-correlation-request-id" : "a514628a-1240-46f9-959a-61f212065261",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045358Z:bc32c89b-0f5a-4b23-9ced-29196c612d41",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022311Z:a514628a-1240-46f9-959a-61f212065261",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "37fd2a64-5ce0-46ab-8759-90cdc7085e71",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "a514628a-1240-46f9-959a-61f212065261",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as335697group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:54:28 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11948",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e7ed8871-70b7-4d38-9eaa-1bbfb4f6d745",
+      "x-ms-correlation-request-id" : "38b57cf8-ef65-414f-bf3e-21d86bac455d",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045429Z:e7ed8871-70b7-4d38-9eaa-1bbfb4f6d745",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022311Z:38b57cf8-ef65-414f-bf3e-21d86bac455d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f3aa41c3-5407-4633-a4be-6c051e5956cf",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "38b57cf8-ef65-414f-bf3e-21d86bac455d",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as22948dgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:54:58 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11947",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "30cc2c8a-6ab5-470c-8056-4606290c1d53",
+      "x-ms-correlation-request-id" : "10159495-5f86-417a-b5f4-4977a85c704c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045459Z:30cc2c8a-6ab5-470c-8056-4606290c1d53",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022311Z:10159495-5f86-417a-b5f4-4977a85c704c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7426ab82-ccc9-46f0-b5f7-78f262281bb1",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "10159495-5f86-417a-b5f4-4977a85c704c",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as11517bgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:55:30 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11946",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0671996e-8941-4e97-aa07-20b26997921c",
+      "x-ms-correlation-request-id" : "7d279e36-1aef-417d-ba76-d2773a022fd6",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045530Z:0671996e-8941-4e97-aa07-20b26997921c",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022311Z:7d279e36-1aef-417d-ba76-d2773a022fd6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3f3f01e8-df52-4536-a39b-e5cabe36017b",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "7d279e36-1aef-417d-ba76-d2773a022fd6",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as906189group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:56:00 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:11 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11945",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "163b66d4-7caf-4cf5-bb47-0f9000c49819",
+      "x-ms-correlation-request-id" : "3599721c-e1e1-4092-a2bd-fb8d1d9bbdac",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045600Z:163b66d4-7caf-4cf5-bb47-0f9000c49819",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022311Z:3599721c-e1e1-4092-a2bd-fb8d1d9bbdac",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "278cce38-83ea-45e4-b152-52a63fde5c4f",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "3599721c-e1e1-4092-a2bd-fb8d1d9bbdac",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:56:30 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:12 GMT",
       "server" : "nginx",
-      "content-length" : "126",
+      "content-length" : "1933",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -1460,471 +1448,363 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "7a8d906d-d81d-4f61-af3b-eedcde286571",
+      "x-ms-correlation-request-id" : "a8370187-005a-4631-8faf-35e7583f61f5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045631Z:7a8d906d-d81d-4f61-af3b-eedcde286571",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022312Z:a8370187-005a-4631-8faf-35e7583f61f5",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f26fd800-3f1e-40a6-b162-550d89e0b085",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "1f990ff6-e75f-42da-b91c-355214d1158d",
+      "Body" : "{\n  \"value\": [\n   {\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/javaacsrg49971/providers/Microsoft.ContainerService/managedClusters/aks66843282e2\",\n    \"location\": \"centralus\",\n    \"name\": \"aks66843282e2\",\n    \"tags\": {\n     \"tag2\": \"value2\",\n     \"tag3\": \"value3\"\n    },\n    \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n    \"properties\": {\n     \"provisioningState\": \"Deleting\",\n     \"kubernetesVersion\": \"1.15.10\",\n     \"dnsPrefix\": \"mp1dns94511d\",\n     \"fqdn\": \"mp1dns94511d-3d22ae46.hcp.centralus.azmk8s.io\",\n     \"agentPoolProfiles\": [\n      {\n       \"name\": \"ap0470064\",\n       \"count\": 5,\n       \"vmSize\": \"Standard_D1\",\n       \"osDiskSizeGB\": 100,\n       \"maxPods\": 110,\n       \"type\": \"VirtualMachineScaleSets\",\n       \"provisioningState\": \"Succeeded\",\n       \"orchestratorVersion\": \"1.15.10\",\n       \"osType\": \"Linux\"\n      }\n     ],\n     \"linuxProfile\": {\n      \"adminUsername\": \"testaks\",\n      \"ssh\": {\n       \"publicKeys\": [\n        {\n         \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\n        }\n       ]\n      }\n     },\n     \"servicePrincipalProfile\": {\n      \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n     },\n     \"nodeResourceGroup\": \"MC_javaacsrg49971_aks66843282e2_centralus\",\n     \"enableRBAC\": false,\n     \"networkProfile\": {\n      \"networkPlugin\": \"kubenet\",\n      \"loadBalancerSku\": \"Basic\",\n      \"podCidr\": \"10.244.0.0/16\",\n      \"serviceCidr\": \"10.0.0.0/16\",\n      \"dnsServiceIP\": \"10.0.0.10\",\n      \"dockerBridgeCidr\": \"172.17.0.1/16\"\n     },\n     \"maxAgentPools\": 8\n    }\n   }\n  ]\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chuxitest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:57:01 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:12 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11943",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0ba13481-8934-4c9f-aba0-155189545ab4",
+      "x-ms-correlation-request-id" : "26f4ff51-8ece-45f0-abf1-8feb9a196b4a",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045701Z:0ba13481-8934-4c9f-aba0-155189545ab4",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:26f4ff51-8ece-45f0-abf1-8feb9a196b4a",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "54a86db8-d16d-4aa8-997b-478f4b5933f3",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "26f4ff51-8ece-45f0-abf1-8feb9a196b4a",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_05d666493318/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:57:31 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:12 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11942",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "fcc183fb-c1ec-4f52-8a14-7518969c9626",
+      "x-ms-correlation-request-id" : "4ab6aa35-e25b-4515-8ffb-79863589db08",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045732Z:fcc183fb-c1ec-4f52-8a14-7518969c9626",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:4ab6aa35-e25b-4515-8ffb-79863589db08",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2f5642b8-dff2-4a4e-9149-23bc6373e0e8",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "4ab6aa35-e25b-4515-8ffb-79863589db08",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_be452811f671/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:58:01 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:12 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11941",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6734ca6e-3aaa-4ffe-8d97-e7a97429050e",
+      "x-ms-correlation-request-id" : "9a46750f-72c4-4caa-82f3-86a7b6111587",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045802Z:6734ca6e-3aaa-4ffe-8d97-e7a97429050e",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:9a46750f-72c4-4caa-82f3-86a7b6111587",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "944b82a1-8cf1-4519-b82b-3e6fa784e3e5",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "9a46750f-72c4-4caa-82f3-86a7b6111587",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_6784645828e2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:58:33 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:12 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11940",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0de7680e-b525-443d-8cfa-2a81b9d9ced0",
+      "x-ms-correlation-request-id" : "971c7c33-8b98-4d4f-bedc-7cacc386e80c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045833Z:0de7680e-b525-443d-8cfa-2a81b9d9ced0",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:971c7c33-8b98-4d4f-bedc-7cacc386e80c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1fd8342a-81b9-456d-93cc-c8a55ddebf38",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "971c7c33-8b98-4d4f-bedc-7cacc386e80c",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_692871535b3c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:59:03 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11939",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "3f3c7de5-b81e-429f-8341-bf9de889c1de",
+      "x-ms-correlation-request-id" : "154b89d1-2102-47b7-8bb7-5b5d2000cd58",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045903Z:3f3c7de5-b81e-429f-8341-bf9de889c1de",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:154b89d1-2102-47b7-8bb7-5b5d2000cd58",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ef53e3d6-0b7f-45a7-b95e-1f9607b903f7",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "154b89d1-2102-47b7-8bb7-5b5d2000cd58",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_1c436623a98b/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 04:59:34 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11938",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6d82c272-06a9-47d9-bcc1-0ceb4fbd04af",
+      "x-ms-correlation-request-id" : "b1b304b9-63f3-48de-b2bd-8ffac99c0893",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T045934Z:6d82c272-06a9-47d9-bcc1-0ceb4fbd04af",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:b1b304b9-63f3-48de-b2bd-8ffac99c0893",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "4cee8714-2f52-45c8-b750-95cf69267228",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "b1b304b9-63f3-48de-b2bd-8ffac99c0893",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_43f60981a7e5/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:00:04 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11937",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5dbe1cad-c370-43b9-87d3-785469b49f69",
+      "x-ms-correlation-request-id" : "d4d1829b-f5c9-4bf0-9dd3-da81d7e75546",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050005Z:5dbe1cad-c370-43b9-87d3-785469b49f69",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022313Z:d4d1829b-f5c9-4bf0-9dd3-da81d7e75546",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6266c216-cf99-4a8b-8063-8d5d95229879",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "d4d1829b-f5c9-4bf0-9dd3-da81d7e75546",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_0d004902eead/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:00:35 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11936",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "edfc0d9c-df8d-4a83-b36e-3b318ea550e3",
+      "x-ms-correlation-request-id" : "76d69d60-4d03-4365-a6d1-8264dccd05aa",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050035Z:edfc0d9c-df8d-4a83-b36e-3b318ea550e3",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:76d69d60-4d03-4365-a6d1-8264dccd05aa",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "26be4553-3eff-47b6-b4fb-961fd374c4cb",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "76d69d60-4d03-4365-a6d1-8264dccd05aa",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_15273952f18b/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:01:05 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11935",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "34f6679c-8d8d-4c8b-baad-df053036fbf2",
+      "x-ms-correlation-request-id" : "35fff282-722b-4623-b9ce-94b0bc9c1ed8",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050105Z:34f6679c-8d8d-4c8b-baad-df053036fbf2",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:35fff282-722b-4623-b9ce-94b0bc9c1ed8",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8fe409b6-3352-49c7-aa88-d033effc2ff1",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "35fff282-722b-4623-b9ce-94b0bc9c1ed8",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ddbRg351/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:01:36 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11934",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1db0f746-a9c2-4f4c-b99e-7ba64c9c0740",
+      "x-ms-correlation-request-id" : "cd6eb58b-ced5-423f-96d0-399620954c06",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050137Z:1db0f746-a9c2-4f4c-b99e-7ba64c9c0740",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:cd6eb58b-ced5-423f-96d0-399620954c06",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2471f84d-7948-46a4-8608-915c6df29413",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\"\n }"
+      "x-ms-request-id" : "cd6eb58b-ced5-423f-96d0-399620954c06",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/380b0fb0-5e6f-484f-bce2-2b08d41932a0?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:06 GMT",
-      "server" : "nginx",
-      "content-length" : "170",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11933",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0094a1b6-23b1-4e30-be7c-246c4c2bc570",
+      "x-ms-correlation-request-id" : "2e3049c6-7c9b-4c47-a5d1-ba64fee1af32",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050207Z:0094a1b6-23b1-4e30-be7c-246c4c2bc570",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:2e3049c6-7c9b-4c47-a5d1-ba64fee1af32",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "b024d70e-2d15-42c3-9bba-675706cd1e31",
-      "Body" : "{\n  \"name\": \"b00f0b38-6f5e-4f48-bce2-2b08d41932a0\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2019-10-23T04:47:20.6601767Z\",\n  \"endTime\": \"2019-10-23T05:02:04.9051474Z\"\n }"
+      "x-ms-request-id" : "2e3049c6-7c9b-4c47-a5d1-ba64fee1af32",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:07 GMT",
-      "server" : "nginx",
-      "content-length" : "1743",
+      "date" : "Thu, 26 Mar 2020 02:23:13 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11932",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "60e67fa9-a15b-4a34-a412-cb0c5d34ff37",
+      "x-ms-correlation-request-id" : "e13c7bc7-4e66-474f-b793-31c107d31dc4",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050208Z:60e67fa9-a15b-4a34-a412-cb0c5d34ff37",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:e13c7bc7-4e66-474f-b793-31c107d31dc4",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "0db5b84d-489b-4e93-baa6-a66b329355e6",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
-    }
-  }, {
-    "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin/listCredential?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:08 GMT",
-      "server" : "nginx",
-      "content-length" : "13115",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1199",
-      "retry-after" : "0",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ebdb98f4-b363-4fe1-a35e-2b3072c06968",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050209Z:ebdb98f4-b363-4fe1-a35e-2b3072c06968",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "55cef1a7-a6c5-4ffc-829a-4f61c119c037",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterAdmin\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlckFkbWluX2Frczc1ODk5OWdyb3VwX2Frczc1ODk5OQogIG5hbWU6IGFrczc1ODk5OQpjdXJyZW50LWNvbnRleHQ6IGFrczc1ODk5OQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJBZG1pbl9ha3M3NTg5OTlncm91cF9ha3M3NTg5OTkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJZVUZFUldSSGNscExkM1YyWjFSdFUwTnJWVWxzUkVGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNFQxUkZkMDFxVFhkT1JFMHpUV3BTWVVaM01IbE5WRVYzVFdwSmQwNUVVVE5OYWxKaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJCWlRrd2VFZDZjVGhIYzNrelUzUk1WamRJYjFvS1dEVXdMeXRXWW1KT05DdFZNMkptU0RZeWEzWkNVbnBQYm14M1drRnZlalpxV2xVek5VdDBZelV4V0ZaT1lXUXJUbGhSZDFGUlNtdFVjRUpXV1haS05RcGlaREpLUm5KTmJEQTBXbUl4YlRka2RHSnZlV1ZzTHpOTk9GUkJNVnByU0hWMGNDOHlLemx4VFVNcmMxQkdkbEI2VHpsb01tNXdRbTl6YldOMFFWb3ZDamRuTDBKWGRGTjViV1JYV2tab2MwdHdjbTlIT1RSbWNqTlZhemM1YmprMWJFazNTMjE2YzNsaWFIVlBVR0lyWVZOdmNHcEpOSFJCVGxKSFdUZDZVbEFLYkdkdFlXTkNjM2hIWm5OTWVYbzJNRk42T1d0Q2JXaEpiSEpJVXpKVVF6bHplbmxWTURjM1dXWjRUbkYwWnpCS1oydDBWVUZLVnpKTVptbFRXR3gxY2dwU2JqTlRhamhFUkRkdlVGTnZlRlJJY1hJMVpraFFXRGREVGxSd01XZ3lZblp3TUVFdlNIaG1lRWRrV2tGNlpUY3dORXhhZURCUVZtRnpRbEpuTUZSb0NrOTVWVm8yT1hFdlUzQnRibkJpVjNocVlYRm5NRW81TkRWb1VVOU1kakoxTW1sUFJuRjJUVlkwZVV0MEx6aFdMM2wzZERsNlpWTjNORVU1TkhCS1JERUtRMUJ2T1d4dmRXcENMell4ZVVwME9WbEpaelZyVTFoaFpVNUhTRVphTUdsUk4xVkphMFpTT0VWRFRHUm1XRWxrTmxVelpGYzRaWFJaVTJscFNTdFpXUXB6UlVRMGRIRlFSR1ZGZHpGWVNuSkVTVkYxV2pGQk1URTFibk5zVkdoUlJGcFNSV2tyWWtZNGVuUTVNVTVGTUhwa2RpOUxhM1IxWkdvNGFsaG9UbmhUQ210YWJrUlNZa1FyU3pOV05XSTVPRWcyZUdaalYwNXhRMWRGUXpNM2QyVlZZV2hUTmtSQ2VFeHJVbG92T0RVeVNXUlBOVXhyTlROU1VUSlVVMlo0YTJVS01FMXlibFV4VjJwa2QwVmhVeTlzWWxKdlFrZG1UR2R4T1U5UVIzVlFXV1JPVFdoSVdra3hUaTloUTI1eVIyMUNVbFJvTkRCUk9HTjFhblozY1RaVk5Bb3lVVUZoWmxSS2RYcEZVakZEYTFsSlYwWjVWMngzU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLYTNsWFNrbEllRE0xV1VkbmNYRjVaM0EzYUZsTVQyUkJOSEZZVkhwUGMxWlJjeXRXTWtOdFp6WkhZVmcyY25SRmRXSnFhV052VldJMldsTnFUbXA0VHdwMmJVbFRRMll6YlRBelZuZFROVXN3YW5kQmRGTTFTSEJyUlVwMlowNUVXa1V2TjNaRWMwSlJNRXRTUzFkNWVuTjROM0ppVEZCUmVHUjJUMXAzWTNvMkNqbEVPVEZHZG1sT2NsaDJaRlJaYmxwYU4wc3JValY0ZWpaSk1tMUROV0ZOWkVSYWEzTkxiVGxJU2tGb1dtcGlZVFZqWXk5eGRuazFTMnhzUmxkVGFrNEtSMVZ6Y21nNE5GcDRkaXRDZERKdGEza3hjRGhGV1dSUWJscHhTRWxCWWs5SFNHSkRjRzFxYTFkUmFqaFBXR3BWYTJ0aFVHa3dVRmRqV2toT0sycG1Td3BGVTNaR2RHbHhOVVowTWtwMVVWUkxhSHA0WkRreEsyeDBOeTlGVFZOU1NHNTNSamN4YjFrMFNsVTROMnBvYm5neVJpdDNVVzlQYkdkdlIySjBVelpZQ210VFFtNWpabkJ6ZHpkVE1VZHdNVzUxVDJKVk9GbHFaVFZWVkRad1FWcHZlblV6TmtkM1pWQm5jMUExVlZWcGQzbHZlazVJY0dweE1sQkJlVXRIVFdRS1ZuWjZURVZ5Ym1SQ2RsSnRXWFJMU2tWNFZrUkxTRXAwZG5WRmNUTnJlRkZMUkhkemIxQlpPVWgyUm10VmJVVjNibk00YmxSSWNVeGpOR1Y2UlU5RWJ3cFFRMEZCV2pWemMyZ3pjMk5LV0M5dlIwRkZUa1IwUVU5MlNuRXhjR2gyZUdoeWNWTnFZbkJtWWxGM1dYQTNWbTlPV0ZkTlJFMW9VSHBsUkdSdVJscEtDbUl3TTJVemJpdE5UMFUxV2pFNVJtYzBXR0ZUYTNJMGMxVnhUaXRIYVVOcE5UbExZMmx5ZVZnMVdIZHpSMFpSUVhaUWExRjFlbHBuTkRCdk9HaHBaSElLTVM5TmVXSllja3A0UkRFdksyUllPREZwWjBOMU5Wb3lhV3Q0TDNvdldscDBVVlJ1TjA4M1VGRlpZbXhDYjJob1lVdFRWR0pFV1VOaWNUVmliSE5XY0FwdVZYazFZbWhxV25GbFNXTkViRE5ZWmxaa2RWaFpTRTVTV1VKUVJrNUhWMkYxU0hKaVpYTkRZWE5aUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZDBoMlpFMVNjeloyUW5KTmREQnlVekZsZURaSFZpdGtVQzlzVnpKNlpWQnNUakl6ZUN0MGNFeDNWV042Y0RWakNrZFJTMDByYnpKV1RpdFRjbGhQWkZZeFZGZHVabXBXTUUxRlJVTmFSVFpSVmxkTWVXVlhNMlJwVW1GNlNtUlBSMWM1V25VellsYzJUVzV3WmpsNlVFVUtkMDVYV2tJM2NtRm1PWFoyWVdwQmRuSkVlR0o2T0hwMldXUndObEZoVEVwdVRGRkhaaXMwVUhkV2NsVnpjRzVXYlZKWllrTnhZVFpDZG1WSU5qa3hTZ3BQTDFvdlpWcFRUM2x3Y3pkTmJUUmlhbW95TDIxcmNVdFplVTlNVVVSVlVtMVBPREJVTlZsS2JXNUJZazFTYmpkRE9ITXJkRVZ6TDFwQldtOVRTbUY0Q2pCMGEzZDJZazA0YkU1UEt6SklPRlJoY2xsT1ExbEtURlpCUTFaMGFUTTBhMncxWW5Fd1dqa3dieTlCZHlzMlJEQnhUVlY0Tm5FcldIaDZNU3QzYWxVS05tUlpaRzAzTm1SQlVIZzRXRGhTYmxkUlRUTjFPVTlETW1Oa1JERlhja0ZWV1U1Rk5GUnpiRWRsZG1GMk1IRmFjRFpYTVhOWk1uRnZUa05tWlU5WlZRcEVhVGM1Y25SdmFtaGhjbnBHWlUxcGNtWXZSbVk0YzB4bVl6TnJjMDlDVUdWTFUxRTVVV28yVUZwaFRHOTNaaXQwWTJsaVpsZERTVTlhUld3eWJtcFNDbWg0VjJSSmEwOHhRMHBDVldaQ1FXa3pXREY1U0dWc1RqTldka2h5VjBWdmIybFFiVWRNUWtFclRHRnFkek5vVFU1V2VXRjNlVVZNYldSUlRtUmxXamNLU2xVMFZVRXlWVkpKZG0xNFprMDNabVJVVWs1Tk0ySXZlWEJNWW01Wkwwa3hORlJqVlhCSFduY3dWM2N2YVhReFpWY3Zaa0lyYzFnelJtcGhaMnhvUVFwMEt6aEliRWR2VlhWbmQyTlROVVZYWmk5UFpHbElWSFZUTlU5a01GVk9hekJ1T0ZwSWRFUkxOVEZPVm04elkwSkhhM1kxVnpCaFFWSnVlVFJMZGxScUNuaHlhakpJVkZSSlVqSlRUbFJtTW1kd05uaHdaMVZWTkdWT1JWQklURzgzT0V0MWJFOU9hMEZIYmpCNVluTjRSV1JSY0VkRFJtaGpiSEJqUTBGM1JVRUtRVkZMUTBGblJVRjBkbVpJUkdKMlpHWkNkRnBvT0RRelZtbFRRU3RCWldObFkyaDRWMDVoWVhoS05YZzJWR05OWlVOaE5pdEhhM1ZGU2xGT1NVMXdaZ3BGYnpseGJWWm9TbXBsT1M5MFNXWndWakJyYTJ4bFltTmhiRFI0VFZZMVVFaE9XVmxIZUdaVUszYzFPWFZ2UkZwaGMzaExNWEpuSzBOcVVFRlZUVzA0Q21zMVpXdEpSMDlJYmxscFQyMWFkM0l6VHl0TFJWVlNSbk0xUTNCTlVXaENjamhJUVhRM2JHeG5hWGw1VEdSRVNYVnZRMjVyYm5nMU9XVmlaSGs1ZERnS1ZraHNNSEoyTldSalZIVm1Sek5LU2pBck1XZHRMM05YVEVSTlRtNWhNVFJ0V0dGQ1ZXODFiM2hvUWtGSVlTODVjRkEwTWs5UVNVOVFUMmMxTTJOck5BcERRbmw2Y1VOWk4yUmpPWGd5ZURCbmNqaDNVMmNyWkRGQ2RWWnpOMEZYU1RaNFR6ZzBSVXRyZVdsQk9WTTBUWGhxVlZsQ1UwMTRabGcxZDNBM2RtTnNDbFpXSzNOa2JtaERObE5yVnpOS1RURkxaME40Y1ZobVpFMXNOaXR3Um1OcksyTjNkVEpIU1dRMmRHMW5jVEIwVm5sUlVXRkhhMUk1YzB4MGFtNUhkM0FLUkU4MU5YaE1ObTFZV0dkU01sWmplalIyUzB0bVdFd3JWMGREYjBoRWEyeEJkWGxWUm1GUE0ycFJNak5TT0dsQ2RtNUxiRk0yTldjM2NqWjRObWh3ZVFvNGJ6UlZWM1JqZUc5V2NGbHBhME5PUWpaMVZuVjZZVTl6T1hBNFdFZDFWSEl4ZFhNM2VEaDNXbFZ2SzJaSWFVOXlWSHByT1dWUmRqaEdUamRZTkZGRENtOUxXRlJVZUVsa1kwSXdWVGgxVWxaa01tRlZiMFYxZHpkeE9XVXhjWE5IWTI4MlZ5OVhaVGRSYjJjelJXazFNbTFtWXpkSFRVeHBla2RPV1VwTWJtZ0tOa3BOUmxCc1FUaDFaRFo1SzBKU1UxQnRWVlo2VXpCRlpuWjNabmg1WTJsV2IxTkxkWEI1VFZOWFkwazBjRVk0ZERBNFduUlBVa1JtUjBOcWNGbFdUUXB4VUhGMlEydDNVbTF5TTFFMFVIcE5NVzlLTDI1blZISkhhbVpTU2twSVdFZGxWa05SY0hCMFRVRkxWR0ZCVVZwd01tdERaMmRGUWtGUVNuQnFkREZrQ2xJeWQwdE5Ua0kxYURObVJEZEpUbWhQWm01dVdTczVNM1o1UlVWVFJXWjJWbWRhVXpGNFZtOW1aMWRMZUdwQ2JFdDFOblZxT0habU5HRkRlWGR1TVhRS2VVazBlV2xuVmpSbU1qTmljWFJoZFhCVFlqaEVZWGxwY0d0QmMxcDBhSGswVkcxeU55ODVWRGxtYlM5WFlURmtMMlp6TmxZMFlYRlZNMFJaVmxoS2RBcFZNR2M1Y0dORE16ZDFSV0pvYjJoT1ZFVmpVSFF3V21kbVdtaDJiV1JOWWxFNVZqQlJRa2hFZVdZMFNHaHNOVGxCWm5wTE5tRlBiWGd5YUdkNVZEbEVDbEZrV2pGbU0xaHpka1l3WmtNeGFYQklNSEpaZG1sSGRWcFpXa0pZYURrNVdYRkxWVXROV2pGelFrOTJiRzFKVDFJNWMwbEthSFJJWkU5NlRsUldhM1VLV2pWdVRrVmxkR3A0VmpkWmRFWlRZVmxuVG1wWVRGVmFaR3BwUzNCQk9YQjBjamd5VEdWTlJISXJRbk53WVhCM1FrTnlVbTlpTkdnMlZGSjJZMkpvTVFveU9FUkNPV1pWT1RGUWJrOTJkMVZEWjJkRlFrRk5kRVl6YWk5eVRuUnFjWGQyTlUxTWRGbEJTV0Z2VFZVdmJqSktWR3huTWt0Sk1qZDRVemh3ZUc5a0NsZHZaM1puY205S1lYY3haV2hHYW5sV1MxTlNSbU5VYjA1S1NYaDNlV0pzUlZCdU0xbGhlWEJOTUhoRlRESTJjblIxTWpCSE9IWkxVelJKV1V0cWMzUUtkV05UTVZwMlZGTXpNVzFtWm0xbVJXNTJiR3h3UW05YVpUbHJaVXBSVkdaeVQzTlZRazlrT0RBeFJ6VnFWRVZPVEhoWWFWSkVhVWRuYnpKd1dqaHNSd3ByTWpSVFFuZEVVblZOY0c4NFdHUndkeXRIUmk5M2JESkJTVGhQTTNoVWVETlRabE5IS3pOa1ZFZGxNMGxEYzNkUGVuTklXR0ZPUlRjemJVNU5iakkyQ2xkelpFOVlkM1pOVWpkTVpGWnZUMlUwZVZsSFF6RnZlWFJyZVdSVlRHWkhiSEpSUlRoclkwTjRSRXAwVGk5c1ZVVkVka3RRTHpSNlVEVnVNbGRPUzBnS2FuWkRaRmx4V0hSRGVVdGxWV295Y3k5WWFpdDFZbnAyVlhORldWZEZkQzlVUTNkclN6WnRTVEpsYzBOblowVkJWMEl4UTJwMmFIWkZOMmxKYTJRM05nb3ZUeXM0YzNWNlQyUkRXa1o2ZVM5S2VUWnBVVEZaVlV3d1psTmxkR1YwY21zemQydEhhMlJNTW1OTFpVSnJPVEExYTB4VlN6RXJVMlpSTW13eVpVMDBDaTl4WmxGaE5GUkZRakl5Y2xWemN6Qm1lazFyYkhoNk5pOVZiV2RVVlVWd2MyZFNOa0p0YVZvdk5ETjJZbk5ZVHpKeUwyOUlNVmhhTldaS2VXODJRelFLVG1nNFdsRmpXa2hMWWxaMWRYbG5jblo0VFdnMlVHbExTMkpoT1RaNlkzUXplV0pDUlhWMVFtOHlMMjFwVmxGQlR6bExhV3hHY0ZGUWFrbHlhVXRRY1FwMlJHRnBiWHBIZFdKRWFHOTBSR3dyVFdSVWF6YzNSbFl2ZURZemVUVjJVSGwyWjFOUk9GcEtTRVJpVlVWNWNHZFBRWFJSVTBaQ2VqTkNXVTF2TTBZMkNuUnpWWGxzTWxsbGNHNXBhSEJFY1VSSVNEVlpjMFJ0VHpobFdYaDFPR3RHVkhsQ2RTODBjMFZIVFZKdFpFbFNSRVJ2Y0V3elpUaEtWMEZIYnpnclNISUtNMjV1YlU5UlMwTkJVVUpwY2xGdlZYTldVWGQyVGxodWNVbG1ZamR5YUc4eVp6aDRLMjFHWW14Nk0xTnJVMUpEVW5OdkwycFNlRlJ0SzNsNk4zSndMd3BDVUVSMVZrMVVkVVpzWjJjdlF5ODFRVUp6YVVkSVZFUlJNbTEzTjFodmRtWmlTV2MwVlRaME1sazNZM2RPYTJrd1ExSkJSV2hTY0M5Nk1UVm1OWGhaQ2pNeWJqTmhZVlpoYjBKTGJtTk9UMFZPU0ZBMFFqZFVhbU5TV205WlZtOWpRa0l3WTFGTVFXOTVWM2RuYmtoMGJqRlhURU5tU0ZrMVMzQnpiblJMWTJ3S05uZGxPREZwVkRKd05YVkZkR3B1VkU5SU4yMXdabkZpZVVFd2VYcFJhVFJIUm1WUVdEVjVRa3hVVVhobE9XUmphRVZUVFdOQ2FEbFJMMmQ2ZFM5cVlRcFNWVkZ2U2sxMFZIVXZPWEY1T0RsbVNtTmlNMVF6YmpnM1lVaElRWFp5U0VZcmJtbExVVXQzV1RVdmNFRkhkbEpwTlhKWGNVZFBiRkJ0UjFNNWNEQXZDazExWm5Sa1RIRm1URGxvZFdSVFkxSkJXVnB5VEN0TFJWVjRTeklyS3pNNVFXOUpRa0ZSUkZaa2IwYzRaM0o1VVZSdWRuWjViekF3ZDJSdGNFOU9kV0VLTm5WTEt6Wm5TRTU1ZUZjeVNFODRaWEJoVDJOdEsyUkJORzV2YURobWVXUm5RMlpHU21SdWRrcHlkMFpHTVhKb01VbGlZazAzY1hKQlRXMXVZbFZKWmdwS1dqVnhUVVE0TURCR2IybzNSVmh0UmxSemIzZERMMW93YTJOdmRsZFVRbk4zY1doaFRqSnRkMVl5YXpKUFQwNUZPVU5CYmxSR2RsaHNlVnByTlZWaENrRTNWRUZ6YkN0U2JrazJOMWg2VTJGME0ySXdVazVMVDFGa1YyWklZbWhqU1RSNmJqaHdhMHhUVW0wck1UZHRVWE5DWm5SSVRHNXJVRkZxUm5WUFVYY0tkRlpJVFZFelZEVTRPUzlOUVd4NVVsSlVWRkJUVUVvMVVVTXpNVzg1YkhocldrY3lNWE5CUTNoQ2VtbHRVSEJhVWpoTVdHMUtZVUV5YzNCa1lVTlVXQW94Um1aNU1EQlNRalJOZWxaV2VrNXhaSGszV1haTWQyYzFlRzFKZG1aQmRXZ3labXd2WlhNclNsZGhWVFZIU0hkSmFHaEJWakJWV21kYVdVa0tMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogbVA1aXZSd09MeGxlVlRNbFZDVWh4TnVoVlJUbU1Kb2lPRmN6NW82empKMXZjUmFDcmhjY0MxOFhvVEFybDBVUHJibUdKeEkwd1BmUTRaclM0aGY2SzI0Zk9aN3hCMXNqc0JHbHY4VE0yWVMwRlF3VmpKZGhGMXQ3c0hTSVpXMVQK\"\n  }\n }"
-    }
-  }, {
-    "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser/listCredential?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:09 GMT",
-      "server" : "nginx",
-      "content-length" : "13113",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1198",
-      "retry-after" : "0",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ea33d08a-c883-49f7-9fe2-5d6629b8923c",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050209Z:ea33d08a-c883-49f7-9fe2-5d6629b8923c",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "47c0c325-afec-4b15-9236-5abaa0ffd1ae",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgbmFtZTogYWtzNzU4OTk5CmN1cnJlbnQtY29udGV4dDogYWtzNzU4OTk5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVdlJFTkRRWFZUWjBGM1NVSkJaMGxSWVVGRVJXUkhjbHBMZDNWMloxUnRVME5yVlVsc1JFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNSGxOVkVWM1RXcEpkMDVFVVROTmFsSmhUVVJCZUFwR2VrRldRbWRPVmtKQmIxUkViazQxWXpOU2JHSlVjSFJaV0U0d1dsaEtlazFTVlhkRmQxbEVWbEZSUkVWM2VIUlpXRTR3V2xoS2FtSkhiR3hpYmxGM0NtZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSQlpUa3dlRWQ2Y1RoSGMza3pVM1JNVmpkSWIxb0tXRFV3THl0V1ltSk9OQ3RWTTJKbVNEWXlhM1pDVW5wUGJteDNXa0Z2ZWpacVdsVXpOVXQwWXpVeFdGWk9ZV1FyVGxoUmQxRlJTbXRVY0VKV1dYWktOUXBpWkRKS1JuSk5iREEwV21JeGJUZGtkR0p2ZVdWc0x6Tk5PRlJCTVZwclNIVjBjQzh5S3pseFRVTXJjMUJHZGxCNlR6bG9NbTV3UW05emJXTjBRVm92Q2pkbkwwSlhkRk41YldSWFdrWm9jMHR3Y205SE9UUm1jak5WYXpjNWJqazFiRWszUzIxNmMzbGlhSFZQVUdJcllWTnZjR3BKTkhSQlRsSkhXVGQ2VWxBS2JHZHRZV05DYzNoSFpuTk1lWG8yTUZONk9XdENiV2hKYkhKSVV6SlVRemx6ZW5sVk1EYzNXV1o0VG5GMFp6QktaMnQwVlVGS1Z6Sk1abWxUV0d4MWNncFNiak5UYWpoRVJEZHZVRk52ZUZSSWNYSTFaa2hRV0RkRFRsUndNV2d5WW5ad01FRXZTSGhtZUVka1drRjZaVGN3TkV4YWVEQlFWbUZ6UWxKbk1GUm9Dazk1VlZvMk9YRXZVM0J0Ym5CaVYzaHFZWEZuTUVvNU5EVm9VVTlNZGpKMU1tbFBSbkYyVFZZMGVVdDBMemhXTDNsM2REbDZaVk4zTkVVNU5IQktSREVLUTFCdk9XeHZkV3BDTHpZeGVVcDBPVmxKWnpWclUxaGhaVTVIU0VaYU1HbFJOMVZKYTBaU09FVkRUR1JtV0Vsa05sVXpaRmM0WlhSWlUybHBTU3RaV1FwelJVUTBkSEZRUkdWRmR6RllTbkpFU1ZGMVdqRkJNVEUxYm5Oc1ZHaFJSRnBTUldrcllrWTRlblE1TVU1Rk1IcGtkaTlMYTNSMVpHbzRhbGhvVG5oVENtdGFia1JTWWtRclN6TldOV0k1T0VnMmVHWmpWMDV4UTFkRlF6TTNkMlZWWVdoVE5rUkNlRXhyVWxvdk9EVXlTV1JQTlV4ck5UTlNVVEpVVTJaNGEyVUtNRTF5YmxVeFYycGtkMFZoVXk5c1lsSnZRa2RtVEdkeE9VOVFSM1ZRV1dST1RXaElXa2t4VGk5aFEyNXlSMjFDVWxSb05EQlJPR04xYW5aM2NUWlZOQW95VVVGaFpsUktkWHBGVWpGRGExbEpWMFo1VjJ4M1NVUkJVVUZDYjNwVmQwMTZRVTlDWjA1V1NGRTRRa0ZtT0VWQ1FVMURRbUZCZDBWM1dVUldVakJzQ2tKQmQzZERaMWxKUzNkWlFrSlJWVWhCZDBsM1JFRlpSRlpTTUZSQlVVZ3ZRa0ZKZDBGRVFVNUNaMnR4YUd0cFJ6bDNNRUpCVVhOR1FVRlBRMEZuUlVFS2EzbFhTa2xJZURNMVdVZG5jWEY1WjNBM2FGbE1UMlJCTkhGWVZIcFBjMVpSY3l0V01rTnRaelpIWVZnMmNuUkZkV0pxYVdOdlZXSTJXbE5xVG1wNFR3cDJiVWxUUTJZemJUQXpWbmRUTlVzd2FuZEJkRk0xU0hCclJVcDJaMDVFV2tVdk4zWkVjMEpSTUV0U1MxZDVlbk40TjNKaVRGQlJlR1IyVDFwM1kzbzJDamxFT1RGR2RtbE9jbGgyWkZSWmJscGFOMHNyVWpWNGVqWkpNbTFETldGTlpFUmFhM05MYlRsSVNrRm9XbXBpWVRWall5OXhkbmsxUzJ4c1JsZFRhazRLUjFWemNtZzRORnA0ZGl0Q2RESnRhM2t4Y0RoRldXUlFibHB4U0VsQllrOUhTR0pEY0cxcWExZFJhamhQV0dwVmEydGhVR2t3VUZkaldraE9LMnBtU3dwRlUzWkdkR2x4TlVaME1rcDFVVlJMYUhwNFpEa3hLMngwTnk5RlRWTlNTRzUzUmpjeGIxazBTbFU0TjJwb2JuZ3lSaXQzVVc5UGJHZHZSMkowVXpaWUNtdFRRbTVqWm5CemR6ZFRNVWR3TVc1MVQySlZPRmxxWlRWVlZEWndRVnB2ZW5Vek5rZDNaVkJuYzFBMVZWVnBkM2x2ZWs1SWNHcHhNbEJCZVV0SFRXUUtWblo2VEVWeWJtUkNkbEp0V1hSTFNrVjRWa1JMU0VwMGRuVkZjVE5yZUZGTFJIZHpiMUJaT1VoMlJtdFZiVVYzYm5NNGJsUkljVXhqTkdWNlJVOUVid3BRUTBGQldqVnpjMmd6YzJOS1dDOXZSMEZGVGtSMFFVOTJTbkV4Y0doMmVHaHljVk5xWW5CbVlsRjNXWEEzVm05T1dGZE5SRTFvVUhwbFJHUnVSbHBLQ21Jd00yVXpiaXROVDBVMVdqRTVSbWMwV0dGVGEzSTBjMVZ4VGl0SGFVTnBOVGxMWTJseWVWZzFXSGR6UjBaUlFYWlFhMUYxZWxwbk5EQnZPR2hwWkhJS01TOU5lV0pZY2twNFJERXZLMlJZT0RGcFowTjFOVm95YVd0NEwzb3ZXbHAwVVZSdU4wODNVRkZaWW14Q2IyaG9ZVXRUVkdKRVdVTmljVFZpYkhOV2NBcHVWWGsxWW1ocVduRmxTV05FYkROWVpsWmtkVmhaU0U1U1dVSlFSazVIVjJGMVNISmlaWE5EWVhOWlBRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLUzFGSlFrRkJTME5CWjBWQmQwaDJaRTFTY3paMlFuSk5kREJ5VXpGbGVEWkhWaXRrVUM5c1Z6SjZaVkJzVGpJemVDdDBjRXgzVldONmNEVmpDa2RSUzAwcmJ6SldUaXRUY2xoUFpGWXhWRmR1Wm1wV01FMUZSVU5hUlRaUlZsZE1lV1ZYTTJScFVtRjZTbVJQUjFjNVduVXpZbGMyVFc1d1pqbDZVRVVLZDA1WFdrSTNjbUZtT1haMllXcEJkbkpFZUdKNk9IcDJXV1J3TmxGaFRFcHVURkZIWmlzMFVIZFdjbFZ6Y0c1V2JWSlpZa054WVRaQ2RtVklOamt4U2dwUEwxb3ZaVnBUVDNsd2N6ZE5iVFJpYW1veUwyMXJjVXRaZVU5TVVVUlZVbTFQT0RCVU5WbEtiVzVCWWsxU2JqZERPSE1yZEVWekwxcEJXbTlUU21GNENqQjBhM2QyWWswNGJFNVBLekpJT0ZSaGNsbE9RMWxLVEZaQlExWjBhVE0wYTJ3MVluRXdXamt3Ynk5QmR5czJSREJ4VFZWNE5uRXJXSGg2TVN0M2FsVUtObVJaWkcwM05tUkJVSGc0V0RoU2JsZFJUVE4xT1U5RE1tTmtSREZYY2tGVldVNUZORlJ6YkVkbGRtRjJNSEZhY0RaWE1YTlpNbkZ2VGtObVpVOVpWUXBFYVRjNWNuUnZhbWhoY25wR1pVMXBjbVl2Um1ZNGMweG1Zek5yYzA5Q1VHVkxVMUU1VVdvMlVGcGhURzkzWml0MFkybGlabGREU1U5YVJXd3libXBTQ21oNFYyUkphMDh4UTBwQ1ZXWkNRV2t6V0RGNVNHVnNUak5XZGtoeVYwVnZiMmxRYlVkTVFrRXJUR0ZxZHpOb1RVNVdlV0YzZVVWTWJXUlJUbVJsV2pjS1NsVTBWVUV5VlZKSmRtMTRaazAzWm1SVVVrNU5NMkl2ZVhCTVltNVpMMGt4TkZSalZYQkhXbmN3VjNjdmFYUXhaVmN2WmtJcmMxZ3pSbXBoWjJ4b1FRcDBLemhJYkVkdlZYVm5kMk5UTlVWWFppOVBaR2xJVkhWVE5VOWtNRlZPYXpCdU9GcElkRVJMTlRGT1ZtOHpZMEpIYTNZMVZ6QmhRVkp1ZVRSTGRsUnFDbmh5YWpKSVZGUkpVakpUVGxSbU1tZHdObmh3WjFWVk5HVk9SVkJJVEc4M09FdDFiRTlPYTBGSGJqQjVZbk40UldSUmNFZERSbWhqYkhCalEwRjNSVUVLUVZGTFEwRm5SVUYwZG1aSVJHSjJaR1pDZEZwb09EUXpWbWxUUVN0QlpXTmxZMmg0VjA1aFlYaEtOWGcyVkdOTlpVTmhOaXRIYTNWRlNsRk9TVTF3WmdwRmJ6bHhiVlpvU21wbE9TOTBTV1p3VmpCcmEyeGxZbU5oYkRSNFRWWTFVRWhPV1ZsSGVHWlVLM2MxT1hWdlJGcGhjM2hMTVhKbkswTnFVRUZWVFcwNENtczFaV3RKUjA5SWJsbHBUMjFhZDNJelR5dExSVlZTUm5NMVEzQk5VV2hDY2poSVFYUTNiR3huYVhsNVRHUkVTWFZ2UTI1cmJuZzFPV1ZpWkhrNWREZ0tWa2hzTUhKMk5XUmpWSFZtUnpOS1NqQXJNV2R0TDNOWFRFUk5UbTVoTVRSdFdHRkNWVzgxYjNob1FrRklZUzg1Y0ZBME1rOVFTVTlRVDJjMU0yTnJOQXBEUW5sNmNVTlpOMlJqT1hneWVEQm5jamgzVTJjclpERkNkVlp6TjBGWFNUWjRUemcwUlV0cmVXbEJPVk0wVFhocVZWbENVMDE0WmxnMWQzQTNkbU5zQ2xaV0szTmtibWhETmxOclZ6TktUVEZMWjBONGNWaG1aRTFzTml0d1JtTnJLMk4zZFRKSFNXUTJkRzFuY1RCMFZubFJVV0ZIYTFJNWMweDBhbTVIZDNBS1JFODFOWGhNTm0xWVdHZFNNbFpqZWpSMlMwdG1XRXdyVjBkRGIwaEVhMnhCZFhsVlJtRlBNMnBSTWpOU09HbENkbTVMYkZNMk5XYzNjalo0Tm1od2VRbzRielJWVjNSamVHOVdjRmxwYTBOT1FqWjFWblY2WVU5ek9YQTRXRWQxVkhJeGRYTTNlRGgzV2xWdksyWklhVTl5Vkhwck9XVlJkamhHVGpkWU5GRkRDbTlMV0ZSVWVFbGtZMEl3VlRoMVVsWmtNbUZWYjBWMWR6ZHhPV1V4Y1hOSFkyODJWeTlYWlRkUmIyY3pSV2sxTW0xbVl6ZEhUVXhwZWtkT1dVcE1ibWdLTmtwTlJsQnNRVGgxWkRaNUswSlNVMUJ0VlZaNlV6QkZablozWm5oNVkybFdiMU5MZFhCNVRWTlhZMGswY0VZNGREQTRXblJQVWtSbVIwTnFjRmxXVFFweFVIRjJRMnQzVW0xeU0xRTBVSHBOTVc5S0wyNW5WSEpIYW1aU1NrcElXRWRsVmtOUmNIQjBUVUZMVkdGQlVWcHdNbXREWjJkRlFrRlFTbkJxZERGa0NsSXlkMHROVGtJMWFETm1SRGRKVG1oUFptNXVXU3M1TTNaNVJVVlRSV1oyVm1kYVV6RjRWbTltWjFkTGVHcENiRXQxTm5WcU9IWm1OR0ZEZVhkdU1YUUtlVWswZVdsblZqUm1Nak5pY1hSaGRYQlRZamhFWVhscGNHdEJjMXAwYUhrMFZHMXlOeTg1VkRsbWJTOVhZVEZrTDJaek5sWTBZWEZWTTBSWlZsaEtkQXBWTUdjNWNHTkRNemQxUldKb2IyaE9WRVZqVUhRd1dtZG1XbWgyYldSTllsRTVWakJSUWtoRWVXWTBTR2hzTlRsQlpucExObUZQYlhneWFHZDVWRGxFQ2xGa1dqRm1NMWh6ZGtZd1prTXhhWEJJTUhKWmRtbEhkVnBaV2tKWWFEazVXWEZMVlV0TldqRnpRazkyYkcxSlQxSTVjMGxLYUhSSVpFOTZUbFJXYTNVS1dqVnVUa1ZsZEdwNFZqZFpkRVpUWVZsblRtcFlURlZhWkdwcFMzQkJPWEIwY2pneVRHVk5SSElyUW5Od1lYQjNRa055VW05aU5HZzJWRkoyWTJKb01Rb3lPRVJDT1daVk9URlFiazkyZDFWRFoyZEZRa0ZOZEVZemFpOXlUblJxY1hkMk5VMU1kRmxCU1dGdlRWVXZiakpLVkd4bk1rdEpNamQ0VXpod2VHOWtDbGR2WjNabmNtOUtZWGN4WldoR2FubFdTMU5TUm1OVWIwNUtTWGgzZVdKc1JWQnVNMWxoZVhCTk1IaEZUREkyY25SMU1qQkhPSFpMVXpSSldVdHFjM1FLZFdOVE1WcDJWRk16TVcxbVptMW1SVzUyYkd4d1FtOWFaVGxyWlVwUlZHWnlUM05WUWs5a09EQXhSelZxVkVWT1RIaFlhVkpFYVVkbmJ6SndXamhzUndwck1qUlRRbmRFVW5WTmNHODRXR1J3ZHl0SFJpOTNiREpCU1RoUE0zaFVlRE5UWmxOSEt6TmtWRWRsTTBsRGMzZFBlbk5JV0dGT1JUY3piVTVOYmpJMkNsZHpaRTlZZDNaTlVqZE1aRlp2VDJVMGVWbEhRekZ2ZVhScmVXUlZUR1pIYkhKUlJUaHJZME40UkVwMFRpOXNWVVZFZGt0UUx6UjZVRFZ1TWxkT1MwZ0thblpEWkZseFdIUkRlVXRsVldveWN5OVlhaXQxWW5wMlZYTkZXVmRGZEM5VVEzZHJTelp0U1RKbGMwTm5aMFZCVjBJeFEycDJhSFpGTjJsSmEyUTNOZ292VHlzNGMzVjZUMlJEV2taNmVTOUtlVFpwVVRGWlZVd3dabE5sZEdWMGNtc3pkMnRIYTJSTU1tTkxaVUpyT1RBMWEweFZTekVyVTJaUk1td3laVTAwQ2k5eFpsRmhORlJGUWpJeWNsVnpjekJtZWsxcmJIaDZOaTlWYldkVVZVVndjMmRTTmtKdGFWb3ZORE4yWW5OWVR6SnlMMjlJTVZoYU5XWktlVzgyUXpRS1RtZzRXbEZqV2toTFlsWjFkWGxuY25aNFRXZzJVR2xMUzJKaE9UWjZZM1F6ZVdKQ1JYVjFRbTh5TDIxcFZsRkJUemxMYVd4R2NGRlFha2x5YVV0UWNRcDJSR0ZwYlhwSGRXSkVhRzkwUkd3clRXUlVhemMzUmxZdmVEWXplVFYyVUhsMloxTlJPRnBLU0VSaVZVVjVjR2RQUVhSUlUwWkNlak5DV1Uxdk0wWTJDblJ6Vlhsc01sbGxjRzVwYUhCRWNVUklTRFZaYzBSdFR6aGxXWGgxT0d0R1ZIbENkUzgwYzBWSFRWSnRaRWxTUkVSdmNFd3paVGhLVjBGSGJ6Z3JTSElLTTI1dWJVOVJTME5CVVVKcGNsRnZWWE5XVVhkMlRsaHVjVWxtWWpkeWFHOHlaemg0SzIxR1lteDZNMU5yVTFKRFVuTnZMMnBTZUZSdEszbDZOM0p3THdwQ1VFUjFWazFVZFVac1oyY3ZReTgxUVVKemFVZElWRVJSTW0xM04xaHZkbVppU1djMFZUWjBNbGszWTNkT2Eya3dRMUpCUldoU2NDOTZNVFZtTlhoWkNqTXliak5oWVZaaGIwSkxibU5PVDBWT1NGQTBRamRVYW1OU1dtOVpWbTlqUWtJd1kxRk1RVzk1VjNkbmJraDBiakZYVEVObVNGazFTM0J6Ym5STFkyd0tObmRsT0RGcFZESndOWFZGZEdwdVZFOUlOMjF3Wm5GaWVVRXdlWHBSYVRSSFJtVlFXRFY1UWt4VVVYaGxPV1JqYUVWVFRXTkNhRGxSTDJkNmRTOXFZUXBTVlZGdlNrMTBWSFV2T1hGNU9EbG1TbU5pTTFRemJqZzNZVWhJUVhaeVNFWXJibWxMVVV0M1dUVXZjRUZIZGxKcE5YSlhjVWRQYkZCdFIxTTVjREF2Q2sxMVpuUmtUSEZtVERsb2RXUlRZMUpCV1ZweVRDdExSVlY0U3pJckt6TTVRVzlKUWtGUlJGWmtiMGM0WjNKNVVWUnVkblo1YnpBd2QyUnRjRTlPZFdFS05uVkxLelpuU0U1NWVGY3lTRTg0WlhCaFQyTnRLMlJCTkc1dmFEaG1lV1JuUTJaR1NtUnVka3B5ZDBaR01YSm9NVWxpWWswM2NYSkJUVzF1WWxWSlpncEtXalZ4VFVRNE1EQkdiMm8zUlZodFJsUnpiM2RETDFvd2EyTnZkbGRVUW5OM2NXaGhUakp0ZDFZeWF6SlBUMDVGT1VOQmJsUkdkbGhzZVZwck5WVmhDa0UzVkVGemJDdFNia2syTjFoNlUyRjBNMkl3VWs1TFQxRmtWMlpJWW1oalNUUjZiamh3YTB4VFVtMHJNVGR0VVhOQ1puUklURzVyVUZGcVJuVlBVWGNLZEZaSVRWRXpWRFU0T1M5TlFXeDVVbEpVVkZCVFVFbzFVVU16TVc4NWJIaHJXa2N5TVhOQlEzaENlbWx0VUhCYVVqaE1XRzFLWVVFeWMzQmtZVU5VV0FveFJtWjVNREJTUWpSTmVsWldlazV4WkhrM1dYWk1kMmMxZUcxSmRtWkJkV2d5Wm13dlpYTXJTbGRoVlRWSFNIZEphR2hCVmpCVldtZGFXVWtLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IHNCVFoxeWdDcjYxN0pJMTNodlNoVmFFcndNZmxFY21XSWFxdE9xMFBvOWhwYzI0SXZDQ3dGWmpwbW9hcUpBZU1tUWxZTVRaNjZ0ZG9lMllrM1ZzeHRoYTVwUDdmbjNKRWFLSkdwVmdIWjhEdTNuMXQyN0RvZ2t0dUI2VFM1eUExCg==\"\n  }\n }"
+      "x-ms-request-id" : "e13c7bc7-4e66-474f-b793-31c107d31dc4",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-ae130410-4a26-4259-b84f-d5543899e342/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:09 GMT",
-      "server" : "nginx",
-      "content-length" : "1743",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11931",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "45ef8b39-dbcf-4750-b6d5-b70caaa5196e",
+      "x-ms-correlation-request-id" : "1b95a1f0-ffce-4356-812b-dc3f083e4b15",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050210Z:45ef8b39-dbcf-4750-b6d5-b70caaa5196e",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:1b95a1f0-ffce-4356-812b-dc3f083e4b15",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "d51908ef-5a10-4a5c-bfba-f6111b066c5e",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
-    }
-  }, {
-    "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin/listCredential?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:10 GMT",
-      "server" : "nginx",
-      "content-length" : "13115",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1197",
-      "retry-after" : "0",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6b46b9cd-0147-4238-a04b-9ce707dc1db1",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050211Z:6b46b9cd-0147-4238-a04b-9ce707dc1db1",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "327c93af-7ab5-4eab-b2a7-1cfc3cb09cb1",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterAdmin\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlckFkbWluX2Frczc1ODk5OWdyb3VwX2Frczc1ODk5OQogIG5hbWU6IGFrczc1ODk5OQpjdXJyZW50LWNvbnRleHQ6IGFrczc1ODk5OQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJBZG1pbl9ha3M3NTg5OTlncm91cF9ha3M3NTg5OTkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJZVUZFUldSSGNscExkM1YyWjFSdFUwTnJWVWxzUkVGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNFQxUkZkMDFxVFhkT1JFMHpUV3BTWVVaM01IbE5WRVYzVFdwSmQwNUVVVE5OYWxKaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJCWlRrd2VFZDZjVGhIYzNrelUzUk1WamRJYjFvS1dEVXdMeXRXWW1KT05DdFZNMkptU0RZeWEzWkNVbnBQYm14M1drRnZlalpxV2xVek5VdDBZelV4V0ZaT1lXUXJUbGhSZDFGUlNtdFVjRUpXV1haS05RcGlaREpLUm5KTmJEQTBXbUl4YlRka2RHSnZlV1ZzTHpOTk9GUkJNVnByU0hWMGNDOHlLemx4VFVNcmMxQkdkbEI2VHpsb01tNXdRbTl6YldOMFFWb3ZDamRuTDBKWGRGTjViV1JYV2tab2MwdHdjbTlIT1RSbWNqTlZhemM1YmprMWJFazNTMjE2YzNsaWFIVlBVR0lyWVZOdmNHcEpOSFJCVGxKSFdUZDZVbEFLYkdkdFlXTkNjM2hIWm5OTWVYbzJNRk42T1d0Q2JXaEpiSEpJVXpKVVF6bHplbmxWTURjM1dXWjRUbkYwWnpCS1oydDBWVUZLVnpKTVptbFRXR3gxY2dwU2JqTlRhamhFUkRkdlVGTnZlRlJJY1hJMVpraFFXRGREVGxSd01XZ3lZblp3TUVFdlNIaG1lRWRrV2tGNlpUY3dORXhhZURCUVZtRnpRbEpuTUZSb0NrOTVWVm8yT1hFdlUzQnRibkJpVjNocVlYRm5NRW81TkRWb1VVOU1kakoxTW1sUFJuRjJUVlkwZVV0MEx6aFdMM2wzZERsNlpWTjNORVU1TkhCS1JERUtRMUJ2T1d4dmRXcENMell4ZVVwME9WbEpaelZyVTFoaFpVNUhTRVphTUdsUk4xVkphMFpTT0VWRFRHUm1XRWxrTmxVelpGYzRaWFJaVTJscFNTdFpXUXB6UlVRMGRIRlFSR1ZGZHpGWVNuSkVTVkYxV2pGQk1URTFibk5zVkdoUlJGcFNSV2tyWWtZNGVuUTVNVTVGTUhwa2RpOUxhM1IxWkdvNGFsaG9UbmhUQ210YWJrUlNZa1FyU3pOV05XSTVPRWcyZUdaalYwNXhRMWRGUXpNM2QyVlZZV2hUTmtSQ2VFeHJVbG92T0RVeVNXUlBOVXhyTlROU1VUSlVVMlo0YTJVS01FMXlibFV4VjJwa2QwVmhVeTlzWWxKdlFrZG1UR2R4T1U5UVIzVlFXV1JPVFdoSVdra3hUaTloUTI1eVIyMUNVbFJvTkRCUk9HTjFhblozY1RaVk5Bb3lVVUZoWmxSS2RYcEZVakZEYTFsSlYwWjVWMngzU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLYTNsWFNrbEllRE0xV1VkbmNYRjVaM0EzYUZsTVQyUkJOSEZZVkhwUGMxWlJjeXRXTWtOdFp6WkhZVmcyY25SRmRXSnFhV052VldJMldsTnFUbXA0VHdwMmJVbFRRMll6YlRBelZuZFROVXN3YW5kQmRGTTFTSEJyUlVwMlowNUVXa1V2TjNaRWMwSlJNRXRTUzFkNWVuTjROM0ppVEZCUmVHUjJUMXAzWTNvMkNqbEVPVEZHZG1sT2NsaDJaRlJaYmxwYU4wc3JValY0ZWpaSk1tMUROV0ZOWkVSYWEzTkxiVGxJU2tGb1dtcGlZVFZqWXk5eGRuazFTMnhzUmxkVGFrNEtSMVZ6Y21nNE5GcDRkaXRDZERKdGEza3hjRGhGV1dSUWJscHhTRWxCWWs5SFNHSkRjRzFxYTFkUmFqaFBXR3BWYTJ0aFVHa3dVRmRqV2toT0sycG1Td3BGVTNaR2RHbHhOVVowTWtwMVVWUkxhSHA0WkRreEsyeDBOeTlGVFZOU1NHNTNSamN4YjFrMFNsVTROMnBvYm5neVJpdDNVVzlQYkdkdlIySjBVelpZQ210VFFtNWpabkJ6ZHpkVE1VZHdNVzUxVDJKVk9GbHFaVFZWVkRad1FWcHZlblV6TmtkM1pWQm5jMUExVlZWcGQzbHZlazVJY0dweE1sQkJlVXRIVFdRS1ZuWjZURVZ5Ym1SQ2RsSnRXWFJMU2tWNFZrUkxTRXAwZG5WRmNUTnJlRkZMUkhkemIxQlpPVWgyUm10VmJVVjNibk00YmxSSWNVeGpOR1Y2UlU5RWJ3cFFRMEZCV2pWemMyZ3pjMk5LV0M5dlIwRkZUa1IwUVU5MlNuRXhjR2gyZUdoeWNWTnFZbkJtWWxGM1dYQTNWbTlPV0ZkTlJFMW9VSHBsUkdSdVJscEtDbUl3TTJVemJpdE5UMFUxV2pFNVJtYzBXR0ZUYTNJMGMxVnhUaXRIYVVOcE5UbExZMmx5ZVZnMVdIZHpSMFpSUVhaUWExRjFlbHBuTkRCdk9HaHBaSElLTVM5TmVXSllja3A0UkRFdksyUllPREZwWjBOMU5Wb3lhV3Q0TDNvdldscDBVVlJ1TjA4M1VGRlpZbXhDYjJob1lVdFRWR0pFV1VOaWNUVmliSE5XY0FwdVZYazFZbWhxV25GbFNXTkViRE5ZWmxaa2RWaFpTRTVTV1VKUVJrNUhWMkYxU0hKaVpYTkRZWE5aUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZDBoMlpFMVNjeloyUW5KTmREQnlVekZsZURaSFZpdGtVQzlzVnpKNlpWQnNUakl6ZUN0MGNFeDNWV042Y0RWakNrZFJTMDByYnpKV1RpdFRjbGhQWkZZeFZGZHVabXBXTUUxRlJVTmFSVFpSVmxkTWVXVlhNMlJwVW1GNlNtUlBSMWM1V25VellsYzJUVzV3WmpsNlVFVUtkMDVYV2tJM2NtRm1PWFoyWVdwQmRuSkVlR0o2T0hwMldXUndObEZoVEVwdVRGRkhaaXMwVUhkV2NsVnpjRzVXYlZKWllrTnhZVFpDZG1WSU5qa3hTZ3BQTDFvdlpWcFRUM2x3Y3pkTmJUUmlhbW95TDIxcmNVdFplVTlNVVVSVlVtMVBPREJVTlZsS2JXNUJZazFTYmpkRE9ITXJkRVZ6TDFwQldtOVRTbUY0Q2pCMGEzZDJZazA0YkU1UEt6SklPRlJoY2xsT1ExbEtURlpCUTFaMGFUTTBhMncxWW5Fd1dqa3dieTlCZHlzMlJEQnhUVlY0Tm5FcldIaDZNU3QzYWxVS05tUlpaRzAzTm1SQlVIZzRXRGhTYmxkUlRUTjFPVTlETW1Oa1JERlhja0ZWV1U1Rk5GUnpiRWRsZG1GMk1IRmFjRFpYTVhOWk1uRnZUa05tWlU5WlZRcEVhVGM1Y25SdmFtaGhjbnBHWlUxcGNtWXZSbVk0YzB4bVl6TnJjMDlDVUdWTFUxRTVVV28yVUZwaFRHOTNaaXQwWTJsaVpsZERTVTlhUld3eWJtcFNDbWg0VjJSSmEwOHhRMHBDVldaQ1FXa3pXREY1U0dWc1RqTldka2h5VjBWdmIybFFiVWRNUWtFclRHRnFkek5vVFU1V2VXRjNlVVZNYldSUlRtUmxXamNLU2xVMFZVRXlWVkpKZG0xNFprMDNabVJVVWs1Tk0ySXZlWEJNWW01Wkwwa3hORlJqVlhCSFduY3dWM2N2YVhReFpWY3Zaa0lyYzFnelJtcGhaMnhvUVFwMEt6aEliRWR2VlhWbmQyTlROVVZYWmk5UFpHbElWSFZUTlU5a01GVk9hekJ1T0ZwSWRFUkxOVEZPVm04elkwSkhhM1kxVnpCaFFWSnVlVFJMZGxScUNuaHlhakpJVkZSSlVqSlRUbFJtTW1kd05uaHdaMVZWTkdWT1JWQklURzgzT0V0MWJFOU9hMEZIYmpCNVluTjRSV1JSY0VkRFJtaGpiSEJqUTBGM1JVRUtRVkZMUTBGblJVRjBkbVpJUkdKMlpHWkNkRnBvT0RRelZtbFRRU3RCWldObFkyaDRWMDVoWVhoS05YZzJWR05OWlVOaE5pdEhhM1ZGU2xGT1NVMXdaZ3BGYnpseGJWWm9TbXBsT1M5MFNXWndWakJyYTJ4bFltTmhiRFI0VFZZMVVFaE9XVmxIZUdaVUszYzFPWFZ2UkZwaGMzaExNWEpuSzBOcVVFRlZUVzA0Q21zMVpXdEpSMDlJYmxscFQyMWFkM0l6VHl0TFJWVlNSbk0xUTNCTlVXaENjamhJUVhRM2JHeG5hWGw1VEdSRVNYVnZRMjVyYm5nMU9XVmlaSGs1ZERnS1ZraHNNSEoyTldSalZIVm1Sek5LU2pBck1XZHRMM05YVEVSTlRtNWhNVFJ0V0dGQ1ZXODFiM2hvUWtGSVlTODVjRkEwTWs5UVNVOVFUMmMxTTJOck5BcERRbmw2Y1VOWk4yUmpPWGd5ZURCbmNqaDNVMmNyWkRGQ2RWWnpOMEZYU1RaNFR6ZzBSVXRyZVdsQk9WTTBUWGhxVlZsQ1UwMTRabGcxZDNBM2RtTnNDbFpXSzNOa2JtaERObE5yVnpOS1RURkxaME40Y1ZobVpFMXNOaXR3Um1OcksyTjNkVEpIU1dRMmRHMW5jVEIwVm5sUlVXRkhhMUk1YzB4MGFtNUhkM0FLUkU4MU5YaE1ObTFZV0dkU01sWmplalIyUzB0bVdFd3JWMGREYjBoRWEyeEJkWGxWUm1GUE0ycFJNak5TT0dsQ2RtNUxiRk0yTldjM2NqWjRObWh3ZVFvNGJ6UlZWM1JqZUc5V2NGbHBhME5PUWpaMVZuVjZZVTl6T1hBNFdFZDFWSEl4ZFhNM2VEaDNXbFZ2SzJaSWFVOXlWSHByT1dWUmRqaEdUamRZTkZGRENtOUxXRlJVZUVsa1kwSXdWVGgxVWxaa01tRlZiMFYxZHpkeE9XVXhjWE5IWTI4MlZ5OVhaVGRSYjJjelJXazFNbTFtWXpkSFRVeHBla2RPV1VwTWJtZ0tOa3BOUmxCc1FUaDFaRFo1SzBKU1UxQnRWVlo2VXpCRlpuWjNabmg1WTJsV2IxTkxkWEI1VFZOWFkwazBjRVk0ZERBNFduUlBVa1JtUjBOcWNGbFdUUXB4VUhGMlEydDNVbTF5TTFFMFVIcE5NVzlLTDI1blZISkhhbVpTU2twSVdFZGxWa05SY0hCMFRVRkxWR0ZCVVZwd01tdERaMmRGUWtGUVNuQnFkREZrQ2xJeWQwdE5Ua0kxYURObVJEZEpUbWhQWm01dVdTczVNM1o1UlVWVFJXWjJWbWRhVXpGNFZtOW1aMWRMZUdwQ2JFdDFOblZxT0habU5HRkRlWGR1TVhRS2VVazBlV2xuVmpSbU1qTmljWFJoZFhCVFlqaEVZWGxwY0d0QmMxcDBhSGswVkcxeU55ODVWRGxtYlM5WFlURmtMMlp6TmxZMFlYRlZNMFJaVmxoS2RBcFZNR2M1Y0dORE16ZDFSV0pvYjJoT1ZFVmpVSFF3V21kbVdtaDJiV1JOWWxFNVZqQlJRa2hFZVdZMFNHaHNOVGxCWm5wTE5tRlBiWGd5YUdkNVZEbEVDbEZrV2pGbU0xaHpka1l3WmtNeGFYQklNSEpaZG1sSGRWcFpXa0pZYURrNVdYRkxWVXROV2pGelFrOTJiRzFKVDFJNWMwbEthSFJJWkU5NlRsUldhM1VLV2pWdVRrVmxkR3A0VmpkWmRFWlRZVmxuVG1wWVRGVmFaR3BwUzNCQk9YQjBjamd5VEdWTlJISXJRbk53WVhCM1FrTnlVbTlpTkdnMlZGSjJZMkpvTVFveU9FUkNPV1pWT1RGUWJrOTJkMVZEWjJkRlFrRk5kRVl6YWk5eVRuUnFjWGQyTlUxTWRGbEJTV0Z2VFZVdmJqSktWR3huTWt0Sk1qZDRVemh3ZUc5a0NsZHZaM1puY205S1lYY3haV2hHYW5sV1MxTlNSbU5VYjA1S1NYaDNlV0pzUlZCdU0xbGhlWEJOTUhoRlRESTJjblIxTWpCSE9IWkxVelJKV1V0cWMzUUtkV05UTVZwMlZGTXpNVzFtWm0xbVJXNTJiR3h3UW05YVpUbHJaVXBSVkdaeVQzTlZRazlrT0RBeFJ6VnFWRVZPVEhoWWFWSkVhVWRuYnpKd1dqaHNSd3ByTWpSVFFuZEVVblZOY0c4NFdHUndkeXRIUmk5M2JESkJTVGhQTTNoVWVETlRabE5IS3pOa1ZFZGxNMGxEYzNkUGVuTklXR0ZPUlRjemJVNU5iakkyQ2xkelpFOVlkM1pOVWpkTVpGWnZUMlUwZVZsSFF6RnZlWFJyZVdSVlRHWkhiSEpSUlRoclkwTjRSRXAwVGk5c1ZVVkVka3RRTHpSNlVEVnVNbGRPUzBnS2FuWkRaRmx4V0hSRGVVdGxWV295Y3k5WWFpdDFZbnAyVlhORldWZEZkQzlVUTNkclN6WnRTVEpsYzBOblowVkJWMEl4UTJwMmFIWkZOMmxKYTJRM05nb3ZUeXM0YzNWNlQyUkRXa1o2ZVM5S2VUWnBVVEZaVlV3d1psTmxkR1YwY21zemQydEhhMlJNTW1OTFpVSnJPVEExYTB4VlN6RXJVMlpSTW13eVpVMDBDaTl4WmxGaE5GUkZRakl5Y2xWemN6Qm1lazFyYkhoNk5pOVZiV2RVVlVWd2MyZFNOa0p0YVZvdk5ETjJZbk5ZVHpKeUwyOUlNVmhhTldaS2VXODJRelFLVG1nNFdsRmpXa2hMWWxaMWRYbG5jblo0VFdnMlVHbExTMkpoT1RaNlkzUXplV0pDUlhWMVFtOHlMMjFwVmxGQlR6bExhV3hHY0ZGUWFrbHlhVXRRY1FwMlJHRnBiWHBIZFdKRWFHOTBSR3dyVFdSVWF6YzNSbFl2ZURZemVUVjJVSGwyWjFOUk9GcEtTRVJpVlVWNWNHZFBRWFJSVTBaQ2VqTkNXVTF2TTBZMkNuUnpWWGxzTWxsbGNHNXBhSEJFY1VSSVNEVlpjMFJ0VHpobFdYaDFPR3RHVkhsQ2RTODBjMFZIVFZKdFpFbFNSRVJ2Y0V3elpUaEtWMEZIYnpnclNISUtNMjV1YlU5UlMwTkJVVUpwY2xGdlZYTldVWGQyVGxodWNVbG1ZamR5YUc4eVp6aDRLMjFHWW14Nk0xTnJVMUpEVW5OdkwycFNlRlJ0SzNsNk4zSndMd3BDVUVSMVZrMVVkVVpzWjJjdlF5ODFRVUp6YVVkSVZFUlJNbTEzTjFodmRtWmlTV2MwVlRaME1sazNZM2RPYTJrd1ExSkJSV2hTY0M5Nk1UVm1OWGhaQ2pNeWJqTmhZVlpoYjBKTGJtTk9UMFZPU0ZBMFFqZFVhbU5TV205WlZtOWpRa0l3WTFGTVFXOTVWM2RuYmtoMGJqRlhURU5tU0ZrMVMzQnpiblJMWTJ3S05uZGxPREZwVkRKd05YVkZkR3B1VkU5SU4yMXdabkZpZVVFd2VYcFJhVFJIUm1WUVdEVjVRa3hVVVhobE9XUmphRVZUVFdOQ2FEbFJMMmQ2ZFM5cVlRcFNWVkZ2U2sxMFZIVXZPWEY1T0RsbVNtTmlNMVF6YmpnM1lVaElRWFp5U0VZcmJtbExVVXQzV1RVdmNFRkhkbEpwTlhKWGNVZFBiRkJ0UjFNNWNEQXZDazExWm5Sa1RIRm1URGxvZFdSVFkxSkJXVnB5VEN0TFJWVjRTeklyS3pNNVFXOUpRa0ZSUkZaa2IwYzRaM0o1VVZSdWRuWjViekF3ZDJSdGNFOU9kV0VLTm5WTEt6Wm5TRTU1ZUZjeVNFODRaWEJoVDJOdEsyUkJORzV2YURobWVXUm5RMlpHU21SdWRrcHlkMFpHTVhKb01VbGlZazAzY1hKQlRXMXVZbFZKWmdwS1dqVnhUVVE0TURCR2IybzNSVmh0UmxSemIzZERMMW93YTJOdmRsZFVRbk4zY1doaFRqSnRkMVl5YXpKUFQwNUZPVU5CYmxSR2RsaHNlVnByTlZWaENrRTNWRUZ6YkN0U2JrazJOMWg2VTJGME0ySXdVazVMVDFGa1YyWklZbWhqU1RSNmJqaHdhMHhUVW0wck1UZHRVWE5DWm5SSVRHNXJVRkZxUm5WUFVYY0tkRlpJVFZFelZEVTRPUzlOUVd4NVVsSlVWRkJUVUVvMVVVTXpNVzg1YkhocldrY3lNWE5CUTNoQ2VtbHRVSEJhVWpoTVdHMUtZVUV5YzNCa1lVTlVXQW94Um1aNU1EQlNRalJOZWxaV2VrNXhaSGszV1haTWQyYzFlRzFKZG1aQmRXZ3labXd2WlhNclNsZGhWVFZIU0hkSmFHaEJWakJWV21kYVdVa0tMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogbVA1aXZSd09MeGxlVlRNbFZDVWh4TnVoVlJUbU1Kb2lPRmN6NW82empKMXZjUmFDcmhjY0MxOFhvVEFybDBVUHJibUdKeEkwd1BmUTRaclM0aGY2SzI0Zk9aN3hCMXNqc0JHbHY4VE0yWVMwRlF3VmpKZGhGMXQ3c0hTSVpXMVQK\"\n  }\n }"
-    }
-  }, {
-    "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser/listCredential?api-version=2019-08-01",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:10 GMT",
-      "server" : "nginx",
-      "content-length" : "13113",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "x-ms-ratelimit-remaining-subscription-writes" : "1196",
-      "retry-after" : "0",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "39b6505e-843d-43c6-adbe-df565d2dfb8c",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050211Z:39b6505e-843d-43c6-adbe-df565d2dfb8c",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "24ce8a2c-08e6-4dd6-a3e3-a0d90aaf4ca4",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgbmFtZTogYWtzNzU4OTk5CmN1cnJlbnQtY29udGV4dDogYWtzNzU4OTk5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVdlJFTkRRWFZUWjBGM1NVSkJaMGxSWVVGRVJXUkhjbHBMZDNWMloxUnRVME5yVlVsc1JFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNSGxOVkVWM1RXcEpkMDVFVVROTmFsSmhUVVJCZUFwR2VrRldRbWRPVmtKQmIxUkViazQxWXpOU2JHSlVjSFJaV0U0d1dsaEtlazFTVlhkRmQxbEVWbEZSUkVWM2VIUlpXRTR3V2xoS2FtSkhiR3hpYmxGM0NtZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSQlpUa3dlRWQ2Y1RoSGMza3pVM1JNVmpkSWIxb0tXRFV3THl0V1ltSk9OQ3RWTTJKbVNEWXlhM1pDVW5wUGJteDNXa0Z2ZWpacVdsVXpOVXQwWXpVeFdGWk9ZV1FyVGxoUmQxRlJTbXRVY0VKV1dYWktOUXBpWkRKS1JuSk5iREEwV21JeGJUZGtkR0p2ZVdWc0x6Tk5PRlJCTVZwclNIVjBjQzh5S3pseFRVTXJjMUJHZGxCNlR6bG9NbTV3UW05emJXTjBRVm92Q2pkbkwwSlhkRk41YldSWFdrWm9jMHR3Y205SE9UUm1jak5WYXpjNWJqazFiRWszUzIxNmMzbGlhSFZQVUdJcllWTnZjR3BKTkhSQlRsSkhXVGQ2VWxBS2JHZHRZV05DYzNoSFpuTk1lWG8yTUZONk9XdENiV2hKYkhKSVV6SlVRemx6ZW5sVk1EYzNXV1o0VG5GMFp6QktaMnQwVlVGS1Z6Sk1abWxUV0d4MWNncFNiak5UYWpoRVJEZHZVRk52ZUZSSWNYSTFaa2hRV0RkRFRsUndNV2d5WW5ad01FRXZTSGhtZUVka1drRjZaVGN3TkV4YWVEQlFWbUZ6UWxKbk1GUm9Dazk1VlZvMk9YRXZVM0J0Ym5CaVYzaHFZWEZuTUVvNU5EVm9VVTlNZGpKMU1tbFBSbkYyVFZZMGVVdDBMemhXTDNsM2REbDZaVk4zTkVVNU5IQktSREVLUTFCdk9XeHZkV3BDTHpZeGVVcDBPVmxKWnpWclUxaGhaVTVIU0VaYU1HbFJOMVZKYTBaU09FVkRUR1JtV0Vsa05sVXpaRmM0WlhSWlUybHBTU3RaV1FwelJVUTBkSEZRUkdWRmR6RllTbkpFU1ZGMVdqRkJNVEUxYm5Oc1ZHaFJSRnBTUldrcllrWTRlblE1TVU1Rk1IcGtkaTlMYTNSMVpHbzRhbGhvVG5oVENtdGFia1JTWWtRclN6TldOV0k1T0VnMmVHWmpWMDV4UTFkRlF6TTNkMlZWWVdoVE5rUkNlRXhyVWxvdk9EVXlTV1JQTlV4ck5UTlNVVEpVVTJaNGEyVUtNRTF5YmxVeFYycGtkMFZoVXk5c1lsSnZRa2RtVEdkeE9VOVFSM1ZRV1dST1RXaElXa2t4VGk5aFEyNXlSMjFDVWxSb05EQlJPR04xYW5aM2NUWlZOQW95VVVGaFpsUktkWHBGVWpGRGExbEpWMFo1VjJ4M1NVUkJVVUZDYjNwVmQwMTZRVTlDWjA1V1NGRTRRa0ZtT0VWQ1FVMURRbUZCZDBWM1dVUldVakJzQ2tKQmQzZERaMWxKUzNkWlFrSlJWVWhCZDBsM1JFRlpSRlpTTUZSQlVVZ3ZRa0ZKZDBGRVFVNUNaMnR4YUd0cFJ6bDNNRUpCVVhOR1FVRlBRMEZuUlVFS2EzbFhTa2xJZURNMVdVZG5jWEY1WjNBM2FGbE1UMlJCTkhGWVZIcFBjMVpSY3l0V01rTnRaelpIWVZnMmNuUkZkV0pxYVdOdlZXSTJXbE5xVG1wNFR3cDJiVWxUUTJZemJUQXpWbmRUTlVzd2FuZEJkRk0xU0hCclJVcDJaMDVFV2tVdk4zWkVjMEpSTUV0U1MxZDVlbk40TjNKaVRGQlJlR1IyVDFwM1kzbzJDamxFT1RGR2RtbE9jbGgyWkZSWmJscGFOMHNyVWpWNGVqWkpNbTFETldGTlpFUmFhM05MYlRsSVNrRm9XbXBpWVRWall5OXhkbmsxUzJ4c1JsZFRhazRLUjFWemNtZzRORnA0ZGl0Q2RESnRhM2t4Y0RoRldXUlFibHB4U0VsQllrOUhTR0pEY0cxcWExZFJhamhQV0dwVmEydGhVR2t3VUZkaldraE9LMnBtU3dwRlUzWkdkR2x4TlVaME1rcDFVVlJMYUhwNFpEa3hLMngwTnk5RlRWTlNTRzUzUmpjeGIxazBTbFU0TjJwb2JuZ3lSaXQzVVc5UGJHZHZSMkowVXpaWUNtdFRRbTVqWm5CemR6ZFRNVWR3TVc1MVQySlZPRmxxWlRWVlZEWndRVnB2ZW5Vek5rZDNaVkJuYzFBMVZWVnBkM2x2ZWs1SWNHcHhNbEJCZVV0SFRXUUtWblo2VEVWeWJtUkNkbEp0V1hSTFNrVjRWa1JMU0VwMGRuVkZjVE5yZUZGTFJIZHpiMUJaT1VoMlJtdFZiVVYzYm5NNGJsUkljVXhqTkdWNlJVOUVid3BRUTBGQldqVnpjMmd6YzJOS1dDOXZSMEZGVGtSMFFVOTJTbkV4Y0doMmVHaHljVk5xWW5CbVlsRjNXWEEzVm05T1dGZE5SRTFvVUhwbFJHUnVSbHBLQ21Jd00yVXpiaXROVDBVMVdqRTVSbWMwV0dGVGEzSTBjMVZ4VGl0SGFVTnBOVGxMWTJseWVWZzFXSGR6UjBaUlFYWlFhMUYxZWxwbk5EQnZPR2hwWkhJS01TOU5lV0pZY2twNFJERXZLMlJZT0RGcFowTjFOVm95YVd0NEwzb3ZXbHAwVVZSdU4wODNVRkZaWW14Q2IyaG9ZVXRUVkdKRVdVTmljVFZpYkhOV2NBcHVWWGsxWW1ocVduRmxTV05FYkROWVpsWmtkVmhaU0U1U1dVSlFSazVIVjJGMVNISmlaWE5EWVhOWlBRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLUzFGSlFrRkJTME5CWjBWQmQwaDJaRTFTY3paMlFuSk5kREJ5VXpGbGVEWkhWaXRrVUM5c1Z6SjZaVkJzVGpJemVDdDBjRXgzVldONmNEVmpDa2RSUzAwcmJ6SldUaXRUY2xoUFpGWXhWRmR1Wm1wV01FMUZSVU5hUlRaUlZsZE1lV1ZYTTJScFVtRjZTbVJQUjFjNVduVXpZbGMyVFc1d1pqbDZVRVVLZDA1WFdrSTNjbUZtT1haMllXcEJkbkpFZUdKNk9IcDJXV1J3TmxGaFRFcHVURkZIWmlzMFVIZFdjbFZ6Y0c1V2JWSlpZa054WVRaQ2RtVklOamt4U2dwUEwxb3ZaVnBUVDNsd2N6ZE5iVFJpYW1veUwyMXJjVXRaZVU5TVVVUlZVbTFQT0RCVU5WbEtiVzVCWWsxU2JqZERPSE1yZEVWekwxcEJXbTlUU21GNENqQjBhM2QyWWswNGJFNVBLekpJT0ZSaGNsbE9RMWxLVEZaQlExWjBhVE0wYTJ3MVluRXdXamt3Ynk5QmR5czJSREJ4VFZWNE5uRXJXSGg2TVN0M2FsVUtObVJaWkcwM05tUkJVSGc0V0RoU2JsZFJUVE4xT1U5RE1tTmtSREZYY2tGVldVNUZORlJ6YkVkbGRtRjJNSEZhY0RaWE1YTlpNbkZ2VGtObVpVOVpWUXBFYVRjNWNuUnZhbWhoY25wR1pVMXBjbVl2Um1ZNGMweG1Zek5yYzA5Q1VHVkxVMUU1VVdvMlVGcGhURzkzWml0MFkybGlabGREU1U5YVJXd3libXBTQ21oNFYyUkphMDh4UTBwQ1ZXWkNRV2t6V0RGNVNHVnNUak5XZGtoeVYwVnZiMmxRYlVkTVFrRXJUR0ZxZHpOb1RVNVdlV0YzZVVWTWJXUlJUbVJsV2pjS1NsVTBWVUV5VlZKSmRtMTRaazAzWm1SVVVrNU5NMkl2ZVhCTVltNVpMMGt4TkZSalZYQkhXbmN3VjNjdmFYUXhaVmN2WmtJcmMxZ3pSbXBoWjJ4b1FRcDBLemhJYkVkdlZYVm5kMk5UTlVWWFppOVBaR2xJVkhWVE5VOWtNRlZPYXpCdU9GcElkRVJMTlRGT1ZtOHpZMEpIYTNZMVZ6QmhRVkp1ZVRSTGRsUnFDbmh5YWpKSVZGUkpVakpUVGxSbU1tZHdObmh3WjFWVk5HVk9SVkJJVEc4M09FdDFiRTlPYTBGSGJqQjVZbk40UldSUmNFZERSbWhqYkhCalEwRjNSVUVLUVZGTFEwRm5SVUYwZG1aSVJHSjJaR1pDZEZwb09EUXpWbWxUUVN0QlpXTmxZMmg0VjA1aFlYaEtOWGcyVkdOTlpVTmhOaXRIYTNWRlNsRk9TVTF3WmdwRmJ6bHhiVlpvU21wbE9TOTBTV1p3VmpCcmEyeGxZbU5oYkRSNFRWWTFVRWhPV1ZsSGVHWlVLM2MxT1hWdlJGcGhjM2hMTVhKbkswTnFVRUZWVFcwNENtczFaV3RKUjA5SWJsbHBUMjFhZDNJelR5dExSVlZTUm5NMVEzQk5VV2hDY2poSVFYUTNiR3huYVhsNVRHUkVTWFZ2UTI1cmJuZzFPV1ZpWkhrNWREZ0tWa2hzTUhKMk5XUmpWSFZtUnpOS1NqQXJNV2R0TDNOWFRFUk5UbTVoTVRSdFdHRkNWVzgxYjNob1FrRklZUzg1Y0ZBME1rOVFTVTlRVDJjMU0yTnJOQXBEUW5sNmNVTlpOMlJqT1hneWVEQm5jamgzVTJjclpERkNkVlp6TjBGWFNUWjRUemcwUlV0cmVXbEJPVk0wVFhocVZWbENVMDE0WmxnMWQzQTNkbU5zQ2xaV0szTmtibWhETmxOclZ6TktUVEZMWjBONGNWaG1aRTFzTml0d1JtTnJLMk4zZFRKSFNXUTJkRzFuY1RCMFZubFJVV0ZIYTFJNWMweDBhbTVIZDNBS1JFODFOWGhNTm0xWVdHZFNNbFpqZWpSMlMwdG1XRXdyVjBkRGIwaEVhMnhCZFhsVlJtRlBNMnBSTWpOU09HbENkbTVMYkZNMk5XYzNjalo0Tm1od2VRbzRielJWVjNSamVHOVdjRmxwYTBOT1FqWjFWblY2WVU5ek9YQTRXRWQxVkhJeGRYTTNlRGgzV2xWdksyWklhVTl5Vkhwck9XVlJkamhHVGpkWU5GRkRDbTlMV0ZSVWVFbGtZMEl3VlRoMVVsWmtNbUZWYjBWMWR6ZHhPV1V4Y1hOSFkyODJWeTlYWlRkUmIyY3pSV2sxTW0xbVl6ZEhUVXhwZWtkT1dVcE1ibWdLTmtwTlJsQnNRVGgxWkRaNUswSlNVMUJ0VlZaNlV6QkZablozWm5oNVkybFdiMU5MZFhCNVRWTlhZMGswY0VZNGREQTRXblJQVWtSbVIwTnFjRmxXVFFweFVIRjJRMnQzVW0xeU0xRTBVSHBOTVc5S0wyNW5WSEpIYW1aU1NrcElXRWRsVmtOUmNIQjBUVUZMVkdGQlVWcHdNbXREWjJkRlFrRlFTbkJxZERGa0NsSXlkMHROVGtJMWFETm1SRGRKVG1oUFptNXVXU3M1TTNaNVJVVlRSV1oyVm1kYVV6RjRWbTltWjFkTGVHcENiRXQxTm5WcU9IWm1OR0ZEZVhkdU1YUUtlVWswZVdsblZqUm1Nak5pY1hSaGRYQlRZamhFWVhscGNHdEJjMXAwYUhrMFZHMXlOeTg1VkRsbWJTOVhZVEZrTDJaek5sWTBZWEZWTTBSWlZsaEtkQXBWTUdjNWNHTkRNemQxUldKb2IyaE9WRVZqVUhRd1dtZG1XbWgyYldSTllsRTVWakJSUWtoRWVXWTBTR2hzTlRsQlpucExObUZQYlhneWFHZDVWRGxFQ2xGa1dqRm1NMWh6ZGtZd1prTXhhWEJJTUhKWmRtbEhkVnBaV2tKWWFEazVXWEZMVlV0TldqRnpRazkyYkcxSlQxSTVjMGxLYUhSSVpFOTZUbFJXYTNVS1dqVnVUa1ZsZEdwNFZqZFpkRVpUWVZsblRtcFlURlZhWkdwcFMzQkJPWEIwY2pneVRHVk5SSElyUW5Od1lYQjNRa055VW05aU5HZzJWRkoyWTJKb01Rb3lPRVJDT1daVk9URlFiazkyZDFWRFoyZEZRa0ZOZEVZemFpOXlUblJxY1hkMk5VMU1kRmxCU1dGdlRWVXZiakpLVkd4bk1rdEpNamQ0VXpod2VHOWtDbGR2WjNabmNtOUtZWGN4WldoR2FubFdTMU5TUm1OVWIwNUtTWGgzZVdKc1JWQnVNMWxoZVhCTk1IaEZUREkyY25SMU1qQkhPSFpMVXpSSldVdHFjM1FLZFdOVE1WcDJWRk16TVcxbVptMW1SVzUyYkd4d1FtOWFaVGxyWlVwUlZHWnlUM05WUWs5a09EQXhSelZxVkVWT1RIaFlhVkpFYVVkbmJ6SndXamhzUndwck1qUlRRbmRFVW5WTmNHODRXR1J3ZHl0SFJpOTNiREpCU1RoUE0zaFVlRE5UWmxOSEt6TmtWRWRsTTBsRGMzZFBlbk5JV0dGT1JUY3piVTVOYmpJMkNsZHpaRTlZZDNaTlVqZE1aRlp2VDJVMGVWbEhRekZ2ZVhScmVXUlZUR1pIYkhKUlJUaHJZME40UkVwMFRpOXNWVVZFZGt0UUx6UjZVRFZ1TWxkT1MwZ0thblpEWkZseFdIUkRlVXRsVldveWN5OVlhaXQxWW5wMlZYTkZXVmRGZEM5VVEzZHJTelp0U1RKbGMwTm5aMFZCVjBJeFEycDJhSFpGTjJsSmEyUTNOZ292VHlzNGMzVjZUMlJEV2taNmVTOUtlVFpwVVRGWlZVd3dabE5sZEdWMGNtc3pkMnRIYTJSTU1tTkxaVUpyT1RBMWEweFZTekVyVTJaUk1td3laVTAwQ2k5eFpsRmhORlJGUWpJeWNsVnpjekJtZWsxcmJIaDZOaTlWYldkVVZVVndjMmRTTmtKdGFWb3ZORE4yWW5OWVR6SnlMMjlJTVZoYU5XWktlVzgyUXpRS1RtZzRXbEZqV2toTFlsWjFkWGxuY25aNFRXZzJVR2xMUzJKaE9UWjZZM1F6ZVdKQ1JYVjFRbTh5TDIxcFZsRkJUemxMYVd4R2NGRlFha2x5YVV0UWNRcDJSR0ZwYlhwSGRXSkVhRzkwUkd3clRXUlVhemMzUmxZdmVEWXplVFYyVUhsMloxTlJPRnBLU0VSaVZVVjVjR2RQUVhSUlUwWkNlak5DV1Uxdk0wWTJDblJ6Vlhsc01sbGxjRzVwYUhCRWNVUklTRFZaYzBSdFR6aGxXWGgxT0d0R1ZIbENkUzgwYzBWSFRWSnRaRWxTUkVSdmNFd3paVGhLVjBGSGJ6Z3JTSElLTTI1dWJVOVJTME5CVVVKcGNsRnZWWE5XVVhkMlRsaHVjVWxtWWpkeWFHOHlaemg0SzIxR1lteDZNMU5yVTFKRFVuTnZMMnBTZUZSdEszbDZOM0p3THdwQ1VFUjFWazFVZFVac1oyY3ZReTgxUVVKemFVZElWRVJSTW0xM04xaHZkbVppU1djMFZUWjBNbGszWTNkT2Eya3dRMUpCUldoU2NDOTZNVFZtTlhoWkNqTXliak5oWVZaaGIwSkxibU5PVDBWT1NGQTBRamRVYW1OU1dtOVpWbTlqUWtJd1kxRk1RVzk1VjNkbmJraDBiakZYVEVObVNGazFTM0J6Ym5STFkyd0tObmRsT0RGcFZESndOWFZGZEdwdVZFOUlOMjF3Wm5GaWVVRXdlWHBSYVRSSFJtVlFXRFY1UWt4VVVYaGxPV1JqYUVWVFRXTkNhRGxSTDJkNmRTOXFZUXBTVlZGdlNrMTBWSFV2T1hGNU9EbG1TbU5pTTFRemJqZzNZVWhJUVhaeVNFWXJibWxMVVV0M1dUVXZjRUZIZGxKcE5YSlhjVWRQYkZCdFIxTTVjREF2Q2sxMVpuUmtUSEZtVERsb2RXUlRZMUpCV1ZweVRDdExSVlY0U3pJckt6TTVRVzlKUWtGUlJGWmtiMGM0WjNKNVVWUnVkblo1YnpBd2QyUnRjRTlPZFdFS05uVkxLelpuU0U1NWVGY3lTRTg0WlhCaFQyTnRLMlJCTkc1dmFEaG1lV1JuUTJaR1NtUnVka3B5ZDBaR01YSm9NVWxpWWswM2NYSkJUVzF1WWxWSlpncEtXalZ4VFVRNE1EQkdiMm8zUlZodFJsUnpiM2RETDFvd2EyTnZkbGRVUW5OM2NXaGhUakp0ZDFZeWF6SlBUMDVGT1VOQmJsUkdkbGhzZVZwck5WVmhDa0UzVkVGemJDdFNia2syTjFoNlUyRjBNMkl3VWs1TFQxRmtWMlpJWW1oalNUUjZiamh3YTB4VFVtMHJNVGR0VVhOQ1puUklURzVyVUZGcVJuVlBVWGNLZEZaSVRWRXpWRFU0T1M5TlFXeDVVbEpVVkZCVFVFbzFVVU16TVc4NWJIaHJXa2N5TVhOQlEzaENlbWx0VUhCYVVqaE1XRzFLWVVFeWMzQmtZVU5VV0FveFJtWjVNREJTUWpSTmVsWldlazV4WkhrM1dYWk1kMmMxZUcxSmRtWkJkV2d5Wm13dlpYTXJTbGRoVlRWSFNIZEphR2hCVmpCVldtZGFXVWtLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IHNCVFoxeWdDcjYxN0pJMTNodlNoVmFFcndNZmxFY21XSWFxdE9xMFBvOWhwYzI0SXZDQ3dGWmpwbW9hcUpBZU1tUWxZTVRaNjZ0ZG9lMllrM1ZzeHRoYTVwUDdmbjNKRWFLSkdwVmdIWjhEdTNuMXQyN0RvZ2t0dUI2VFM1eUExCg==\"\n  }\n }"
+      "x-ms-request-id" : "1b95a1f0-ffce-4356-812b-dc3f083e4b15",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ResourceManagementClient, 2019-08-01)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:10 GMT",
-      "content-length" : "10064",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
+      "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
@@ -1932,23 +1812,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9590c7d4-933e-4c88-82d0-09576f2656c1",
+      "x-ms-correlation-request-id" : "d7f70963-5707-4150-a178-055a1de3d6a6",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050211Z:9590c7d4-933e-4c88-82d0-09576f2656c1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022314Z:d7f70963-5707-4150-a178-055a1de3d6a6",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9590c7d4-933e-4c88-82d0-09576f2656c1",
-      "Body" : "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/a1-test-sql\",\"name\":\"a1-test-sql\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group\",\"name\":\"aks758999group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-23T04:47:10.449Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice\",\"name\":\"cleanupservice\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"What Is Cleanup Service\":\"https://aka.ms/WhatIsCleanupService\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS\",\"name\":\"Default-Storage-EastUS\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/flksjerlk\",\"name\":\"flksjerlk\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg00a720985\",\"name\":\"javacsmrg00a720985\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-14T04:00:10.646Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg236403\",\"name\":\"javacsmrg236403\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2019-10-14T11:02:54.588Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javanwmrg99069\",\"name\":\"javanwmrg99069\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-22T13:58:07.238Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jmonitor_4c473300\",\"name\":\"jmonitor_4c473300\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_aks758999group_aks758999_eastus\",\"name\":\"MC_aks758999group_aks758999_eastus\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\"tags\":{\"tag1\":\"value1\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG\",\"name\":\"NetworkWatcherRG\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_8fd8947481be\",\"name\":\"rg1nemv_8fd8947481be\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-20T09:05:08.132Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_c7b25576b432\",\"name\":\"rg1nemv_c7b25576b432\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_d1f10904c5be\",\"name\":\"rg1nemv_d1f10904c5be\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-15T01:16:28.865Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg234085226f\",\"name\":\"rg234085226f\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg46678\",\"name\":\"rg46678\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"northcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg760944107c\",\"name\":\"rg760944107c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-18T15:39:39.272Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu\",\"name\":\"rg-weidxu\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr268020\",\"name\":\"rgacr268020\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-20T00:35:46.559Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr742334\",\"name\":\"rgacr742334\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-20T07:24:04.907Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3e83753426e8ff29\",\"name\":\"rgcomv3e83753426e8ff29\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv68a360842c14044e\",\"name\":\"rgcomv68a360842c14044e\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv92407708\",\"name\":\"rgcomv92407708\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvd73932032d4ac980\",\"name\":\"rgcomvd73932032d4ac980\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcosmosdb13d02156d\",\"name\":\"rgcosmosdb13d02156d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westcentralus\",\"tags\":{\"date\":\"2019-10-18T03:03:09.151Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7ac76366e9bd0\",\"name\":\"rgnemv7ac76366e9bd0\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_58319828ee1d\",\"name\":\"rgnemv_58319828ee1d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T01:25:18.262Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5de57049f5ce\",\"name\":\"rgnemv_5de57049f5ce\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5f3215901ad6\",\"name\":\"rgnemv_5f3215901ad6\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T08:42:59.358Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_dd9490362951\",\"name\":\"rgnemv_dd9490362951\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2019-10-21T01:47:59.969Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib40963937438423\",\"name\":\"rgrsdsib40963937438423\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2019-10-21T05:49:13.502Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgvmdeb62\",\"name\":\"rgvmdeb62\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"japaneast\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/skjehr\",\"name\":\"skjehr\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql275957group\",\"name\":\"sql275957group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"centralindia\",\"tags\":{\"date\":\"2019-10-20T00:34:51.146Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi\",\"name\":\"tanyi\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi1\",\"name\":\"tanyi1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tytest\",\"name\":\"tytest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Deleting\"}}]}"
+      "x-ms-request-id" : "d7f70963-5707-4150-a178-055a1de3d6a6",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/a1-test-sql/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-2d782770-0242-41f1-84bf-54426c283420/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -1957,50 +1838,50 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "8e3eddbe-e46d-428c-9427-239419bdf74e",
+      "x-ms-correlation-request-id" : "50c21ac3-e0e1-4309-85b2-8de40eee17c0",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050211Z:8e3eddbe-e46d-428c-9427-239419bdf74e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:50c21ac3-e0e1-4309-85b2-8de40eee17c0",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8e3eddbe-e46d-428c-9427-239419bdf74e",
+      "x-ms-request-id" : "50c21ac3-e0e1-4309-85b2-8de40eee17c0",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
-      "server" : "nginx",
-      "content-length" : "1870",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11928",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "798c311a-0d2c-437c-96df-f570984336a2",
+      "x-ms-correlation-request-id" : "d65a73b2-269d-4d2d-ab41-ea0c700110da",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:798c311a-0d2c-437c-96df-f570984336a2",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:d65a73b2-269d-4d2d-ab41-ea0c700110da",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "22e8c1b2-4697-40ce-84ef-f71f3167f0d9",
-      "Body" : "{\n  \"value\": [\n   {\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n    \"location\": \"eastus\",\n    \"name\": \"aks758999\",\n    \"tags\": {\n     \"tag1\": \"value1\"\n    },\n    \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n    \"properties\": {\n     \"provisioningState\": \"Succeeded\",\n     \"kubernetesVersion\": \"1.13.11\",\n     \"dnsPrefix\": \"dnsaks758999\",\n     \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\": [\n      {\n       \"name\": \"apaks758999\",\n       \"count\": 1,\n       \"vmSize\": \"Standard_D2_v2\",\n       \"osDiskSizeGB\": 100,\n       \"maxPods\": 110,\n       \"type\": \"AvailabilitySet\",\n       \"provisioningState\": \"Succeeded\",\n       \"orchestratorVersion\": \"1.13.11\",\n       \"osType\": \"Linux\"\n      }\n     ],\n     \"linuxProfile\": {\n      \"adminUsername\": \"aksadmin\",\n      \"ssh\": {\n       \"publicKeys\": [\n        {\n         \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n        }\n       ]\n      }\n     },\n     \"servicePrincipalProfile\": {\n      \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n     },\n     \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n     \"enableRBAC\": false,\n     \"networkProfile\": {\n      \"networkPlugin\": \"kubenet\",\n      \"loadBalancerSku\": \"Basic\",\n      \"podCidr\": \"10.244.0.0/16\",\n      \"serviceCidr\": \"10.0.0.0/16\",\n      \"dnsServiceIP\": \"10.0.0.10\",\n      \"dockerBridgeCidr\": \"172.17.0.1/16\"\n     },\n     \"maxAgentPools\": 1\n    }\n   }\n  ]\n }"
+      "x-ms-request-id" : "d65a73b2-269d-4d2d-ab41-ea0c700110da",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2009,23 +1890,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "87b1f3d2-76c9-4413-95bc-edd24666eb80",
+      "x-ms-correlation-request-id" : "7d43c95f-fdf4-418e-baab-db27082fdec5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:87b1f3d2-76c9-4413-95bc-edd24666eb80",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:7d43c95f-fdf4-418e-baab-db27082fdec5",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "87b1f3d2-76c9-4413-95bc-edd24666eb80",
+      "x-ms-request-id" : "7d43c95f-fdf4-418e-baab-db27082fdec5",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2034,23 +1916,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "bfad3a4b-6eb6-4697-af29-c3a02d0124d4",
+      "x-ms-correlation-request-id" : "eac5f3ee-72b6-4972-bde5-9a2dca5694b8",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:bfad3a4b-6eb6-4697-af29-c3a02d0124d4",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:eac5f3ee-72b6-4972-bde5-9a2dca5694b8",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "bfad3a4b-6eb6-4697-af29-c3a02d0124d4",
+      "x-ms-request-id" : "eac5f3ee-72b6-4972-bde5-9a2dca5694b8",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/flksjerlk/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ty/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:14 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2059,23 +1942,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "34bbf1c9-849b-40dd-a556-e4dbbd051bed",
+      "x-ms-correlation-request-id" : "30ec1068-d0ea-4258-a35d-6775d0c8862b",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:34bbf1c9-849b-40dd-a556-e4dbbd051bed",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:30ec1068-d0ea-4258-a35d-6775d0c8862b",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "34bbf1c9-849b-40dd-a556-e4dbbd051bed",
+      "x-ms-request-id" : "30ec1068-d0ea-4258-a35d-6775d0c8862b",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg00a720985/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg16682/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2084,23 +1968,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "bec829df-52a5-4f05-b8b3-f22b654cfd67",
+      "x-ms-correlation-request-id" : "582d76d7-4e98-44f7-8378-d40f0e371486",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:bec829df-52a5-4f05-b8b3-f22b654cfd67",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:582d76d7-4e98-44f7-8378-d40f0e371486",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "bec829df-52a5-4f05-b8b3-f22b654cfd67",
+      "x-ms-request-id" : "582d76d7-4e98-44f7-8378-d40f0e371486",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg236403/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2109,23 +1994,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2af25926-d880-486f-ab40-412c6f41b6d9",
+      "x-ms-correlation-request-id" : "12c3095b-47ba-4ee1-99df-56d2a3f579af",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:2af25926-d880-486f-ab40-412c6f41b6d9",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:12c3095b-47ba-4ee1-99df-56d2a3f579af",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2af25926-d880-486f-ab40-412c6f41b6d9",
+      "x-ms-request-id" : "12c3095b-47ba-4ee1-99df-56d2a3f579af",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javanwmrg99069/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lenatest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2134,23 +2020,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5bff565f-68c3-4e26-818a-ad54678a8dae",
+      "x-ms-correlation-request-id" : "05ed7551-e7f2-48a7-b6e0-64dee3c10c8f",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:5bff565f-68c3-4e26-818a-ad54678a8dae",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022315Z:05ed7551-e7f2-48a7-b6e0-64dee3c10c8f",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5bff565f-68c3-4e26-818a-ad54678a8dae",
+      "x-ms-request-id" : "05ed7551-e7f2-48a7-b6e0-64dee3c10c8f",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/jmonitor_4c473300/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgac6642161bef4/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2159,23 +2046,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "98778923-f50d-4865-96a3-f5024df77da1",
+      "x-ms-correlation-request-id" : "884e950e-246a-4928-8013-5698725e8627",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:98778923-f50d-4865-96a3-f5024df77da1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:884e950e-246a-4928-8013-5698725e8627",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "98778923-f50d-4865-96a3-f5024df77da1",
+      "x-ms-request-id" : "884e950e-246a-4928-8013-5698725e8627",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_aks758999group_aks758999_eastus/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg76a43058c8/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2184,23 +2072,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ad0e1fe7-53f5-4331-a4a7-81d94a397669",
+      "x-ms-correlation-request-id" : "ad17d504-acc6-4515-8f55-70f72abdd872",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050212Z:ad0e1fe7-53f5-4331-a4a7-81d94a397669",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:ad17d504-acc6-4515-8f55-70f72abdd872",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ad0e1fe7-53f5-4331-a4a7-81d94a397669",
+      "x-ms-request-id" : "ad17d504-acc6-4515-8f55-70f72abdd872",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2209,23 +2098,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "b2111975-8e72-4e45-82db-8e73e11deb8d",
+      "x-ms-correlation-request-id" : "1bdd2500-2de2-4cbb-8097-f93fa87384aa",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:b2111975-8e72-4e45-82db-8e73e11deb8d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:1bdd2500-2de2-4cbb-8097-f93fa87384aa",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "b2111975-8e72-4e45-82db-8e73e11deb8d",
+      "x-ms-request-id" : "1bdd2500-2de2-4cbb-8097-f93fa87384aa",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_8fd8947481be/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azfluent/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2234,23 +2124,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e9f2cbe1-6a7d-49d9-8df5-c78b81c4e2e8",
+      "x-ms-correlation-request-id" : "a31b32bb-f6c2-475a-9db1-502ff878d265",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:e9f2cbe1-6a7d-49d9-8df5-c78b81c4e2e8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:a31b32bb-f6c2-475a-9db1-502ff878d265",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e9f2cbe1-6a7d-49d9-8df5-c78b81c4e2e8",
+      "x-ms-request-id" : "a31b32bb-f6c2-475a-9db1-502ff878d265",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_c7b25576b432/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:15 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2259,23 +2150,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "833c7a2e-5552-4bcf-b394-58df1ed052cc",
+      "x-ms-correlation-request-id" : "a33f0c09-e506-40e1-b144-66ebfaa154eb",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:833c7a2e-5552-4bcf-b394-58df1ed052cc",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:a33f0c09-e506-40e1-b144-66ebfaa154eb",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "833c7a2e-5552-4bcf-b394-58df1ed052cc",
+      "x-ms-request-id" : "a33f0c09-e506-40e1-b144-66ebfaa154eb",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_d1f10904c5be/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2284,23 +2176,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c8fde6e8-ba52-49ad-9a52-299d22608b3a",
+      "x-ms-correlation-request-id" : "0b01b38f-80ed-4f18-bcc7-e50442d93023",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:c8fde6e8-ba52-49ad-9a52-299d22608b3a",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:0b01b38f-80ed-4f18-bcc7-e50442d93023",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c8fde6e8-ba52-49ad-9a52-299d22608b3a",
+      "x-ms-request-id" : "0b01b38f-80ed-4f18-bcc7-e50442d93023",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg234085226f/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2309,23 +2202,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e1d13649-506d-479e-b4f4-a606d63cceb1",
+      "x-ms-correlation-request-id" : "3e863d47-9947-46c9-8710-b3b8215b6e63",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:e1d13649-506d-479e-b4f4-a606d63cceb1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022316Z:3e863d47-9947-46c9-8710-b3b8215b6e63",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e1d13649-506d-479e-b4f4-a606d63cceb1",
+      "x-ms-request-id" : "3e863d47-9947-46c9-8710-b3b8215b6e63",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg46678/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2334,23 +2228,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "7de54cec-834f-4ed8-80b5-9d904325be11",
+      "x-ms-correlation-request-id" : "952fd28d-7cc0-4af2-94e9-3fb6260d0b9a",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:7de54cec-834f-4ed8-80b5-9d904325be11",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022317Z:952fd28d-7cc0-4af2-94e9-3fb6260d0b9a",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7de54cec-834f-4ed8-80b5-9d904325be11",
+      "x-ms-request-id" : "952fd28d-7cc0-4af2-94e9-3fb6260d0b9a",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg760944107c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2359,23 +2254,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1677c2c9-327e-44c1-afbb-d4a397cdc39e",
+      "x-ms-correlation-request-id" : "1778dd86-a45e-40f6-a4ee-918bdd67c1a1",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:1677c2c9-327e-44c1-afbb-d4a397cdc39e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022317Z:1778dd86-a45e-40f6-a4ee-918bdd67c1a1",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1677c2c9-327e-44c1-afbb-d4a397cdc39e",
+      "x-ms-request-id" : "1778dd86-a45e-40f6-a4ee-918bdd67c1a1",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2384,23 +2280,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9939e616-0852-4cb9-a282-afddebe739d0",
+      "x-ms-correlation-request-id" : "8991eaf9-4f5d-43f7-acc4-c6dd08423939",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:9939e616-0852-4cb9-a282-afddebe739d0",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022317Z:8991eaf9-4f5d-43f7-acc4-c6dd08423939",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9939e616-0852-4cb9-a282-afddebe739d0",
+      "x-ms-request-id" : "8991eaf9-4f5d-43f7-acc4-c6dd08423939",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr268020/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:12 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2409,23 +2306,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "76f227e5-b9fe-4e2d-9f89-0927fff84c7d",
+      "x-ms-correlation-request-id" : "8b8aa8bb-7968-4fe7-a422-9e896281bc6e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:76f227e5-b9fe-4e2d-9f89-0927fff84c7d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022317Z:8b8aa8bb-7968-4fe7-a422-9e896281bc6e",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "76f227e5-b9fe-4e2d-9f89-0927fff84c7d",
+      "x-ms-request-id" : "8b8aa8bb-7968-4fe7-a422-9e896281bc6e",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgacr742334/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
+      "date" : "Thu, 26 Mar 2020 02:23:16 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2434,374 +2332,568 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0dd0e60e-24bb-4bbb-8f6f-a6d6ec49b19e",
+      "x-ms-correlation-request-id" : "377a314d-2cc0-4095-a523-322c2c906454",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:0dd0e60e-24bb-4bbb-8f6f-a6d6ec49b19e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022317Z:377a314d-2cc0-4095-a523-322c2c906454",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "0dd0e60e-24bb-4bbb-8f6f-a6d6ec49b19e",
+      "x-ms-request-id" : "377a314d-2cc0-4095-a523-322c2c906454",
       "Body" : "{\"value\":[]}"
     }
   }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3e83753426e8ff29/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Method" : "PUT",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:23:21 GMT",
+      "content-length" : "309",
       "expires" : "-1",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1199",
+      "retry-after" : "0",
+      "StatusCode" : "201",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "38a6e0ab-f7ef-47a0-bb41-6f16bce36e7e",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022322Z:38a6e0ab-f7ef-47a0-bb41-6f16bce36e7e",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "38a6e0ab-f7ef-47a0-bb41-6f16bce36e7e",
+      "Body" : "{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group\",\"name\":\"aks769349group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-26T02:23:17.689Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}}"
+    }
+  }, {
+    "Method" : "PUT",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:23:30 GMT",
+      "content-length" : "1741",
+      "server" : "nginx",
+      "expires" : "-1",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1198",
+      "retry-after" : "0",
+      "StatusCode" : "201",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "0046a12d-4c78-439a-a0b2-17858880f5f4",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022331Z:0046a12d-4c78-439a-a0b2-17858880f5f4",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "6e0a0aef-cf7d-4063-b9e0-d5683ca605ca",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
+      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:23:30 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11909",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d4b5137c-9e68-4fa3-934d-0844521a90b5",
+      "x-ms-correlation-request-id" : "ea71287e-a659-4941-bf7c-97e134902014",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050213Z:d4b5137c-9e68-4fa3-934d-0844521a90b5",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022331Z:ea71287e-a659-4941-bf7c-97e134902014",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "d4b5137c-9e68-4fa3-934d-0844521a90b5",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "aac90499-ae36-470c-b98d-2bbf3ec78fcd",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv68a360842c14044e/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:24:01 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11908",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "3e6331f6-101d-4cd0-b7b2-ab6c964ba6f4",
+      "x-ms-correlation-request-id" : "3e831c1e-e266-4497-8c74-30073e656d44",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:3e6331f6-101d-4cd0-b7b2-ab6c964ba6f4",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022402Z:3e831c1e-e266-4497-8c74-30073e656d44",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "3e6331f6-101d-4cd0-b7b2-ab6c964ba6f4",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "b4b8c7fc-667b-4f2f-a152-b29898d9f1f5",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv92407708/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:24:32 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11907",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "8d7c2a39-552a-48b5-9b09-2eda3cd4cfd4",
+      "x-ms-correlation-request-id" : "bde47f66-9062-4ff0-a124-41248bc0298c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:8d7c2a39-552a-48b5-9b09-2eda3cd4cfd4",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022432Z:bde47f66-9062-4ff0-a124-41248bc0298c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8d7c2a39-552a-48b5-9b09-2eda3cd4cfd4",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "eb3ed728-fdda-4de4-861c-724bde1ef97d",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvd73932032d4ac980/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:25:02 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11906",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ff5c7dfe-976b-43d7-8263-5e0f871b69af",
+      "x-ms-correlation-request-id" : "a6b3221c-f706-406e-af28-856c3f0b6a70",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:ff5c7dfe-976b-43d7-8263-5e0f871b69af",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022503Z:a6b3221c-f706-406e-af28-856c3f0b6a70",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ff5c7dfe-976b-43d7-8263-5e0f871b69af",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "65fe1062-be7c-4986-a882-91a857fd81ad",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcosmosdb13d02156d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:25:33 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11905",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "8975fd4d-9c54-4967-a98c-87aeb5d76e3d",
+      "x-ms-correlation-request-id" : "839587c0-0224-4c6d-93bd-8783e466b8f5",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:8975fd4d-9c54-4967-a98c-87aeb5d76e3d",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022533Z:839587c0-0224-4c6d-93bd-8783e466b8f5",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8975fd4d-9c54-4967-a98c-87aeb5d76e3d",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "387daaec-6c3e-4d33-8cd7-0d4125dfbee0",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7ac76366e9bd0/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:13 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:26:03 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11904",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1059adcb-8461-4fb8-9498-d94ba82e7e33",
+      "x-ms-correlation-request-id" : "9a6c8fae-71ec-4c62-a950-3d25588b0dc6",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:1059adcb-8461-4fb8-9498-d94ba82e7e33",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022604Z:9a6c8fae-71ec-4c62-a950-3d25588b0dc6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1059adcb-8461-4fb8-9498-d94ba82e7e33",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "df8f334b-8366-4078-8cbc-14b6793c7862",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_58319828ee1d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:26:33 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11903",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1a28910a-d4b6-4b23-b389-65e56c2bd96c",
+      "x-ms-correlation-request-id" : "a0a07526-418d-4704-9692-48b91cbf22f7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:1a28910a-d4b6-4b23-b389-65e56c2bd96c",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022634Z:a0a07526-418d-4704-9692-48b91cbf22f7",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "1a28910a-d4b6-4b23-b389-65e56c2bd96c",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "e7580ead-dcae-4311-9857-b3d496d18ca9",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5de57049f5ce/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:27:04 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11902",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "68700b62-825f-4f57-8587-cf48e215954b",
+      "x-ms-correlation-request-id" : "5e903d17-e0a3-4a8e-b0d8-eb62397eff07",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050214Z:68700b62-825f-4f57-8587-cf48e215954b",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022705Z:5e903d17-e0a3-4a8e-b0d8-eb62397eff07",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "68700b62-825f-4f57-8587-cf48e215954b",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "523abb81-302f-469b-9127-d22c0c964000",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_5f3215901ad6/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:27:34 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11901",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0cef8848-d622-4bec-a84e-3d1ead7048bc",
+      "x-ms-correlation-request-id" : "369bff73-b4b6-4e2b-bd84-9548ded892f3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:0cef8848-d622-4bec-a84e-3d1ead7048bc",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022735Z:369bff73-b4b6-4e2b-bd84-9548ded892f3",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "0cef8848-d622-4bec-a84e-3d1ead7048bc",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "bee2aab1-e241-4f05-a2ac-babbcde85096",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_dd9490362951/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:28:05 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11900",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e2764fad-e637-4d73-94dc-be1c68dcf71d",
+      "x-ms-correlation-request-id" : "5ff29553-f78f-4840-bba3-cbf1026565e3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:e2764fad-e637-4d73-94dc-be1c68dcf71d",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022805Z:5ff29553-f78f-4840-bba3-cbf1026565e3",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "e2764fad-e637-4d73-94dc-be1c68dcf71d",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "d88874ff-9558-43e5-9605-696221756ebb",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib40963937438423/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:28:36 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11899",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "bf002c02-f183-4676-b7b5-c3f23616e642",
+      "x-ms-correlation-request-id" : "bc0f48c6-5f02-4409-be35-09c619c4af58",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:bf002c02-f183-4676-b7b5-c3f23616e642",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022836Z:bc0f48c6-5f02-4409-be35-09c619c4af58",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "bf002c02-f183-4676-b7b5-c3f23616e642",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "e2722c6f-b6b1-4d42-9200-1e063defc54b",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgvmdeb62/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/6e0a0aef-cf7d-4063-b9e0-d5683ca605ca?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:29:06 GMT",
+      "server" : "nginx",
+      "content-length" : "170",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11898",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "2ab246b6-63cc-4bf7-8d60-6d4c2a31e19a",
+      "x-ms-correlation-request-id" : "9782e53f-0dee-4e42-b7f8-2b0bea9c0aba",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:2ab246b6-63cc-4bf7-8d60-6d4c2a31e19a",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022907Z:9782e53f-0dee-4e42-b7f8-2b0bea9c0aba",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2ab246b6-63cc-4bf7-8d60-6d4c2a31e19a",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "2d8dfb66-2bbe-43f8-a9ba-759a5e16a178",
+      "Body" : "{\n  \"name\": \"ef0a0a6e-7dcf-6340-b9e0-d5683ca605ca\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2020-03-26T02:23:30.0521153Z\",\n  \"endTime\": \"2020-03-26T02:28:58.8134011Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/skjehr/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
-      "Content-Type" : "application/json; charset=utf-8"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:29:07 GMT",
+      "server" : "nginx",
+      "content-length" : "1743",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11897",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "604761b6-5727-4220-9878-8b05e5745cb7",
+      "x-ms-correlation-request-id" : "1700c256-b1e2-47d4-8802-260e3e8074a9",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:604761b6-5727-4220-9878-8b05e5745cb7",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022907Z:1700c256-b1e2-47d4-8802-260e3e8074a9",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "604761b6-5727-4220-9878-8b05e5745cb7",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "c9c4dadc-8715-4425-a5bd-ff7bc19231da",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
     }
   }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql275957group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Method" : "POST",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterAdminCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:29:07 GMT",
+      "server" : "nginx",
+      "content-length" : "12857",
       "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1199",
+      "retry-after" : "0",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5ed054bc-0d93-485f-9fad-101fe4da105b",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022908Z:5ed054bc-0d93-485f-9fad-101fe4da105b",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "21a892ca-eabb-4827-b6bc-de705ad8a15e",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterAdmin\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyQWRtaW5fYWtzNzY5MzQ5Z3JvdXBfYWtzNzY5MzQ5CiAgbmFtZTogYWtzNzY5MzQ5CmN1cnJlbnQtY29udGV4dDogYWtzNzY5MzQ5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlckFkbWluX2Frczc2OTM0OWdyb3VwX2Frczc2OTM0OQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZSRU5EUVhWVFowRjNTVUpCWjBsUlZtd3liMFJWWVhNclNtdFNPVUZ1ZUhGNU5FeG9ha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRnpSa0ZFUVU0S1RWRnpkME5SV1VSV1VWRkVSWGRLYWxsVVFXVkdkekI1VFVSQmVrMXFXWGROYWtWNlRYcEtZVVozTUhsTmFrRjZUV3BaZDAxcVNYcE5la3BoVFVSQmVBcEdla0ZXUW1kT1ZrSkJiMVJFYms0MVl6TlNiR0pVY0hSWldFNHdXbGhLZWsxU1ZYZEZkMWxFVmxGUlJFVjNlSFJaV0U0d1dsaEthbUpIYkd4aWJsRjNDbWRuU1dsTlFUQkhRMU54UjFOSllqTkVVVVZDUVZGVlFVRTBTVU5FZDBGM1oyZEpTMEZ2U1VOQlVVUlBWRmd3Y2xNclRWQmliMlJ2ZWtoUGRXUXZXbFlLVTB0dVJtc3JPR2RsZUZkdVQzQndXbk5JV21jM1dYWnJZWEpLWm0xUVZETkxiVU53TTBKcFpEWXJZMmh3T0hscmJrTXphMEZhZFZvd1pqQkJlak5XZUFweGMxZHVaMDh2VkZkSVJtSnNPRlp5YzFkVWFGQlJTMHQxVVhaRmVtTlNkemRFWlhKamQwUlpjR2RxYkU0clJtbHVUV1Z1T0dOaWFYZDJZbk50WldoVkNsSnFWMmh0ZDFGYVIwWjNVRzg1UjI1elRqVnZNREZDY3pnMWRrOXJka05HZDFOMFVISlpjRUl6YWtkQ1JrWnVkRXhMUmt0eldXRTBNSGg0U0dwb1UyMEthRTV6ZVRKRWVGRlVjbXBJVld0QlEzUk9TR015TlhsTmFXdHNWa3BrWTNkbVRUaHBMMWh2VEdSQmExbDVTbTlhUzAxcmFWbG5TSGQ1VW5aV2FWTmlUQW80VUdNMU1IZFRZVTVKZVRac1NtMXpaU3R6V1hVM05WZFBkRE5FUjBKR2NXdHJXblF6VDJRNGQyWm1TMHhXZUhWRldGRllhVlU0YkdreWMwdEdkR0Z2Q2taRmFHSmlVazFwTm1NME56aDVlbVJQZUZNM2RreHhkWGhKY2tjNGVXazFSVE53ZW5OcE1XeFVlblpwT0U5bWRFcEVSRFZXTVU1bVUyWmtTVVptUlZRS2JrSXJkRnB1Tnpod2MzWlFNVE13TmxkSmN6WkxjM0JVVUhOdVUzTTRSVFY0WVd0Q1V6UklUMDE1VWtSaVZVOTFWbGxGTVdaYWRqQmpOVmxtWVZCdWNncEROWEZMTlVneGQxVkpWa2xrTTNaaFQyc3liSGd5VVZkNFMzaDVXR3AwVVdSb1MybExPREoyWVhneVJWaE1NbGRFT0hkdk4zVnhNRUZVY2xsbkwwWTRDamQzY21kbFVHdGpRU3RUVUhkQmVEUTROV1pwTjFZNVJsWXpiVTQyY1M4MmVtdEdSekZKTVdkcVZqQXZiazVrUldWYWJESk9ja0ZtTjNaWk5HeDRjWGNLUlhwMmNrbDFOR2hJZWtKcmNtbGpTa00yWTBSaGFqRkxUVGRTUTB4WE9URlVUbTlGTmpKalJVSXlZMHBzVERGdEwyRjFRM1JtYjFBME4zZzJTMlEwV0FwUVNHRjNaRXBVZFRWS1ZIWnpia3AwY0U1TlN6bFJTVVJCVVVGQ2IzcFZkMDE2UVU5Q1owNVdTRkU0UWtGbU9FVkNRVTFEUW1GQmQwVjNXVVJXVWpCc0NrSkJkM2REWjFsSlMzZFpRa0pSVlVoQmQwbDNSRUZaUkZaU01GUkJVVWd2UWtGSmQwRkVRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRUtka1pGVEU1NVRDdExkSEJCWWtGd0x5OXpZbVpFV0dneE1uWk5UbHBUTW5CdFVYTllTbGRUT1hGUmRrSXpXazFCVEVaU2EydHFMM2hWWW5jMFYwa3hWZ281T0RsM1NGQnBTVWh6YlZkNksxRnhiR3hLVWxwdVQzVTBlbVphYm10UE9XTlJMMk14ZVZKSE9HZDFaMFJNWlhWMVNFbE9lSGhoY21wUlpuWnFVVlJWQ25sMlJFSm9XR1JLY3pOSE5rOVlSSFk1TkhGQmN6QkxZbGQxUjAxRFJrWk9NVTE2VmpkWWVFWnBVbFZ2T1dKbFowZHFTMkkwWjJwUmFIUkpUVmhIUjNFS1pHYzJZVkU0TDNGSGNFMUJaMHh6Um01R05VWndkMEoyZVdSdFdHTlJaV0ZuUkhOclNUTTNTMGxaY0RGeFFqRkliVXQwY3pReFFsTk9MMHRKYkd0SFVncHZObXQySzJoRWMzbEtiMDU0Y3pKUmRHcGxXRUpyVG1wbFFtVnZWbWh1V25Wa1VWZEdUR3NyYjJSaGFFSjNWa2t2UjJNNE9HcE9XRVZsTWs1a1RXMXBDbXc1ZUhWcFYwWkdZa1IxY21KeFEzQnFPRUV6T0VobmRtSkNTVGRDVWtaelpVNTRTMUpyUW1reFdVcE9UbXRoYUhOc2NXVmFjV1kzU1c5c2VubFBPR1FLV2tRMlNFNWlNMVIzVGtWSWJGSnNUVEkwYlRkM1ZsSkdXRVpCZHpWaVp6ZGFWM0pZV25KMVNrNUdaelZ2TkhBeVNsUk5aMHRwY0hseGMxVXpUV3M0VUFwMllWVndhR0pUYlhGT2FETllSRlYwYUhGRGVVVjFlVU5OYzA5bGJVcE1XVVZUUVUxUVQzcERibVZETTNKQ2FEY3ZhRzB5VDJkMVEydEJaV3c0YTA5ekNsTkxSM0ZLWWprMWIyZzJRMGxDU1VGTE4wNDNjeTkyY0ZsSVVUVnpjMlI0YjJnMlpWUkNLM0JyUVdOSkwwWlFkVVJMTWxGSEsyaG5XVzl0Y1ZsaGMxY0taVmhtVjIwMlRrdFdSRXgyZERKc1NFRnRjamwzWWpSQ1NsVnpkM1JRYkhsT2IzTkJlRzV1WjBSVlNtaDNVV3hEYWpVMllUUjBWMUJhWW1aRmEya3ZWZ3BQUnpsdlprSmhhRVZVVFVsck5EWmtabVo2TDFKellrbG5WV2t5TTBkd2VuUldUeXQyY3psUVlsaE5QUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJlbXN4T1Vzd2RtcEVNalpJWVUxNGVuSnVaakpXVldsd2VGcFFka2xJYzFad2VuRmhWMkpDTWxsUE1rdzFSM0Y1Q2xnMWFqQTVlWEJuY1dSM1dXNWxkbTVKWVdaTmNFcDNkRFZCUjJKdFpFZzVRVTA1TVdOaGNrWndORVIyTURGb2VGYzFaa1poTjBack5GUXdRMmx5YTB3S2VFMHpSV05QZHpOeE0wMUJNa3RaU1RWVVptaFpjSHBJY0M5SVJ6UnpUREkzU201dlZrVlpNVzlhYzBWSFVtaGpSRFpRVW5BM1JHVmhUazVSWWxCUFlncDZjRXgzYUdORmNsUTJNa3RSWkRSNFoxSlNXamRUZVdoVGNrZEhkVTVOWTFJME5GVndiMVJpVFhSbk9GVkZOalI0TVVwQlFYSlVVak5PZFdOcVNYQktDbFpUV0ZoTlNIcFFTWFl4TmtNelVVcEhUV2xoUjFOcVNrbHRTVUk0VFd0aU1WbHJiWGt2UkROUFpFMUZiV3BUVFhWd1UxcHlTSFp5UjB4MUsxWnFjbVFLZDNoblVtRndTa2RpWkhwdVprMUlNM2xwTVdOaWFFWXdSalJzVUVwWmRISkRhR0pYY1VKU1NWY3lNRlJKZFc1UFR5OU5jek5VYzFWMU4zazJjbk5UU3dwNGRrMXZkVkpPTm1NM1NYUmFWVGczTkhaRWJqZFRVWGNyVm1SVVdEQnVNMU5DV0hoRk5YZG1jbGRhS3k5TFlreDZPV1E1VDJ4cFRFOXBja3RWZWpkS0NqQnlVRUpQWTFkd1FWVjFRbnBxVFd0Uk1qRkVjbXhYUWs1WU1tSTVTRTlYU0RKcU5UWjNkV0ZwZFZJNVkwWkRSbE5JWkRjeWFuQk9jR05rYTBaelUzTUtZMncwTjFWSVdWTnZhWFpPY2pKelpHaEdlVGxzWnk5TlMwODNjWFJCUlRZeVNWQjRaazg0U3pSSWFqVklRVkJyYWpoQlRXVlFUMWcwZFRGbVVsWmtOUXBxWlhGMkszTTFRbEowVTA1WlNURmtVRFY2V0ZKSWJWcGthbUYzU0NzM01rOUtZMkZ6UWswM05ubE1kVWxTT0hkYVN6UnVRMUYxYmtFeWJ6bFRhazh3Q2xGcE1YWmtWWHBoUWs5MGJrSkJaRzVEV2xNNVduWXljbWR5V0RaRUswODRaV2x1WlVaNmVESnpTRk5WTjNWVFZUYzNTbmxpWVZSVVEzWlZRMEYzUlVFS1FWRkxRMEZuUVc1TFRqVlNhMW8wVVVZNVRITlBZVXhpZDNwdGJrSndkbnBRVW14MUswODBjbE5DZURCWFpVdGxhek5wZVdGMU5XYzFkeTlaZFhSeFR3cFpOVVJ2Y1ZKaEsyUk1UMHh4TTIxeGFHZFBZazU0YW01U2JtNXphMXBZYWt4aU5WbFNOMnc0ZDFad1owUjBVWFpVVURGdGFEWnRUVTlsVEVnM1NUZEZDbkJLWmsxb0wyVTBVM1J6YkdSTk1GSlBMM1ZqYmpWV2Rsa3JaVTR4TmxodFpuZzFVVUpUWlRCalJYZHFiMHBqV0VoelZuUmhVRUo1VkdOSlMwbGFhWFlLUkhsdWJsSjBNM1YxYjFrelZuWnNiWHBFZG1WaFdGRTRkMDlPTm0xRk1XcFpWbWhTYUdndll6bGxabWR0TmtsaFdXcFdaRWRCVEVSbWRVNVNLMDQzTkFweVZsTXhVamxzVTAxM1NFNU9UV2sxUm1oR05FOTZVbXhZUW5SYVMzVjRRM1JoVG5sQlptVlZhM2hDTkdoVE1HcEVUVUZqWW1sQllVbEVPWFZGTUZnM0NrcExkSE5MZDFZeVFYaGFRV0pzSzNrclFWWnRRWGRxVjJGWE9XeE5USFJQT0dsWmEyeHJiekJ1U21WM1Jtb3ZVVVo0VGxVeWVVeDZhVVZWUjBSQ1JEQUtTRzFuTUZCbFIxRkhSVFJhS3poeFNsWkpNMnhpY2pZM1ZuaFpabTB5T1VKc2NDOWhSRUpDVmpab09HNVpXRE5PSzJoVEwxZFZabXBtVFZoSU15OVNUd3BTU1V0d0x6bGpZVnA2YmxsVFkyaFVkRzg1Y1cxM2JHdEJiVXRhZUVGMlVIRkVUSHBuUW0xMGRUWkZaMlIwYWpGUmNXNVhjVzVKUlVvME1WZGFjMVpIQ204d1VWQlpkMlpSVjJ0U1JETmlOR05CYjNReVQzaENjbkpXTjNKQ1p6VlpObVpCYWpkM1p6QXJhbGhLY21WYUsxbzJlR0Z5WlZsSWFuaEdjbEpzTVdJS2IxUjViazh4TkRCc1ExTnhZV2MyZUd4T2VtdFhURUZwYkRoQ1VVRTRVRWhSUkRSQ1NIUnRiekY1T0hnME9FSnpibGhNU1hWQ2NtSkRaVFpwTVZCbGVBbzBUV29yT0hGQ1MweFhUVVo0TTB3dkx6ZDJTR05LUjNKR1ZFZDJSa0Z4YjBjMVJtbElVbWswUlhrelVVdzRSREpCVVV0RFFWRkZRVGwzV0ZwS1QwVkxDbXBVV21oS1dsaHZObWMzUW1nM1VVWlJXbTByYzIxU2EwRTJXV1pxYzNWNFpWWnpXV1ZLVVVJclMycHFhM05QYkdWSE5IUlZRMUZWUVRKWWFVSk5VblFLVjBzMmJVMXFXVTlTZW5wUVZIQTNXakpEZVc1T2RWRnpTVEJKZWpaak9XVkRVMWcwY2s1TksxVnlUR293Tkc1U2IxUnFjVXBIYW1aT1ZtZDRjWGREVXdvMWVIaHROeTh4TTI5SWRETTFkakpHTUZVMFMyUlNla3MxTTNsTGN5dElSeXRFVm04cmJWWmFTelp6TlM5SVRVWTRNbFo1YzA5UldISTFlSEZYZURZekNtTldkVEUxVkVST2JtbEhZVXBsYVRCWlRFODBla0oxVVVaUlRERTVaRTFwYjFJelQyaFdhbHBPUmpGRE1USlNhazFIV1VaM1V6VlllbVJRUldvMVMwZ0tUblZsWlROTU1XWlJUMFEwY1hKWFpsUk5ibE0yTXpGdlZHdzFMMjg0UTB3MFZUUnFWM3BsVDFoWU9EWjRVR2xQUkhoRldVRkphakZoU2pnMFRuRnJiZ3BFY3paeGNIUktkR3Q0TmxKRlVVdERRVkZGUVRGamVrOUZTRWx3YW05Q1FYVXJURUZ4YTBaSVVuVmFObVJZU1doT1pWQlFjMFl4VFVaaFJHUnpUMGR1Q2pJdlpGcGlkUzlqWm5OWmRHUlZTRWN5ZVhkMVpTOUNXa3hCWlZoNVVYTjBXV0Y2YUN0SlJrMXJaMlUwVmtsVmVsTXdhV2ROTmpoamFsVTBURmM1Y1VZS1dsQjBiRkJFTDAwdmMzQXZaRlZSUzBSd2FYbDZUVXQyUmtSd1NFNU5hemM1TTJNMGVWRndiRGhQU0ZsNmJFRmpjRWhCVDFJM1p6Vk9UbmxMT1ZOV1NBcHZTSEphVURVNVZsWlhkbEJuVW04NVRrMXZUblZuTWtRNFNUZG1SWGRoVEhoVWQxRkJkbkZQT0hkcFRHWkNkbE5aVjFwR2NqWTJUbVUxTVVJek5TOUJDbHBUZURKbVpHaGpTVXB3YmpKR1JtOU1XbmxDUVM5b05FcHJUM3B3TkdORFdXNVBSVEp5U0hwR1l6YzVaa3RtWWl0emNIaEJPVEJDV25KVVRVMHdhVXdLUlZRM09XTTNWSFpsYnpoaVRGUmxPRFZYWjJ0TVpIWlZWRzlUWVRkQ2MyTjVOa05YTmpaaVluQlJTME5CVVVWQmJXUlpjMmwzYTFST2VXODRhV1J0TkFwUFluVkRlblUxVUhJM1JEbDZOemg0WjJkM09EZDNUSFoyWWtnM2NGZDNXRnBxU2xoME5XcGpVR2R1ZG1Ock9XeHVNVUZrTVM5Wk1GZDBkelZoUmlzNUNuVkxUMjlRTUVGNVZIRjRVVmh4UkhVd0t6VjNkMmhYUVdKS1dWaE1hSEJKV0RsNFJXZG5URGhoUkdzemNVRkZabk5QYzBJd05ITkNPR0ZuUVdVd2ExRUtOMUZMTTJjd1ZYcDRNSFZuZFRWd05IbHVNRWhNUlhSYVZFVTJSekpDYlhneFREVklNa2MwVW5OTGFtNUxhalpEWldJd2FHaDViWG9yU1dGNU1uTTNkZ296Y1VSNWFrNVdSazFGZGpoMFJFRmxTazVsTlUxaFUxSnNiVVZ1YzIxbVNYSlNSeTlvVFVKb0wxVjNjMGhWYVhSTFpWQlBURGxQUkVoaVFsWm5VV0l5Q21kVlRWb3lZMXBQVGs1WmFqUnpRWGMyTURGNWJFSndabWR4Y2xVeloxQldVakpxY1hkeGVFRllRMWMzUjNWdmQxZDZNVGxHY0RFeFZUUldiRkpaYzJFS04yeHdSVFJSUzBOQlVVSjVkbUYxU200dmN6Rm5lR00yZG05TWRqTkpSRWxUUlVaSlluRjJjMHBCY2l0a09VOTRaRGxuUTJGa2FWRmpUSE5MYTNGblpncFZXRkp6UkZwVlVGbDZTeTlUVlhCVFIzWkZWemhIZVRKcmRsaHFWRWRGZG5KbWVqZFFNVVU0UVdkdldVMXpOVGM1TTNGYVNGUnRhRGRHYkRCalJHdDNDazVNVldFeGFEQm1iMFYxTVVsSVlXUjNTR3RsYkhwRlluRnNlRXhoVFRBd04yTkNVbGRUVmtkRGRURm1RMFIxVEZwNVJXTldOVzFPVVhWRU9VTkRTR1lLTm1wQkt6bFViMHczY2xKWVQxcEhjSFJOVGpkcWJsQk5jMjFPVm1SbGNuQXJOV2RCVkRFMGF6YzJTazl0Y25STWMwTllLMUZrYjJKamFsWldZa3A0YXdvd2RtdFJWM2RCZVVkdFFWUktXRWt4T1habFpqTlNSVzFxVTBOeWVtWjZURzh6TjJaUE5tTlFabFEwVWl0TVdXSjZUVkZoWTJOQ1VYcFRSbmQ1TlZsTENtcEhjbXhhV21neU9XVkZWWGt6YlhobFprVTJOMWxKVTNSdGFrbHdOVUZTUVc5SlFrRlJRekp2U2psemQwWk9WblE1SzJ0SmFVdDVOak0yTlcxaWJVRUtiaXRoWTJOWFJFOVhRbUpKWjFWb1IxWm5jMFZpY25Sck5rSnJkazlLYldGclp6WllaRGxqVkZCb1pHUndNRVJOWWs5UlJrRkJiV3BzVlRaMk1HUm5SQXBzU1dSR1VuaHBVbU5oTW00dk9VY3dkelJGYURCQ09YYzRMMGM0ZDJGVVIzWlJUVVJwY25GYVFXUmhiMGRXUzNCa2VFdHVaMlozSzJJMU9HcENiQ3N4Q25GbFVraDNZWE5ZYTNKTFFURnNXVzB4VFdZNVEyTkhXbWxHZUdacU1tcG1PRzloWlZaYU4zRlJValJ6Um10V2VFWTJiVGNyYTBKMFUyWkthV3R3WkU4S1EyTk1hSFZtWjI1RVJXcGpSV05LVEZObWNEbE5ZVUZZWW1SRlFtTnJSWEU0WW5jMVkydGpjRlV4ZUdWRlUwUkdhVGx4ZG1aaVVucHRWblJtWTAxbVVnb3JSM3BVYjFWV0wwbGpTR2hFV2tkaE4xSklla3RRTVRGc1JXRlRPVzV5VTNkdE5YRXZSMVZNZFd4V0sydEJSMVEwZERJMWVWcGFUbU5MTkdRS0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiA3ZDJkYjBkMzFhNjNmNTAzOTAxMzc2MjY3NDViNjU5YTIwYTQyNTIyN2E5YTkxMTY2YWU3ZjRhY2Q4NTIzMmY5MjJhNzRlNmE3ZGQ3YTdlNzg3NGRlYjZkYWU0YjA3YmQ0M2FmZmM1ZGRiZTdjZDdlOGYyM2I3MGZmM2Q4YTMzNQo=\"\n   }\n  ]\n }"
+    }
+  }, {
+    "Method" : "POST",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterUserCredential?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:08 GMT",
+      "server" : "nginx",
+      "content-length" : "12852",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1198",
+      "retry-after" : "0",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "dbcefd30-8b7b-404c-8310-23e8f4d82c03",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022908Z:dbcefd30-8b7b-404c-8310-23e8f4d82c03",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "9c5a4572-0eaa-4808-9785-ecb4654a11f6",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterUser\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICBuYW1lOiBha3M3NjkzNDkKY3VycmVudC1jb250ZXh0OiBha3M3NjkzNDkKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJWbXd5YjBSVllYTXJTbXRTT1VGdWVIRjVORXhvYWtGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNVRVUkJlazFxV1hkTmFrVjZUWHBLWVVaM01IbE5ha0Y2VFdwWmQwMXFTWHBOZWtwaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJQVkZnd2NsTXJUVkJpYjJSdmVraFBkV1F2V2xZS1UwdHVSbXNyT0dkbGVGZHVUM0J3V25OSVdtYzNXWFpyWVhKS1ptMVFWRE5MYlVOd00wSnBaRFlyWTJod09IbHJia016YTBGYWRWb3daakJCZWpOV2VBcHhjMWR1WjA4dlZGZElSbUpzT0ZaeWMxZFVhRkJSUzB0MVVYWkZlbU5TZHpkRVpYSmpkMFJaY0dkcWJFNHJSbWx1VFdWdU9HTmlhWGQyWW5OdFpXaFZDbEpxVjJodGQxRmFSMFozVUc4NVIyNXpUalZ2TURGQ2N6ZzFkazlyZGtOR2QxTjBVSEpaY0VJemFrZENSa1p1ZEV4TFJrdHpXV0UwTUhoNFNHcG9VMjBLYUU1emVUSkVlRkZVY21wSVZXdEJRM1JPU0dNeU5YbE5hV3RzVmtwa1kzZG1UVGhwTDFodlRHUkJhMWw1U205YVMwMXJhVmxuU0hkNVVuWldhVk5pVEFvNFVHTTFNSGRUWVU1SmVUWnNTbTF6WlN0eldYVTNOVmRQZERORVIwSkdjV3RyV25RelQyUTRkMlptUzB4V2VIVkZXRkZZYVZVNGJHa3ljMHRHZEdGdkNrWkZhR0ppVWsxcE5tTTBOemg1ZW1SUGVGTTNka3h4ZFhoSmNrYzRlV2sxUlROd2VuTnBNV3hVZW5acE9FOW1kRXBFUkRWV01VNW1VMlprU1VabVJWUUtia0lyZEZwdU56aHdjM1pRTVRNd05sZEpjelpMYzNCVVVITnVVM000UlRWNFlXdENVelJJVDAxNVVrUmlWVTkxVmxsRk1XWmFkakJqTlZsbVlWQnVjZ3BETlhGTE5VZ3hkMVZKVmtsa00zWmhUMnN5YkhneVVWZDRTM2g1V0dwMFVXUm9TMmxMT0RKMllYZ3lSVmhNTWxkRU9IZHZOM1Z4TUVGVWNsbG5MMFk0Q2pkM2NtZGxVR3RqUVN0VFVIZEJlRFE0TldacE4xWTVSbFl6YlU0MmNTODJlbXRHUnpGSk1XZHFWakF2Yms1a1JXVmFiREpPY2tGbU4zWlpOR3g0Y1hjS1JYcDJja2wxTkdoSWVrSnJjbWxqU2tNMlkwUmhhakZMVFRkU1EweFhPVEZVVG05Rk5qSmpSVUl5WTBwc1RERnRMMkYxUTNSbWIxQTBOM2cyUzJRMFdBcFFTR0YzWkVwVWRUVktWSFp6YmtwMGNFNU5TemxSU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLZGtaRlRFNTVUQ3RMZEhCQllrRndMeTl6WW1aRVdHZ3hNblpOVGxwVE1uQnRVWE5ZU2xkVE9YRlJka0l6V2sxQlRFWlNhMnRxTDNoVlluYzBWMGt4VmdvNU9EbDNTRkJwU1VoemJWZDZLMUZ4Ykd4S1VscHVUM1UwZW1aYWJtdFBPV05STDJNeGVWSkhPR2QxWjBSTVpYVjFTRWxPZUhoaGNtcFJablpxVVZSVkNubDJSRUpvV0dSS2N6TkhOazlZUkhZNU5IRkJjekJMWWxkMVIwMURSa1pPTVUxNlZqZFllRVpwVWxWdk9XSmxaMGRxUzJJMFoycFJhSFJKVFZoSFIzRUtaR2MyWVZFNEwzRkhjRTFCWjB4elJtNUdOVVp3ZDBKMmVXUnRXR05SWldGblJITnJTVE0zUzBsWmNERnhRakZJYlV0MGN6UXhRbE5PTDB0SmJHdEhVZ3B2Tm10MksyaEVjM2xLYjA1NGN6SlJkR3BsV0VKclRtcGxRbVZ2Vm1odVduVmtVVmRHVEdzcmIyUmhhRUozVmtrdlIyTTRPR3BPV0VWbE1rNWtUVzFwQ213NWVIVnBWMFpHWWtSMWNtSnhRM0JxT0VFek9FaG5kbUpDU1RkQ1VrWnpaVTU0UzFKclFta3hXVXBPVG10aGFITnNjV1ZhY1dZM1NXOXNlbmxQT0dRS1drUTJTRTVpTTFSM1RrVkliRkpzVFRJMGJUZDNWbEpHV0VaQmR6VmlaemRhVjNKWVduSjFTazVHWnpWdk5IQXlTbFJOWjB0cGNIbHhjMVV6VFdzNFVBcDJZVlZ3YUdKVGJYRk9hRE5ZUkZWMGFIRkRlVVYxZVVOTmMwOWxiVXBNV1VWVFFVMVFUM3BEYm1WRE0zSkNhRGN2YUcweVQyZDFRMnRCWld3NGEwOXpDbE5MUjNGS1lqazFiMmcyUTBsQ1NVRkxOMDQzY3k5MmNGbElVVFZ6YzJSNGIyZzJaVlJDSzNCclFXTkpMMFpRZFVSTE1sRkhLMmhuV1c5dGNWbGhjMWNLWlZobVYyMDJUa3RXUkV4MmRESnNTRUZ0Y2psM1lqUkNTbFZ6ZDNSUWJIbE9iM05CZUc1dVowUlZTbWgzVVd4RGFqVTJZVFIwVjFCYVltWkZhMmt2VmdwUFJ6bHZaa0poYUVWVVRVbHJORFprWm1aNkwxSnpZa2xuVldreU0wZHdlblJXVHl0MmN6bFFZbGhOUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZW1zeE9Vc3dkbXBFTWpaSVlVMTRlbkp1WmpKV1ZXbHdlRnBRZGtsSWMxWndlbkZoVjJKQ01sbFBNa3cxUjNGNUNsZzFhakE1ZVhCbmNXUjNXVzVsZG01SllXWk5jRXAzZERWQlIySnRaRWc1UVUwNU1XTmhja1p3TkVSMk1ERm9lRmMxWmtaaE4wWnJORlF3UTJseWEwd0tlRTB6UldOUGR6TnhNMDFCTWt0WlNUVlVabWhaY0hwSWNDOUlSelJ6VERJM1NtNXZWa1ZaTVc5YWMwVkhVbWhqUkRaUVVuQTNSR1ZoVGs1UllsQlBZZ3A2Y0V4M2FHTkZjbFEyTWt0UlpEUjRaMUpTV2pkVGVXaFRja2RIZFU1TlkxSTBORlZ3YjFSaVRYUm5PRlZGTmpSNE1VcEJRWEpVVWpOT2RXTnFTWEJLQ2xaVFdGaE5TSHBRU1hZeE5rTXpVVXBIVFdsaFIxTnFTa2x0U1VJNFRXdGlNVmxyYlhrdlJETlBaRTFGYldwVFRYVndVMXB5U0haeVIweDFLMVpxY21RS2QzaG5VbUZ3U2tkaVpIcHVaazFJTTNscE1XTmlhRVl3UmpSc1VFcFpkSEpEYUdKWGNVSlNTVmN5TUZSSmRXNVBUeTlOY3pOVWMxVjFOM2syY25OVFN3cDRkazF2ZFZKT05tTTNTWFJhVlRnM05IWkViamRUVVhjclZtUlVXREJ1TTFOQ1dIaEZOWGRtY2xkYUt5OUxZa3g2T1dRNVQyeHBURTlwY2t0VmVqZEtDakJ5VUVKUFkxZHdRVlYxUW5wcVRXdFJNakZFY214WFFrNVlNbUk1U0U5WFNESnFOVFozZFdGcGRWSTVZMFpEUmxOSVpEY3lhbkJPY0dOa2EwWnpVM01LWTJ3ME4xVklXVk52YVhaT2NqSnpaR2hHZVRsc1p5OU5TMDgzY1hSQlJUWXlTVkI0Wms4NFN6UklhalZJUVZCcmFqaEJUV1ZRVDFnMGRURm1VbFprTlFwcVpYRjJLM00xUWxKMFUwNVpTVEZrVURWNldGSkliVnBrYW1GM1NDczNNazlLWTJGelFrMDNObmxNZFVsU09IZGFTelJ1UTFGMWJrRXliemxUYWs4d0NsRnBNWFprVlhwaFFrOTBia0pCWkc1RFdsTTVXbll5Y21keVdEWkVLMDg0WldsdVpVWjZlREp6U0ZOVk4zVlRWVGMzU25saVlWUlVRM1pWUTBGM1JVRUtRVkZMUTBGblFXNUxUalZTYTFvMFVVWTVUSE5QWVV4aWQzcHRia0p3ZG5wUVVteDFLMDgwY2xOQ2VEQlhaVXRsYXpOcGVXRjFOV2MxZHk5WmRYUnhUd3BaTlVSdmNWSmhLMlJNVDB4eE0yMXhhR2RQWWs1NGFtNVNibTV6YTFwWWFreGlOVmxTTjJ3NGQxWndaMFIwVVhaVVVERnRhRFp0VFU5bFRFZzNTVGRGQ25CS1prMW9MMlUwVTNSemJHUk5NRkpQTDNWamJqVldkbGtyWlU0eE5saHRabmcxVVVKVFpUQmpSWGRxYjBwaldFaHpWblJoVUVKNVZHTkpTMGxhYVhZS1JIbHVibEowTTNWMWIxa3pWblpzYlhwRWRtVmhXRkU0ZDA5T05tMUZNV3BaVm1oU2FHZ3ZZemxsWm1kdE5rbGhXV3BXWkVkQlRFUm1kVTVTSzA0M05BcHlWbE14VWpsc1UwMTNTRTVPVFdrMVJtaEdORTk2VW14WVFuUmFTM1Y0UTNSaFRubEJabVZWYTNoQ05HaFRNR3BFVFVGalltbEJZVWxFT1hWRk1GZzNDa3BMZEhOTGQxWXlRWGhhUVdKc0sza3JRVlp0UVhkcVYyRlhPV3hOVEhSUE9HbFphMnhyYnpCdVNtVjNSbW92VVVaNFRsVXllVXg2YVVWVlIwUkNSREFLU0cxbk1GQmxSMUZIUlRSYUt6aHhTbFpKTTJ4aWNqWTNWbmhaWm0weU9VSnNjQzloUkVKQ1ZqWm9PRzVaV0ROT0syaFRMMWRWWm1wbVRWaElNeTlTVHdwU1NVdHdMemxqWVZwNmJsbFRZMmhVZEc4NWNXMTNiR3RCYlV0YWVFRjJVSEZFVEhwblFtMTBkVFpGWjJSMGFqRlJjVzVYY1c1SlJVbzBNVmRhYzFaSENtOHdVVkJaZDJaUlYydFNSRE5pTkdOQmIzUXlUM2hDY25KV04zSkNaelZaTm1aQmFqZDNaekFyYWxoS2NtVmFLMW8yZUdGeVpWbElhbmhHY2xKc01XSUtiMVI1Yms4eE5EQnNRMU54WVdjMmVHeE9lbXRYVEVGcGJEaENVVUU0VUVoUlJEUkNTSFJ0YnpGNU9IZzBPRUp6YmxoTVNYVkNjbUpEWlRacE1WQmxlQW8wVFdvck9IRkNTMHhYVFVaNE0wd3ZMemQyU0dOS1IzSkdWRWQyUmtGeGIwYzFSbWxJVW1rMFJYa3pVVXc0UkRKQlVVdERRVkZGUVRsM1dGcEtUMFZMQ21wVVdtaEtXbGh2Tm1jM1FtZzNVVVpSV20wcmMyMVNhMEUyV1dacWMzVjRaVlp6V1dWS1VVSXJTMnBxYTNOUGJHVkhOSFJWUTFGVlFUSllhVUpOVW5RS1YwczJiVTFxV1U5U2VucFFWSEEzV2pKRGVXNU9kVkZ6U1RCSmVqWmpPV1ZEVTFnMGNrNU5LMVZ5VEdvd05HNVNiMVJxY1VwSGFtWk9WbWQ0Y1hkRFV3bzFlSGh0Tnk4eE0yOUlkRE0xZGpKR01GVTBTMlJTZWtzMU0zbExjeXRJUnl0RVZtOHJiVlphU3paek5TOUlUVVk0TWxaNWMwOVJXSEkxZUhGWGVEWXpDbU5XZFRFMVZFUk9ibWxIWVVwbGFUQlpURTgwZWtKMVVVWlJUREU1WkUxcGIxSXpUMmhXYWxwT1JqRkRNVEpTYWsxSFdVWjNVelZZZW1SUVJXbzFTMGdLVG5WbFpUTk1NV1pSVDBRMGNYSlhabFJOYmxNMk16RnZWR3cxTDI4NFEwdzBWVFJxVjNwbFQxaFlPRFo0VUdsUFJIaEZXVUZKYWpGaFNqZzBUbkZyYmdwRWN6WnhjSFJLZEd0NE5sSkZVVXREUVZGRlFURmplazlGU0Vsd2FtOUNRWFVyVEVGeGEwWklVblZhTm1SWVNXaE9aVkJRYzBZeFRVWmhSR1J6VDBkdUNqSXZaRnBpZFM5alpuTlpkR1JWU0VjeWVYZDFaUzlDV2t4QlpWaDVVWE4wV1dGNmFDdEpSazFyWjJVMFZrbFZlbE13YVdkTk5qaGphbFUwVEZjNWNVWUtXbEIwYkZCRUwwMHZjM0F2WkZWUlMwUndhWGw2VFV0MlJrUndTRTVOYXpjNU0yTTBlVkZ3YkRoUFNGbDZiRUZqY0VoQlQxSTNaelZPVG5sTE9WTldTQXB2U0hKYVVEVTVWbFpYZGxCblVtODVUazF2VG5Wbk1rUTRTVGRtUlhkaFRIaFVkMUZCZG5GUE9IZHBUR1pDZGxOWlYxcEdjalkyVG1VMU1VSXpOUzlCQ2xwVGVESm1aR2hqU1Vwd2JqSkdSbTlNV25sQ1FTOW9ORXByVDNwd05HTkRXVzVQUlRKeVNIcEdZemM1Wmt0bVlpdHpjSGhCT1RCQ1duSlVUVTB3YVV3S1JWUTNPV00zVkhabGJ6aGlURlJsT0RWWFoydE1aSFpWVkc5VFlUZENjMk41TmtOWE5qWmlZbkJSUzBOQlVVVkJiV1JaYzJsM2ExUk9lVzg0YVdSdE5BcFBZblZEZW5VMVVISTNSRGw2TnpoNFoyZDNPRGQzVEhaMllrZzNjRmQzV0ZwcVNsaDBOV3BqVUdkdWRtTnJPV3h1TVVGa01TOVpNRmQwZHpWaFJpczVDblZMVDI5UU1FRjVWSEY0VVZoeFJIVXdLelYzZDJoWFFXSktXVmhNYUhCSldEbDRSV2RuVERoaFJHc3pjVUZGWm5OUGMwSXdOSE5DT0dGblFXVXdhMUVLTjFGTE0yY3dWWHA0TUhWbmRUVndOSGx1TUVoTVJYUmFWRVUyUnpKQ2JYZ3hURFZJTWtjMFVuTkxhbTVMYWpaRFpXSXdhR2g1YlhvclNXRjVNbk0zZGdvemNVUjVhazVXUmsxRmRqaDBSRUZsU2s1bE5VMWhVMUpzYlVWdWMyMW1TWEpTUnk5b1RVSm9MMVYzYzBoVmFYUkxaVkJQVERsUFJFaGlRbFpuVVdJeUNtZFZUVm95WTFwUFRrNVphalJ6UVhjMk1ERjViRUp3Wm1keGNsVXpaMUJXVWpKcWNYZHhlRUZZUTFjM1IzVnZkMWQ2TVRsR2NERXhWVFJXYkZKWmMyRUtOMnh3UlRSUlMwTkJVVUo1ZG1GMVNtNHZjekZuZUdNMmRtOU1kak5KUkVsVFJVWkpZbkYyYzBwQmNpdGtPVTk0WkRsblEyRmthVkZqVEhOTGEzRm5aZ3BWV0ZKelJGcFZVRmw2U3k5VFZYQlRSM1pGVnpoSGVUSnJkbGhxVkVkRmRuSm1lamRRTVVVNFFXZHZXVTF6TlRjNU0zRmFTRlJ0YURkR2JEQmpSR3QzQ2s1TVZXRXhhREJtYjBWMU1VbElZV1IzU0d0bGJIcEZZbkZzZUV4aFRUQXdOMk5DVWxkVFZrZERkVEZtUTBSMVRGcDVSV05XTlcxT1VYVkVPVU5EU0dZS05tcEJLemxVYjB3M2NsSllUMXBIY0hSTlRqZHFibEJOYzIxT1ZtUmxjbkFyTldkQlZERTBhemMyU2s5dGNuUk1jME5ZSzFGa2IySmphbFpXWWtwNGF3b3dkbXRSVjNkQmVVZHRRVlJLV0VreE9YWmxaak5TUlcxcVUwTnllbVo2VEc4ek4yWlBObU5RWmxRMFVpdE1XV0o2VFZGaFkyTkNVWHBUUm5kNU5WbExDbXBIY214YVdtZ3lPV1ZGVlhremJYaGxaa1UyTjFsSlUzUnRha2x3TlVGU1FXOUpRa0ZSUXpKdlNqbHpkMFpPVm5RNUsydEphVXQ1TmpNMk5XMWliVUVLYml0aFkyTlhSRTlYUW1KSloxVm9SMVpuYzBWaWNuUnJOa0pyZGs5S2JXRnJaelpZWkRsalZGQm9aR1J3TUVSTllrOVJSa0ZCYldwc1ZUWjJNR1JuUkFwc1NXUkdVbmhwVW1OaE1tNHZPVWN3ZHpSRmFEQkNPWGM0TDBjNGQyRlVSM1pSVFVScGNuRmFRV1JoYjBkV1MzQmtlRXR1WjJaM0sySTFPR3BDYkNzeENuRmxVa2gzWVhOWWEzSkxRVEZzV1cweFRXWTVRMk5IV21sR2VHWnFNbXBtT0c5aFpWWmFOM0ZSVWpSelJtdFdlRVkyYlRjcmEwSjBVMlpLYVd0d1pFOEtRMk5NYUhWbVoyNUVSV3BqUldOS1RGTm1jRGxOWVVGWVltUkZRbU5yUlhFNFluYzFZMnRqY0ZVeGVHVkZVMFJHYVRseGRtWmlVbnB0Vm5SbVkwMW1VZ29yUjNwVWIxVldMMGxqU0doRVdrZGhOMUpJZWt0UU1URnNSV0ZUT1c1eVUzZHROWEV2UjFWTWRXeFdLMnRCUjFRMGRESTFlVnBhVG1OTE5HUUtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogZmUwYjU0ZjIyYzhhMGM5OTc0MzBkZjdiNDdlY2MyN2MzZGQyOTBkNWNiNGZhNWRlNmI4Nzk4Mzk1NDJhNzdlYTI2NGU3MjBkZDliZjJlZjc1OTVlZWZkMTIxNWM3OWNjYTBlMmRhYjk2OGQ5ZmQyOWRjNDRmMDZjODVkNjcwYmUK\"\n   }\n  ]\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:08 GMT",
+      "server" : "nginx",
+      "content-length" : "1743",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11896",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d1d255a8-d39f-4ebf-8a62-e1ecd2a7cad1",
+      "x-ms-correlation-request-id" : "9d59db5b-8b15-46e1-9cb2-3cec40e78142",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:d1d255a8-d39f-4ebf-8a62-e1ecd2a7cad1",
-      "content-type" : "application/json; charset=utf-8",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022909Z:9d59db5b-8b15-46e1-9cb2-3cec40e78142",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "d1d255a8-d39f-4ebf-8a62-e1ecd2a7cad1",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "a1fc9a8c-1bc4-4753-b0b7-24758250c1d0",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
     }
   }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Method" : "POST",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterAdminCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
-      "content-length" : "12",
+      "date" : "Thu, 26 Mar 2020 02:29:09 GMT",
+      "server" : "nginx",
+      "content-length" : "12857",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1197",
+      "retry-after" : "0",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "ac1b4e0e-c5c3-4f13-a1d6-4dabfaa18388",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022909Z:ac1b4e0e-c5c3-4f13-a1d6-4dabfaa18388",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5a053bd4-76b5-47e2-8f8f-1f86e5ccf6c5",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterAdmin\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyQWRtaW5fYWtzNzY5MzQ5Z3JvdXBfYWtzNzY5MzQ5CiAgbmFtZTogYWtzNzY5MzQ5CmN1cnJlbnQtY29udGV4dDogYWtzNzY5MzQ5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlckFkbWluX2Frczc2OTM0OWdyb3VwX2Frczc2OTM0OQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZSRU5EUVhWVFowRjNTVUpCWjBsUlZtd3liMFJWWVhNclNtdFNPVUZ1ZUhGNU5FeG9ha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRnpSa0ZFUVU0S1RWRnpkME5SV1VSV1VWRkVSWGRLYWxsVVFXVkdkekI1VFVSQmVrMXFXWGROYWtWNlRYcEtZVVozTUhsTmFrRjZUV3BaZDAxcVNYcE5la3BoVFVSQmVBcEdla0ZXUW1kT1ZrSkJiMVJFYms0MVl6TlNiR0pVY0hSWldFNHdXbGhLZWsxU1ZYZEZkMWxFVmxGUlJFVjNlSFJaV0U0d1dsaEthbUpIYkd4aWJsRjNDbWRuU1dsTlFUQkhRMU54UjFOSllqTkVVVVZDUVZGVlFVRTBTVU5FZDBGM1oyZEpTMEZ2U1VOQlVVUlBWRmd3Y2xNclRWQmliMlJ2ZWtoUGRXUXZXbFlLVTB0dVJtc3JPR2RsZUZkdVQzQndXbk5JV21jM1dYWnJZWEpLWm0xUVZETkxiVU53TTBKcFpEWXJZMmh3T0hscmJrTXphMEZhZFZvd1pqQkJlak5XZUFweGMxZHVaMDh2VkZkSVJtSnNPRlp5YzFkVWFGQlJTMHQxVVhaRmVtTlNkemRFWlhKamQwUlpjR2RxYkU0clJtbHVUV1Z1T0dOaWFYZDJZbk50WldoVkNsSnFWMmh0ZDFGYVIwWjNVRzg1UjI1elRqVnZNREZDY3pnMWRrOXJka05HZDFOMFVISlpjRUl6YWtkQ1JrWnVkRXhMUmt0eldXRTBNSGg0U0dwb1UyMEthRTV6ZVRKRWVGRlVjbXBJVld0QlEzUk9TR015TlhsTmFXdHNWa3BrWTNkbVRUaHBMMWh2VEdSQmExbDVTbTlhUzAxcmFWbG5TSGQ1VW5aV2FWTmlUQW80VUdNMU1IZFRZVTVKZVRac1NtMXpaU3R6V1hVM05WZFBkRE5FUjBKR2NXdHJXblF6VDJRNGQyWm1TMHhXZUhWRldGRllhVlU0YkdreWMwdEdkR0Z2Q2taRmFHSmlVazFwTm1NME56aDVlbVJQZUZNM2RreHhkWGhKY2tjNGVXazFSVE53ZW5OcE1XeFVlblpwT0U5bWRFcEVSRFZXTVU1bVUyWmtTVVptUlZRS2JrSXJkRnB1Tnpod2MzWlFNVE13TmxkSmN6WkxjM0JVVUhOdVUzTTRSVFY0WVd0Q1V6UklUMDE1VWtSaVZVOTFWbGxGTVdaYWRqQmpOVmxtWVZCdWNncEROWEZMTlVneGQxVkpWa2xrTTNaaFQyc3liSGd5VVZkNFMzaDVXR3AwVVdSb1MybExPREoyWVhneVJWaE1NbGRFT0hkdk4zVnhNRUZVY2xsbkwwWTRDamQzY21kbFVHdGpRU3RUVUhkQmVEUTROV1pwTjFZNVJsWXpiVTQyY1M4MmVtdEdSekZKTVdkcVZqQXZiazVrUldWYWJESk9ja0ZtTjNaWk5HeDRjWGNLUlhwMmNrbDFOR2hJZWtKcmNtbGpTa00yWTBSaGFqRkxUVGRTUTB4WE9URlVUbTlGTmpKalJVSXlZMHBzVERGdEwyRjFRM1JtYjFBME4zZzJTMlEwV0FwUVNHRjNaRXBVZFRWS1ZIWnpia3AwY0U1TlN6bFJTVVJCVVVGQ2IzcFZkMDE2UVU5Q1owNVdTRkU0UWtGbU9FVkNRVTFEUW1GQmQwVjNXVVJXVWpCc0NrSkJkM2REWjFsSlMzZFpRa0pSVlVoQmQwbDNSRUZaUkZaU01GUkJVVWd2UWtGSmQwRkVRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRUtka1pGVEU1NVRDdExkSEJCWWtGd0x5OXpZbVpFV0dneE1uWk5UbHBUTW5CdFVYTllTbGRUT1hGUmRrSXpXazFCVEVaU2EydHFMM2hWWW5jMFYwa3hWZ281T0RsM1NGQnBTVWh6YlZkNksxRnhiR3hLVWxwdVQzVTBlbVphYm10UE9XTlJMMk14ZVZKSE9HZDFaMFJNWlhWMVNFbE9lSGhoY21wUlpuWnFVVlJWQ25sMlJFSm9XR1JLY3pOSE5rOVlSSFk1TkhGQmN6QkxZbGQxUjAxRFJrWk9NVTE2VmpkWWVFWnBVbFZ2T1dKbFowZHFTMkkwWjJwUmFIUkpUVmhIUjNFS1pHYzJZVkU0TDNGSGNFMUJaMHh6Um01R05VWndkMEoyZVdSdFdHTlJaV0ZuUkhOclNUTTNTMGxaY0RGeFFqRkliVXQwY3pReFFsTk9MMHRKYkd0SFVncHZObXQySzJoRWMzbEtiMDU0Y3pKUmRHcGxXRUpyVG1wbFFtVnZWbWh1V25Wa1VWZEdUR3NyYjJSaGFFSjNWa2t2UjJNNE9HcE9XRVZsTWs1a1RXMXBDbXc1ZUhWcFYwWkdZa1IxY21KeFEzQnFPRUV6T0VobmRtSkNTVGRDVWtaelpVNTRTMUpyUW1reFdVcE9UbXRoYUhOc2NXVmFjV1kzU1c5c2VubFBPR1FLV2tRMlNFNWlNMVIzVGtWSWJGSnNUVEkwYlRkM1ZsSkdXRVpCZHpWaVp6ZGFWM0pZV25KMVNrNUdaelZ2TkhBeVNsUk5aMHRwY0hseGMxVXpUV3M0VUFwMllWVndhR0pUYlhGT2FETllSRlYwYUhGRGVVVjFlVU5OYzA5bGJVcE1XVVZUUVUxUVQzcERibVZETTNKQ2FEY3ZhRzB5VDJkMVEydEJaV3c0YTA5ekNsTkxSM0ZLWWprMWIyZzJRMGxDU1VGTE4wNDNjeTkyY0ZsSVVUVnpjMlI0YjJnMlpWUkNLM0JyUVdOSkwwWlFkVVJMTWxGSEsyaG5XVzl0Y1ZsaGMxY0taVmhtVjIwMlRrdFdSRXgyZERKc1NFRnRjamwzWWpSQ1NsVnpkM1JRYkhsT2IzTkJlRzV1WjBSVlNtaDNVV3hEYWpVMllUUjBWMUJhWW1aRmEya3ZWZ3BQUnpsdlprSmhhRVZVVFVsck5EWmtabVo2TDFKellrbG5WV2t5TTBkd2VuUldUeXQyY3psUVlsaE5QUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJlbXN4T1Vzd2RtcEVNalpJWVUxNGVuSnVaakpXVldsd2VGcFFka2xJYzFad2VuRmhWMkpDTWxsUE1rdzFSM0Y1Q2xnMWFqQTVlWEJuY1dSM1dXNWxkbTVKWVdaTmNFcDNkRFZCUjJKdFpFZzVRVTA1TVdOaGNrWndORVIyTURGb2VGYzFaa1poTjBack5GUXdRMmx5YTB3S2VFMHpSV05QZHpOeE0wMUJNa3RaU1RWVVptaFpjSHBJY0M5SVJ6UnpUREkzU201dlZrVlpNVzlhYzBWSFVtaGpSRFpRVW5BM1JHVmhUazVSWWxCUFlncDZjRXgzYUdORmNsUTJNa3RSWkRSNFoxSlNXamRUZVdoVGNrZEhkVTVOWTFJME5GVndiMVJpVFhSbk9GVkZOalI0TVVwQlFYSlVVak5PZFdOcVNYQktDbFpUV0ZoTlNIcFFTWFl4TmtNelVVcEhUV2xoUjFOcVNrbHRTVUk0VFd0aU1WbHJiWGt2UkROUFpFMUZiV3BUVFhWd1UxcHlTSFp5UjB4MUsxWnFjbVFLZDNoblVtRndTa2RpWkhwdVprMUlNM2xwTVdOaWFFWXdSalJzVUVwWmRISkRhR0pYY1VKU1NWY3lNRlJKZFc1UFR5OU5jek5VYzFWMU4zazJjbk5UU3dwNGRrMXZkVkpPTm1NM1NYUmFWVGczTkhaRWJqZFRVWGNyVm1SVVdEQnVNMU5DV0hoRk5YZG1jbGRhS3k5TFlreDZPV1E1VDJ4cFRFOXBja3RWZWpkS0NqQnlVRUpQWTFkd1FWVjFRbnBxVFd0Uk1qRkVjbXhYUWs1WU1tSTVTRTlYU0RKcU5UWjNkV0ZwZFZJNVkwWkRSbE5JWkRjeWFuQk9jR05rYTBaelUzTUtZMncwTjFWSVdWTnZhWFpPY2pKelpHaEdlVGxzWnk5TlMwODNjWFJCUlRZeVNWQjRaazg0U3pSSWFqVklRVkJyYWpoQlRXVlFUMWcwZFRGbVVsWmtOUXBxWlhGMkszTTFRbEowVTA1WlNURmtVRFY2V0ZKSWJWcGthbUYzU0NzM01rOUtZMkZ6UWswM05ubE1kVWxTT0hkYVN6UnVRMUYxYmtFeWJ6bFRhazh3Q2xGcE1YWmtWWHBoUWs5MGJrSkJaRzVEV2xNNVduWXljbWR5V0RaRUswODRaV2x1WlVaNmVESnpTRk5WTjNWVFZUYzNTbmxpWVZSVVEzWlZRMEYzUlVFS1FWRkxRMEZuUVc1TFRqVlNhMW8wVVVZNVRITlBZVXhpZDNwdGJrSndkbnBRVW14MUswODBjbE5DZURCWFpVdGxhek5wZVdGMU5XYzFkeTlaZFhSeFR3cFpOVVJ2Y1ZKaEsyUk1UMHh4TTIxeGFHZFBZazU0YW01U2JtNXphMXBZYWt4aU5WbFNOMnc0ZDFad1owUjBVWFpVVURGdGFEWnRUVTlsVEVnM1NUZEZDbkJLWmsxb0wyVTBVM1J6YkdSTk1GSlBMM1ZqYmpWV2Rsa3JaVTR4TmxodFpuZzFVVUpUWlRCalJYZHFiMHBqV0VoelZuUmhVRUo1VkdOSlMwbGFhWFlLUkhsdWJsSjBNM1YxYjFrelZuWnNiWHBFZG1WaFdGRTRkMDlPTm0xRk1XcFpWbWhTYUdndll6bGxabWR0TmtsaFdXcFdaRWRCVEVSbWRVNVNLMDQzTkFweVZsTXhVamxzVTAxM1NFNU9UV2sxUm1oR05FOTZVbXhZUW5SYVMzVjRRM1JoVG5sQlptVlZhM2hDTkdoVE1HcEVUVUZqWW1sQllVbEVPWFZGTUZnM0NrcExkSE5MZDFZeVFYaGFRV0pzSzNrclFWWnRRWGRxVjJGWE9XeE5USFJQT0dsWmEyeHJiekJ1U21WM1Jtb3ZVVVo0VGxVeWVVeDZhVVZWUjBSQ1JEQUtTRzFuTUZCbFIxRkhSVFJhS3poeFNsWkpNMnhpY2pZM1ZuaFpabTB5T1VKc2NDOWhSRUpDVmpab09HNVpXRE5PSzJoVEwxZFZabXBtVFZoSU15OVNUd3BTU1V0d0x6bGpZVnA2YmxsVFkyaFVkRzg1Y1cxM2JHdEJiVXRhZUVGMlVIRkVUSHBuUW0xMGRUWkZaMlIwYWpGUmNXNVhjVzVKUlVvME1WZGFjMVpIQ204d1VWQlpkMlpSVjJ0U1JETmlOR05CYjNReVQzaENjbkpXTjNKQ1p6VlpObVpCYWpkM1p6QXJhbGhLY21WYUsxbzJlR0Z5WlZsSWFuaEdjbEpzTVdJS2IxUjViazh4TkRCc1ExTnhZV2MyZUd4T2VtdFhURUZwYkRoQ1VVRTRVRWhSUkRSQ1NIUnRiekY1T0hnME9FSnpibGhNU1hWQ2NtSkRaVFpwTVZCbGVBbzBUV29yT0hGQ1MweFhUVVo0TTB3dkx6ZDJTR05LUjNKR1ZFZDJSa0Z4YjBjMVJtbElVbWswUlhrelVVdzRSREpCVVV0RFFWRkZRVGwzV0ZwS1QwVkxDbXBVV21oS1dsaHZObWMzUW1nM1VVWlJXbTByYzIxU2EwRTJXV1pxYzNWNFpWWnpXV1ZLVVVJclMycHFhM05QYkdWSE5IUlZRMUZWUVRKWWFVSk5VblFLVjBzMmJVMXFXVTlTZW5wUVZIQTNXakpEZVc1T2RWRnpTVEJKZWpaak9XVkRVMWcwY2s1TksxVnlUR293Tkc1U2IxUnFjVXBIYW1aT1ZtZDRjWGREVXdvMWVIaHROeTh4TTI5SWRETTFkakpHTUZVMFMyUlNla3MxTTNsTGN5dElSeXRFVm04cmJWWmFTelp6TlM5SVRVWTRNbFo1YzA5UldISTFlSEZYZURZekNtTldkVEUxVkVST2JtbEhZVXBsYVRCWlRFODBla0oxVVVaUlRERTVaRTFwYjFJelQyaFdhbHBPUmpGRE1USlNhazFIV1VaM1V6VlllbVJRUldvMVMwZ0tUblZsWlROTU1XWlJUMFEwY1hKWFpsUk5ibE0yTXpGdlZHdzFMMjg0UTB3MFZUUnFWM3BsVDFoWU9EWjRVR2xQUkhoRldVRkphakZoU2pnMFRuRnJiZ3BFY3paeGNIUktkR3Q0TmxKRlVVdERRVkZGUVRGamVrOUZTRWx3YW05Q1FYVXJURUZ4YTBaSVVuVmFObVJZU1doT1pWQlFjMFl4VFVaaFJHUnpUMGR1Q2pJdlpGcGlkUzlqWm5OWmRHUlZTRWN5ZVhkMVpTOUNXa3hCWlZoNVVYTjBXV0Y2YUN0SlJrMXJaMlUwVmtsVmVsTXdhV2ROTmpoamFsVTBURmM1Y1VZS1dsQjBiRkJFTDAwdmMzQXZaRlZSUzBSd2FYbDZUVXQyUmtSd1NFNU5hemM1TTJNMGVWRndiRGhQU0ZsNmJFRmpjRWhCVDFJM1p6Vk9UbmxMT1ZOV1NBcHZTSEphVURVNVZsWlhkbEJuVW04NVRrMXZUblZuTWtRNFNUZG1SWGRoVEhoVWQxRkJkbkZQT0hkcFRHWkNkbE5aVjFwR2NqWTJUbVUxTVVJek5TOUJDbHBUZURKbVpHaGpTVXB3YmpKR1JtOU1XbmxDUVM5b05FcHJUM3B3TkdORFdXNVBSVEp5U0hwR1l6YzVaa3RtWWl0emNIaEJPVEJDV25KVVRVMHdhVXdLUlZRM09XTTNWSFpsYnpoaVRGUmxPRFZYWjJ0TVpIWlZWRzlUWVRkQ2MyTjVOa05YTmpaaVluQlJTME5CVVVWQmJXUlpjMmwzYTFST2VXODRhV1J0TkFwUFluVkRlblUxVUhJM1JEbDZOemg0WjJkM09EZDNUSFoyWWtnM2NGZDNXRnBxU2xoME5XcGpVR2R1ZG1Ock9XeHVNVUZrTVM5Wk1GZDBkelZoUmlzNUNuVkxUMjlRTUVGNVZIRjRVVmh4UkhVd0t6VjNkMmhYUVdKS1dWaE1hSEJKV0RsNFJXZG5URGhoUkdzemNVRkZabk5QYzBJd05ITkNPR0ZuUVdVd2ExRUtOMUZMTTJjd1ZYcDRNSFZuZFRWd05IbHVNRWhNUlhSYVZFVTJSekpDYlhneFREVklNa2MwVW5OTGFtNUxhalpEWldJd2FHaDViWG9yU1dGNU1uTTNkZ296Y1VSNWFrNVdSazFGZGpoMFJFRmxTazVsTlUxaFUxSnNiVVZ1YzIxbVNYSlNSeTlvVFVKb0wxVjNjMGhWYVhSTFpWQlBURGxQUkVoaVFsWm5VV0l5Q21kVlRWb3lZMXBQVGs1WmFqUnpRWGMyTURGNWJFSndabWR4Y2xVeloxQldVakpxY1hkeGVFRllRMWMzUjNWdmQxZDZNVGxHY0RFeFZUUldiRkpaYzJFS04yeHdSVFJSUzBOQlVVSjVkbUYxU200dmN6Rm5lR00yZG05TWRqTkpSRWxUUlVaSlluRjJjMHBCY2l0a09VOTRaRGxuUTJGa2FWRmpUSE5MYTNGblpncFZXRkp6UkZwVlVGbDZTeTlUVlhCVFIzWkZWemhIZVRKcmRsaHFWRWRGZG5KbWVqZFFNVVU0UVdkdldVMXpOVGM1TTNGYVNGUnRhRGRHYkRCalJHdDNDazVNVldFeGFEQm1iMFYxTVVsSVlXUjNTR3RsYkhwRlluRnNlRXhoVFRBd04yTkNVbGRUVmtkRGRURm1RMFIxVEZwNVJXTldOVzFPVVhWRU9VTkRTR1lLTm1wQkt6bFViMHczY2xKWVQxcEhjSFJOVGpkcWJsQk5jMjFPVm1SbGNuQXJOV2RCVkRFMGF6YzJTazl0Y25STWMwTllLMUZrYjJKamFsWldZa3A0YXdvd2RtdFJWM2RCZVVkdFFWUktXRWt4T1habFpqTlNSVzFxVTBOeWVtWjZURzh6TjJaUE5tTlFabFEwVWl0TVdXSjZUVkZoWTJOQ1VYcFRSbmQ1TlZsTENtcEhjbXhhV21neU9XVkZWWGt6YlhobFprVTJOMWxKVTNSdGFrbHdOVUZTUVc5SlFrRlJRekp2U2psemQwWk9WblE1SzJ0SmFVdDVOak0yTlcxaWJVRUtiaXRoWTJOWFJFOVhRbUpKWjFWb1IxWm5jMFZpY25Sck5rSnJkazlLYldGclp6WllaRGxqVkZCb1pHUndNRVJOWWs5UlJrRkJiV3BzVlRaMk1HUm5SQXBzU1dSR1VuaHBVbU5oTW00dk9VY3dkelJGYURCQ09YYzRMMGM0ZDJGVVIzWlJUVVJwY25GYVFXUmhiMGRXUzNCa2VFdHVaMlozSzJJMU9HcENiQ3N4Q25GbFVraDNZWE5ZYTNKTFFURnNXVzB4VFdZNVEyTkhXbWxHZUdacU1tcG1PRzloWlZaYU4zRlJValJ6Um10V2VFWTJiVGNyYTBKMFUyWkthV3R3WkU4S1EyTk1hSFZtWjI1RVJXcGpSV05LVEZObWNEbE5ZVUZZWW1SRlFtTnJSWEU0WW5jMVkydGpjRlV4ZUdWRlUwUkdhVGx4ZG1aaVVucHRWblJtWTAxbVVnb3JSM3BVYjFWV0wwbGpTR2hFV2tkaE4xSklla3RRTVRGc1JXRlRPVzV5VTNkdE5YRXZSMVZNZFd4V0sydEJSMVEwZERJMWVWcGFUbU5MTkdRS0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiA3ZDJkYjBkMzFhNjNmNTAzOTAxMzc2MjY3NDViNjU5YTIwYTQyNTIyN2E5YTkxMTY2YWU3ZjRhY2Q4NTIzMmY5MjJhNzRlNmE3ZGQ3YTdlNzg3NGRlYjZkYWU0YjA3YmQ0M2FmZmM1ZGRiZTdjZDdlOGYyM2I3MGZmM2Q4YTMzNQo=\"\n   }\n  ]\n }"
+    }
+  }, {
+    "Method" : "POST",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterUserCredential?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:09 GMT",
+      "server" : "nginx",
+      "content-length" : "12852",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "x-ms-ratelimit-remaining-subscription-writes" : "1196",
+      "retry-after" : "0",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "ec0a7565-8f3b-491b-93ba-a7bc5895070f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022910Z:ec0a7565-8f3b-491b-93ba-a7bc5895070f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "57a65777-d691-4b3a-9cb5-ac5c349b16d7",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterUser\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICBuYW1lOiBha3M3NjkzNDkKY3VycmVudC1jb250ZXh0OiBha3M3NjkzNDkKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJWbXd5YjBSVllYTXJTbXRTT1VGdWVIRjVORXhvYWtGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNVRVUkJlazFxV1hkTmFrVjZUWHBLWVVaM01IbE5ha0Y2VFdwWmQwMXFTWHBOZWtwaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJQVkZnd2NsTXJUVkJpYjJSdmVraFBkV1F2V2xZS1UwdHVSbXNyT0dkbGVGZHVUM0J3V25OSVdtYzNXWFpyWVhKS1ptMVFWRE5MYlVOd00wSnBaRFlyWTJod09IbHJia016YTBGYWRWb3daakJCZWpOV2VBcHhjMWR1WjA4dlZGZElSbUpzT0ZaeWMxZFVhRkJSUzB0MVVYWkZlbU5TZHpkRVpYSmpkMFJaY0dkcWJFNHJSbWx1VFdWdU9HTmlhWGQyWW5OdFpXaFZDbEpxVjJodGQxRmFSMFozVUc4NVIyNXpUalZ2TURGQ2N6ZzFkazlyZGtOR2QxTjBVSEpaY0VJemFrZENSa1p1ZEV4TFJrdHpXV0UwTUhoNFNHcG9VMjBLYUU1emVUSkVlRkZVY21wSVZXdEJRM1JPU0dNeU5YbE5hV3RzVmtwa1kzZG1UVGhwTDFodlRHUkJhMWw1U205YVMwMXJhVmxuU0hkNVVuWldhVk5pVEFvNFVHTTFNSGRUWVU1SmVUWnNTbTF6WlN0eldYVTNOVmRQZERORVIwSkdjV3RyV25RelQyUTRkMlptUzB4V2VIVkZXRkZZYVZVNGJHa3ljMHRHZEdGdkNrWkZhR0ppVWsxcE5tTTBOemg1ZW1SUGVGTTNka3h4ZFhoSmNrYzRlV2sxUlROd2VuTnBNV3hVZW5acE9FOW1kRXBFUkRWV01VNW1VMlprU1VabVJWUUtia0lyZEZwdU56aHdjM1pRTVRNd05sZEpjelpMYzNCVVVITnVVM000UlRWNFlXdENVelJJVDAxNVVrUmlWVTkxVmxsRk1XWmFkakJqTlZsbVlWQnVjZ3BETlhGTE5VZ3hkMVZKVmtsa00zWmhUMnN5YkhneVVWZDRTM2g1V0dwMFVXUm9TMmxMT0RKMllYZ3lSVmhNTWxkRU9IZHZOM1Z4TUVGVWNsbG5MMFk0Q2pkM2NtZGxVR3RqUVN0VFVIZEJlRFE0TldacE4xWTVSbFl6YlU0MmNTODJlbXRHUnpGSk1XZHFWakF2Yms1a1JXVmFiREpPY2tGbU4zWlpOR3g0Y1hjS1JYcDJja2wxTkdoSWVrSnJjbWxqU2tNMlkwUmhhakZMVFRkU1EweFhPVEZVVG05Rk5qSmpSVUl5WTBwc1RERnRMMkYxUTNSbWIxQTBOM2cyUzJRMFdBcFFTR0YzWkVwVWRUVktWSFp6YmtwMGNFNU5TemxSU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLZGtaRlRFNTVUQ3RMZEhCQllrRndMeTl6WW1aRVdHZ3hNblpOVGxwVE1uQnRVWE5ZU2xkVE9YRlJka0l6V2sxQlRFWlNhMnRxTDNoVlluYzBWMGt4VmdvNU9EbDNTRkJwU1VoemJWZDZLMUZ4Ykd4S1VscHVUM1UwZW1aYWJtdFBPV05STDJNeGVWSkhPR2QxWjBSTVpYVjFTRWxPZUhoaGNtcFJablpxVVZSVkNubDJSRUpvV0dSS2N6TkhOazlZUkhZNU5IRkJjekJMWWxkMVIwMURSa1pPTVUxNlZqZFllRVpwVWxWdk9XSmxaMGRxUzJJMFoycFJhSFJKVFZoSFIzRUtaR2MyWVZFNEwzRkhjRTFCWjB4elJtNUdOVVp3ZDBKMmVXUnRXR05SWldGblJITnJTVE0zUzBsWmNERnhRakZJYlV0MGN6UXhRbE5PTDB0SmJHdEhVZ3B2Tm10MksyaEVjM2xLYjA1NGN6SlJkR3BsV0VKclRtcGxRbVZ2Vm1odVduVmtVVmRHVEdzcmIyUmhhRUozVmtrdlIyTTRPR3BPV0VWbE1rNWtUVzFwQ213NWVIVnBWMFpHWWtSMWNtSnhRM0JxT0VFek9FaG5kbUpDU1RkQ1VrWnpaVTU0UzFKclFta3hXVXBPVG10aGFITnNjV1ZhY1dZM1NXOXNlbmxQT0dRS1drUTJTRTVpTTFSM1RrVkliRkpzVFRJMGJUZDNWbEpHV0VaQmR6VmlaemRhVjNKWVduSjFTazVHWnpWdk5IQXlTbFJOWjB0cGNIbHhjMVV6VFdzNFVBcDJZVlZ3YUdKVGJYRk9hRE5ZUkZWMGFIRkRlVVYxZVVOTmMwOWxiVXBNV1VWVFFVMVFUM3BEYm1WRE0zSkNhRGN2YUcweVQyZDFRMnRCWld3NGEwOXpDbE5MUjNGS1lqazFiMmcyUTBsQ1NVRkxOMDQzY3k5MmNGbElVVFZ6YzJSNGIyZzJaVlJDSzNCclFXTkpMMFpRZFVSTE1sRkhLMmhuV1c5dGNWbGhjMWNLWlZobVYyMDJUa3RXUkV4MmRESnNTRUZ0Y2psM1lqUkNTbFZ6ZDNSUWJIbE9iM05CZUc1dVowUlZTbWgzVVd4RGFqVTJZVFIwVjFCYVltWkZhMmt2VmdwUFJ6bHZaa0poYUVWVVRVbHJORFprWm1aNkwxSnpZa2xuVldreU0wZHdlblJXVHl0MmN6bFFZbGhOUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZW1zeE9Vc3dkbXBFTWpaSVlVMTRlbkp1WmpKV1ZXbHdlRnBRZGtsSWMxWndlbkZoVjJKQ01sbFBNa3cxUjNGNUNsZzFhakE1ZVhCbmNXUjNXVzVsZG01SllXWk5jRXAzZERWQlIySnRaRWc1UVUwNU1XTmhja1p3TkVSMk1ERm9lRmMxWmtaaE4wWnJORlF3UTJseWEwd0tlRTB6UldOUGR6TnhNMDFCTWt0WlNUVlVabWhaY0hwSWNDOUlSelJ6VERJM1NtNXZWa1ZaTVc5YWMwVkhVbWhqUkRaUVVuQTNSR1ZoVGs1UllsQlBZZ3A2Y0V4M2FHTkZjbFEyTWt0UlpEUjRaMUpTV2pkVGVXaFRja2RIZFU1TlkxSTBORlZ3YjFSaVRYUm5PRlZGTmpSNE1VcEJRWEpVVWpOT2RXTnFTWEJLQ2xaVFdGaE5TSHBRU1hZeE5rTXpVVXBIVFdsaFIxTnFTa2x0U1VJNFRXdGlNVmxyYlhrdlJETlBaRTFGYldwVFRYVndVMXB5U0haeVIweDFLMVpxY21RS2QzaG5VbUZ3U2tkaVpIcHVaazFJTTNscE1XTmlhRVl3UmpSc1VFcFpkSEpEYUdKWGNVSlNTVmN5TUZSSmRXNVBUeTlOY3pOVWMxVjFOM2syY25OVFN3cDRkazF2ZFZKT05tTTNTWFJhVlRnM05IWkViamRUVVhjclZtUlVXREJ1TTFOQ1dIaEZOWGRtY2xkYUt5OUxZa3g2T1dRNVQyeHBURTlwY2t0VmVqZEtDakJ5VUVKUFkxZHdRVlYxUW5wcVRXdFJNakZFY214WFFrNVlNbUk1U0U5WFNESnFOVFozZFdGcGRWSTVZMFpEUmxOSVpEY3lhbkJPY0dOa2EwWnpVM01LWTJ3ME4xVklXVk52YVhaT2NqSnpaR2hHZVRsc1p5OU5TMDgzY1hSQlJUWXlTVkI0Wms4NFN6UklhalZJUVZCcmFqaEJUV1ZRVDFnMGRURm1VbFprTlFwcVpYRjJLM00xUWxKMFUwNVpTVEZrVURWNldGSkliVnBrYW1GM1NDczNNazlLWTJGelFrMDNObmxNZFVsU09IZGFTelJ1UTFGMWJrRXliemxUYWs4d0NsRnBNWFprVlhwaFFrOTBia0pCWkc1RFdsTTVXbll5Y21keVdEWkVLMDg0WldsdVpVWjZlREp6U0ZOVk4zVlRWVGMzU25saVlWUlVRM1pWUTBGM1JVRUtRVkZMUTBGblFXNUxUalZTYTFvMFVVWTVUSE5QWVV4aWQzcHRia0p3ZG5wUVVteDFLMDgwY2xOQ2VEQlhaVXRsYXpOcGVXRjFOV2MxZHk5WmRYUnhUd3BaTlVSdmNWSmhLMlJNVDB4eE0yMXhhR2RQWWs1NGFtNVNibTV6YTFwWWFreGlOVmxTTjJ3NGQxWndaMFIwVVhaVVVERnRhRFp0VFU5bFRFZzNTVGRGQ25CS1prMW9MMlUwVTNSemJHUk5NRkpQTDNWamJqVldkbGtyWlU0eE5saHRabmcxVVVKVFpUQmpSWGRxYjBwaldFaHpWblJoVUVKNVZHTkpTMGxhYVhZS1JIbHVibEowTTNWMWIxa3pWblpzYlhwRWRtVmhXRkU0ZDA5T05tMUZNV3BaVm1oU2FHZ3ZZemxsWm1kdE5rbGhXV3BXWkVkQlRFUm1kVTVTSzA0M05BcHlWbE14VWpsc1UwMTNTRTVPVFdrMVJtaEdORTk2VW14WVFuUmFTM1Y0UTNSaFRubEJabVZWYTNoQ05HaFRNR3BFVFVGalltbEJZVWxFT1hWRk1GZzNDa3BMZEhOTGQxWXlRWGhhUVdKc0sza3JRVlp0UVhkcVYyRlhPV3hOVEhSUE9HbFphMnhyYnpCdVNtVjNSbW92VVVaNFRsVXllVXg2YVVWVlIwUkNSREFLU0cxbk1GQmxSMUZIUlRSYUt6aHhTbFpKTTJ4aWNqWTNWbmhaWm0weU9VSnNjQzloUkVKQ1ZqWm9PRzVaV0ROT0syaFRMMWRWWm1wbVRWaElNeTlTVHdwU1NVdHdMemxqWVZwNmJsbFRZMmhVZEc4NWNXMTNiR3RCYlV0YWVFRjJVSEZFVEhwblFtMTBkVFpGWjJSMGFqRlJjVzVYY1c1SlJVbzBNVmRhYzFaSENtOHdVVkJaZDJaUlYydFNSRE5pTkdOQmIzUXlUM2hDY25KV04zSkNaelZaTm1aQmFqZDNaekFyYWxoS2NtVmFLMW8yZUdGeVpWbElhbmhHY2xKc01XSUtiMVI1Yms4eE5EQnNRMU54WVdjMmVHeE9lbXRYVEVGcGJEaENVVUU0VUVoUlJEUkNTSFJ0YnpGNU9IZzBPRUp6YmxoTVNYVkNjbUpEWlRacE1WQmxlQW8wVFdvck9IRkNTMHhYVFVaNE0wd3ZMemQyU0dOS1IzSkdWRWQyUmtGeGIwYzFSbWxJVW1rMFJYa3pVVXc0UkRKQlVVdERRVkZGUVRsM1dGcEtUMFZMQ21wVVdtaEtXbGh2Tm1jM1FtZzNVVVpSV20wcmMyMVNhMEUyV1dacWMzVjRaVlp6V1dWS1VVSXJTMnBxYTNOUGJHVkhOSFJWUTFGVlFUSllhVUpOVW5RS1YwczJiVTFxV1U5U2VucFFWSEEzV2pKRGVXNU9kVkZ6U1RCSmVqWmpPV1ZEVTFnMGNrNU5LMVZ5VEdvd05HNVNiMVJxY1VwSGFtWk9WbWQ0Y1hkRFV3bzFlSGh0Tnk4eE0yOUlkRE0xZGpKR01GVTBTMlJTZWtzMU0zbExjeXRJUnl0RVZtOHJiVlphU3paek5TOUlUVVk0TWxaNWMwOVJXSEkxZUhGWGVEWXpDbU5XZFRFMVZFUk9ibWxIWVVwbGFUQlpURTgwZWtKMVVVWlJUREU1WkUxcGIxSXpUMmhXYWxwT1JqRkRNVEpTYWsxSFdVWjNVelZZZW1SUVJXbzFTMGdLVG5WbFpUTk1NV1pSVDBRMGNYSlhabFJOYmxNMk16RnZWR3cxTDI4NFEwdzBWVFJxVjNwbFQxaFlPRFo0VUdsUFJIaEZXVUZKYWpGaFNqZzBUbkZyYmdwRWN6WnhjSFJLZEd0NE5sSkZVVXREUVZGRlFURmplazlGU0Vsd2FtOUNRWFVyVEVGeGEwWklVblZhTm1SWVNXaE9aVkJRYzBZeFRVWmhSR1J6VDBkdUNqSXZaRnBpZFM5alpuTlpkR1JWU0VjeWVYZDFaUzlDV2t4QlpWaDVVWE4wV1dGNmFDdEpSazFyWjJVMFZrbFZlbE13YVdkTk5qaGphbFUwVEZjNWNVWUtXbEIwYkZCRUwwMHZjM0F2WkZWUlMwUndhWGw2VFV0MlJrUndTRTVOYXpjNU0yTTBlVkZ3YkRoUFNGbDZiRUZqY0VoQlQxSTNaelZPVG5sTE9WTldTQXB2U0hKYVVEVTVWbFpYZGxCblVtODVUazF2VG5Wbk1rUTRTVGRtUlhkaFRIaFVkMUZCZG5GUE9IZHBUR1pDZGxOWlYxcEdjalkyVG1VMU1VSXpOUzlCQ2xwVGVESm1aR2hqU1Vwd2JqSkdSbTlNV25sQ1FTOW9ORXByVDNwd05HTkRXVzVQUlRKeVNIcEdZemM1Wmt0bVlpdHpjSGhCT1RCQ1duSlVUVTB3YVV3S1JWUTNPV00zVkhabGJ6aGlURlJsT0RWWFoydE1aSFpWVkc5VFlUZENjMk41TmtOWE5qWmlZbkJSUzBOQlVVVkJiV1JaYzJsM2ExUk9lVzg0YVdSdE5BcFBZblZEZW5VMVVISTNSRGw2TnpoNFoyZDNPRGQzVEhaMllrZzNjRmQzV0ZwcVNsaDBOV3BqVUdkdWRtTnJPV3h1TVVGa01TOVpNRmQwZHpWaFJpczVDblZMVDI5UU1FRjVWSEY0VVZoeFJIVXdLelYzZDJoWFFXSktXVmhNYUhCSldEbDRSV2RuVERoaFJHc3pjVUZGWm5OUGMwSXdOSE5DT0dGblFXVXdhMUVLTjFGTE0yY3dWWHA0TUhWbmRUVndOSGx1TUVoTVJYUmFWRVUyUnpKQ2JYZ3hURFZJTWtjMFVuTkxhbTVMYWpaRFpXSXdhR2g1YlhvclNXRjVNbk0zZGdvemNVUjVhazVXUmsxRmRqaDBSRUZsU2s1bE5VMWhVMUpzYlVWdWMyMW1TWEpTUnk5b1RVSm9MMVYzYzBoVmFYUkxaVkJQVERsUFJFaGlRbFpuVVdJeUNtZFZUVm95WTFwUFRrNVphalJ6UVhjMk1ERjViRUp3Wm1keGNsVXpaMUJXVWpKcWNYZHhlRUZZUTFjM1IzVnZkMWQ2TVRsR2NERXhWVFJXYkZKWmMyRUtOMnh3UlRSUlMwTkJVVUo1ZG1GMVNtNHZjekZuZUdNMmRtOU1kak5KUkVsVFJVWkpZbkYyYzBwQmNpdGtPVTk0WkRsblEyRmthVkZqVEhOTGEzRm5aZ3BWV0ZKelJGcFZVRmw2U3k5VFZYQlRSM1pGVnpoSGVUSnJkbGhxVkVkRmRuSm1lamRRTVVVNFFXZHZXVTF6TlRjNU0zRmFTRlJ0YURkR2JEQmpSR3QzQ2s1TVZXRXhhREJtYjBWMU1VbElZV1IzU0d0bGJIcEZZbkZzZUV4aFRUQXdOMk5DVWxkVFZrZERkVEZtUTBSMVRGcDVSV05XTlcxT1VYVkVPVU5EU0dZS05tcEJLemxVYjB3M2NsSllUMXBIY0hSTlRqZHFibEJOYzIxT1ZtUmxjbkFyTldkQlZERTBhemMyU2s5dGNuUk1jME5ZSzFGa2IySmphbFpXWWtwNGF3b3dkbXRSVjNkQmVVZHRRVlJLV0VreE9YWmxaak5TUlcxcVUwTnllbVo2VEc4ek4yWlBObU5RWmxRMFVpdE1XV0o2VFZGaFkyTkNVWHBUUm5kNU5WbExDbXBIY214YVdtZ3lPV1ZGVlhremJYaGxaa1UyTjFsSlUzUnRha2x3TlVGU1FXOUpRa0ZSUXpKdlNqbHpkMFpPVm5RNUsydEphVXQ1TmpNMk5XMWliVUVLYml0aFkyTlhSRTlYUW1KSloxVm9SMVpuYzBWaWNuUnJOa0pyZGs5S2JXRnJaelpZWkRsalZGQm9aR1J3TUVSTllrOVJSa0ZCYldwc1ZUWjJNR1JuUkFwc1NXUkdVbmhwVW1OaE1tNHZPVWN3ZHpSRmFEQkNPWGM0TDBjNGQyRlVSM1pSVFVScGNuRmFRV1JoYjBkV1MzQmtlRXR1WjJaM0sySTFPR3BDYkNzeENuRmxVa2gzWVhOWWEzSkxRVEZzV1cweFRXWTVRMk5IV21sR2VHWnFNbXBtT0c5aFpWWmFOM0ZSVWpSelJtdFdlRVkyYlRjcmEwSjBVMlpLYVd0d1pFOEtRMk5NYUhWbVoyNUVSV3BqUldOS1RGTm1jRGxOWVVGWVltUkZRbU5yUlhFNFluYzFZMnRqY0ZVeGVHVkZVMFJHYVRseGRtWmlVbnB0Vm5SbVkwMW1VZ29yUjNwVWIxVldMMGxqU0doRVdrZGhOMUpJZWt0UU1URnNSV0ZUT1c1eVUzZHROWEV2UjFWTWRXeFdLMnRCUjFRMGRESTFlVnBhVG1OTE5HUUtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogZmUwYjU0ZjIyYzhhMGM5OTc0MzBkZjdiNDdlY2MyN2MzZGQyOTBkNWNiNGZhNWRlNmI4Nzk4Mzk1NDJhNzdlYTI2NGU3MjBkZDliZjJlZjc1OTVlZWZkMTIxNWM3OWNjYTBlMmRhYjk2OGQ5ZmQyOWRjNDRmMDZjODVkNjcwYmUK\"\n   }\n  ]\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
+      "content-length" : "28364",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
@@ -2809,23 +2901,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "05acc427-2d62-4177-8872-a4d0f117b091",
+      "x-ms-correlation-request-id" : "15de6fad-e0aa-4300-ad2d-002be86d862d",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:05acc427-2d62-4177-8872-a4d0f117b091",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022910Z:15de6fad-e0aa-4300-ad2d-002be86d862d",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "05acc427-2d62-4177-8872-a4d0f117b091",
-      "Body" : "{\"value\":[]}"
+      "x-ms-request-id" : "15de6fad-e0aa-4300-ad2d-002be86d862d",
+      "Body" : "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e\",\"name\":\"rg34769e\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westeurope\",\"tags\":{\"date\":\"2020-02-02T22:21:58.047Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439\",\"name\":\"fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westeurope\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e/providers/Microsoft.BatchAI/workspaces/ws791482/fileservers/fsac75112743\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG\",\"name\":\"NetworkWatcherRG\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"northcentralus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-3\",\"name\":\"rgjavatest42883-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.975Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-1\",\"name\":\"rgjavatest42883-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.973Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-2\",\"name\":\"rgjavatest42883-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:21.305Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest95218-1\",\"name\":\"rgjavatest95218-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:24:55.038Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-3\",\"name\":\"rgjavatest30297-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:48.645Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-2\",\"name\":\"rgjavatest30297-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:47.803Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-1\",\"name\":\"rgjavatest30297-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:33:48.648Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-2\",\"name\":\"rgjavatest77313-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:35.556Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-3\",\"name\":\"rgjavatest77313-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:34.892Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-1\",\"name\":\"rgjavatest77313-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:35:35.559Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-3\",\"name\":\"rgjavatest69549-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:49.627Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-1\",\"name\":\"rgjavatest69549-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:48.986Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-2\",\"name\":\"rgjavatest69549-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:42:49.624Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest01484-3\",\"name\":\"rgjavatest01484-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:44:14.719Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest96126-3\",\"name\":\"rgjavatest96126-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:48:34.599Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-2\",\"name\":\"rgjavatest70435-2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.905Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-3\",\"name\":\"rgjavatest70435-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.315Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-1\",\"name\":\"rgjavatest70435-1\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:34.901Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest29091-3\",\"name\":\"rgjavatest29091-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:49:59.088Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest54227-3\",\"name\":\"rgjavatest54227-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:50:30.567Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest63101-3\",\"name\":\"rgjavatest63101-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T06:51:39.450Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest39873-3\",\"name\":\"rgjavatest39873-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:04:17.385Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest75563-3\",\"name\":\"rgjavatest75563-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:05:22.611Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest74601-3\",\"name\":\"rgjavatest74601-3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2020-03-17T08:06:58.328Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu\",\"name\":\"rg-weidxu\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv5c0980081f258\",\"name\":\"rgnemv5c0980081f258\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-16T13:06:08.375Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7e411787b902d\",\"name\":\"rgnemv7e411787b902d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-17T01:50:42.288Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87437bgroup\",\"name\":\"as87437bgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T05:10:08.055Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks62487fgroup\",\"name\":\"aks62487fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T05:10:56.938Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfwb150680176\",\"name\":\"rgrssdfwb150680176\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.680Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql87e85417fca\",\"name\":\"rgsql87e85417fca\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:41.971Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdepd1e9415070\",\"name\":\"rgrssdepd1e9415070\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.370Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib6926960a8\",\"name\":\"rgrsdsib6926960a8\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:46.199Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfw5158486360\",\"name\":\"rgrssdfw5158486360\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:40.699Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql811193190a3\",\"name\":\"rgsql811193190a3\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:53.251Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdre485555594a\",\"name\":\"rgrssdre485555594a\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T06:02:56.746Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdrec906822537\",\"name\":\"rgrssdrec906822537\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T07:27:37.065Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql686003036f7\",\"name\":\"rgsql686003036f7\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-19T07:31:08.979Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as40238fgroup\",\"name\":\"as40238fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T04:48:10.412Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as059417group\",\"name\":\"as059417group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T04:59:41.876Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as52157fgroup\",\"name\":\"as52157fgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T05:02:11.952Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as26384agroup\",\"name\":\"as26384agroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T05:08:25.576Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4c11524863308cbc\",\"name\":\"rgsql4c11524863308cbc\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T06:07:01.265Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4195605300031760\",\"name\":\"rgsql4195605300031760\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-20T07:43:34.714Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as80484cgroup\",\"name\":\"as80484cgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:24:18.017Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87545cgroup\",\"name\":\"as87545cgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:25:28.937Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as335697group\",\"name\":\"as335697group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:26:27.740Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as22948dgroup\",\"name\":\"as22948dgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:27:47.202Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as11517bgroup\",\"name\":\"as11517bgroup\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T03:29:35.732Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as906189group\",\"name\":\"as906189group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-23T05:23:17.655Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group\",\"name\":\"aks769349group\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"tags\":{\"date\":\"2020-03-26T02:23:17.689Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_aks769349group_aks769349_eastus\",\"name\":\"MC_aks769349group_aks769349_eastus\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastus\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\"tags\":{\"tag1\":\"value1\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chuxitest\",\"name\":\"chuxitest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_05d666493318\",\"name\":\"rg1nemv_05d666493318\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T05:46:06.683636Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_be452811f671\",\"name\":\"rg1nemv_be452811f671\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T06:02:06.673752600Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_6784645828e2\",\"name\":\"rg1nemv_6784645828e2\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T06:30:34.285231100Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_692871535b3c\",\"name\":\"rg1nemv_692871535b3c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-19T08:35:48.777588500Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_1c436623a98b\",\"name\":\"rg1nemv_1c436623a98b\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T02:45:43.967864Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_43f60981a7e5\",\"name\":\"rg1nemv_43f60981a7e5\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T07:40:40.916943900Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_0d004902eead\",\"name\":\"rg1nemv_0d004902eead\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-20T07:49:23.458515400Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_15273952f18b\",\"name\":\"rg1nemv_15273952f18b\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"tags\":{\"date\":\"2020-03-23T02:22:14.658635500Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ddbRg351\",\"name\":\"ddbRg351\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512\",\"name\":\"fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080/providers/Microsoft.BatchAI/workspaces/ws19469042/fileservers/fs01830076bd\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca\",\"name\":\"fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621/providers/Microsoft.BatchAI/workspaces/ws83e92445/fileservers/fs96068763d3\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-ae130410-4a26-4259-b84f-d5543899e342\",\"name\":\"fileserverrg-ae130410-4a26-4259-b84f-d5543899e342\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621/providers/Microsoft.BatchAI/workspaces/ws7bc05795/fileservers/fsf183444223\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d\",\"name\":\"fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821/providers/Microsoft.BatchAI/workspaces/wsd9f66131/fileservers/fs00b9380944\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-2d782770-0242-41f1-84bf-54426c283420\",\"name\":\"fileserverrg-2d782770-0242-41f1-84bf-54426c283420\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768/providers/Microsoft.BatchAI/workspaces/ws94f33589/fileservers/fs00622717a5\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c\",\"name\":\"fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337/providers/Microsoft.BatchAI/workspaces/wsdc779969/fileservers/fs383444862f\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f\",\"name\":\"fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294/providers/Microsoft.BatchAI/workspaces/wsc8d80975/fileservers/fs1b76451406\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c\",\"name\":\"fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"managedBy\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039/providers/Microsoft.BatchAI/workspaces/ws85e68734/fileservers/fs27944980f0\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ty\",\"name\":\"ty\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southeastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akstest\",\"name\":\"akstest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southeastasia\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg16682\",\"name\":\"javacsmrg16682\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"eastasia\",\"tags\":{\"date\":\"2020-03-25T07:14:43.646043100Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice\",\"name\":\"cleanupservice\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lenatest\",\"name\":\"lenatest\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgac6642161bef4\",\"name\":\"rgac6642161bef4\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg76a43058c8\",\"name\":\"rg76a43058c8\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"southcentralus\",\"tags\":{\"date\":\"2019-12-21T05:08:00.974Z\",\"product\":\"javasdk\",\"cause\":\"automation\"},\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi\",\"name\":\"tanyi\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azfluent\",\"name\":\"azfluent\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080\",\"name\":\"rg24353080\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821\",\"name\":\"rg79d65821\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621\",\"name\":\"rge0b12621\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768\",\"name\":\"rgbba97768\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039\",\"name\":\"rgdac67039\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621\",\"name\":\"rg6cd48621\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337\",\"name\":\"rg41d32337\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294\",\"name\":\"rg78983294\",\"type\":\"Microsoft.Resources/resourceGroups\",\"location\":\"westus2\",\"properties\":{\"provisioningState\":\"Succeeded\"}}]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg34769e/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2834,23 +2927,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "f0654f71-ff8a-4f4b-9b88-71dd6b3d94b2",
+      "x-ms-correlation-request-id" : "c9a66150-bbf9-4766-8144-ae6fd4050ccc",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:f0654f71-ff8a-4f4b-9b88-71dd6b3d94b2",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022910Z:c9a66150-bbf9-4766-8144-ae6fd4050ccc",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f0654f71-ff8a-4f4b-9b88-71dd6b3d94b2",
+      "x-ms-request-id" : "c9a66150-bbf9-4766-8144-ae6fd4050ccc",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tytest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-1a7b081a-6a50-41cc-a913-b2bd01256439/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:14 GMT",
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
       "content-length" : "12",
       "expires" : "-1",
       "vary" : "Accept-Encoding",
@@ -2859,77 +2953,2370 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "599bb1d1-18fa-4b21-aa55-874e01515ea1",
+      "x-ms-correlation-request-id" : "14c89ef7-1edb-4f17-96b4-f5f56006c2af",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050215Z:599bb1d1-18fa-4b21-aa55-874e01515ea1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022910Z:14c89ef7-1edb-4f17-96b4-f5f56006c2af",
+      "connection" : "keep-alive",
       "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "599bb1d1-18fa-4b21-aa55-874e01515ea1",
+      "x-ms-request-id" : "14c89ef7-1edb-4f17-96b4-f5f56006c2af",
       "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/NetworkWatcherRG/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:15 GMT",
-      "server" : "nginx",
-      "content-length" : "1743",
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11892",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5001d99c-b2ae-481e-afa9-99ed812f0eab",
+      "x-ms-correlation-request-id" : "8989c993-a6c3-469c-b76d-cb0365d84469",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050216Z:5001d99c-b2ae-481e-afa9-99ed812f0eab",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:8989c993-a6c3-469c-b76d-cb0365d84469",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "356dd5d9-440c-4f91-aaef-14013c929986",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+      "x-ms-request-id" : "8989c993-a6c3-469c-b76d-cb0365d84469",
+      "Body" : "{\"value\":[]}"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:15 GMT",
-      "server" : "nginx",
-      "content-length" : "1743",
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
+      "content-length" : "12",
       "expires" : "-1",
-      "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
       "x-ms-ratelimit-remaining-subscription-reads" : "11891",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "163f1d8e-c879-4aa0-b688-6f7c54b080e3",
+      "x-ms-correlation-request-id" : "4e8eee49-452c-4b0a-b5e6-dcc0750c1f0c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050216Z:163f1d8e-c879-4aa0-b688-6f7c54b080e3",
-      "content-type" : "application/json",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:4e8eee49-452c-4b0a-b5e6-dcc0750c1f0c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "46eb09e4-dbca-4b96-ae5b-4bf240cd8d52",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+      "x-ms-request-id" : "4e8eee49-452c-4b0a-b5e6-dcc0750c1f0c",
+      "Body" : "{\"value\":[]}"
     }
   }, {
-    "Method" : "PUT",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:22 GMT",
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11890",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "b33600bd-eea3-4fc3-ac2a-cbd9d56f36a2",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:b33600bd-eea3-4fc3-ac2a-cbd9d56f36a2",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b33600bd-eea3-4fc3-ac2a-cbd9d56f36a2",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest42883-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:10 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11889",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a0622d8c-1958-4423-a878-c9c1d6c3747d",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:a0622d8c-1958-4423-a878-c9c1d6c3747d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a0622d8c-1958-4423-a878-c9c1d6c3747d",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest95218-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11888",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a05338d1-3b7b-4e6a-a92c-225204d2cf1c",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:a05338d1-3b7b-4e6a-a92c-225204d2cf1c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a05338d1-3b7b-4e6a-a92c-225204d2cf1c",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11887",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "231c90c9-b56d-445d-a458-aefea39c1bf7",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022911Z:231c90c9-b56d-445d-a458-aefea39c1bf7",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "231c90c9-b56d-445d-a458-aefea39c1bf7",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11886",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "af304ae6-02b7-4625-a0df-7b64505b9dcf",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:af304ae6-02b7-4625-a0df-7b64505b9dcf",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "af304ae6-02b7-4625-a0df-7b64505b9dcf",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest30297-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11885",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5e2846aa-56dd-4eab-b4af-293cf8fc0798",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:5e2846aa-56dd-4eab-b4af-293cf8fc0798",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5e2846aa-56dd-4eab-b4af-293cf8fc0798",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11884",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "25708f8b-250e-4e38-80ef-6c9838636402",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:25708f8b-250e-4e38-80ef-6c9838636402",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "25708f8b-250e-4e38-80ef-6c9838636402",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11883",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "9bfe978a-2781-4be2-af37-5701d75beade",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:9bfe978a-2781-4be2-af37-5701d75beade",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "9bfe978a-2781-4be2-af37-5701d75beade",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest77313-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11882",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "cf3e90a3-4667-4023-8cd0-625a1ed467dd",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:cf3e90a3-4667-4023-8cd0-625a1ed467dd",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "cf3e90a3-4667-4023-8cd0-625a1ed467dd",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:11 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11881",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "0fe7e25a-12e3-45cf-9841-e3d14e2e4409",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:0fe7e25a-12e3-45cf-9841-e3d14e2e4409",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "0fe7e25a-12e3-45cf-9841-e3d14e2e4409",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11880",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "14e6ba29-ec15-4ef4-ae0b-e30b879473ba",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:14e6ba29-ec15-4ef4-ae0b-e30b879473ba",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "14e6ba29-ec15-4ef4-ae0b-e30b879473ba",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest69549-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11879",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "359332df-7d04-41e8-8487-9101a0a727e7",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022912Z:359332df-7d04-41e8-8487-9101a0a727e7",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "359332df-7d04-41e8-8487-9101a0a727e7",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest01484-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11878",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "f1361952-8a7b-4e91-8254-be2cafc0e42d",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:f1361952-8a7b-4e91-8254-be2cafc0e42d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "f1361952-8a7b-4e91-8254-be2cafc0e42d",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest96126-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11877",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a3246ad3-2f58-4c9d-a6ac-94b4416445b5",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:a3246ad3-2f58-4c9d-a6ac-94b4416445b5",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a3246ad3-2f58-4c9d-a6ac-94b4416445b5",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11876",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "f9386e09-c421-45e5-bfcb-99efff47170e",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:f9386e09-c421-45e5-bfcb-99efff47170e",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "f9386e09-c421-45e5-bfcb-99efff47170e",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11875",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "b5e4e1e1-3fad-47fd-8bd3-bcc907e77efb",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:b5e4e1e1-3fad-47fd-8bd3-bcc907e77efb",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b5e4e1e1-3fad-47fd-8bd3-bcc907e77efb",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest70435-1/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:12 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11874",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "85cfa283-0eea-49f9-a8eb-65fee5865ecf",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:85cfa283-0eea-49f9-a8eb-65fee5865ecf",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "85cfa283-0eea-49f9-a8eb-65fee5865ecf",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest29091-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11873",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "840ac1c3-d674-41bb-8764-35518269b0c2",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:840ac1c3-d674-41bb-8764-35518269b0c2",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "840ac1c3-d674-41bb-8764-35518269b0c2",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest54227-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11872",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "f0ff6b1e-263e-46eb-856b-c659adb7b57e",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022913Z:f0ff6b1e-263e-46eb-856b-c659adb7b57e",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "f0ff6b1e-263e-46eb-856b-c659adb7b57e",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest63101-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11871",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "c1c0425e-04f7-45ca-b7bc-02be32105edd",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:c1c0425e-04f7-45ca-b7bc-02be32105edd",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "c1c0425e-04f7-45ca-b7bc-02be32105edd",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest39873-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11870",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "2e5dcd4e-eb63-4ee3-b03e-a3b7c93b19de",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:2e5dcd4e-eb63-4ee3-b03e-a3b7c93b19de",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "2e5dcd4e-eb63-4ee3-b03e-a3b7c93b19de",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest75563-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11869",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "d2cd35c5-c802-4e02-9beb-13c1b6e731a0",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:d2cd35c5-c802-4e02-9beb-13c1b6e731a0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "d2cd35c5-c802-4e02-9beb-13c1b6e731a0",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgjavatest74601-3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11868",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "22f89e51-cd81-43fb-8f9d-0cde2f6e088a",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:22f89e51-cd81-43fb-8f9d-0cde2f6e088a",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "22f89e51-cd81-43fb-8f9d-0cde2f6e088a",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-weidxu/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:13 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11867",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "210ed4ca-1b45-449c-99a3-f68daf8b3b5f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:210ed4ca-1b45-449c-99a3-f68daf8b3b5f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "210ed4ca-1b45-449c-99a3-f68daf8b3b5f",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv5c0980081f258/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11866",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "85553337-d274-4481-a11e-4a890d74dbfc",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:85553337-d274-4481-a11e-4a890d74dbfc",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "85553337-d274-4481-a11e-4a890d74dbfc",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv7e411787b902d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11865",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "2ad1a4cf-a2a0-4504-a88c-233d54fa49df",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022914Z:2ad1a4cf-a2a0-4504-a88c-233d54fa49df",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "2ad1a4cf-a2a0-4504-a88c-233d54fa49df",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87437bgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11864",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "b8456a4a-bec8-452b-aa0b-af37a93bfc5a",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:b8456a4a-bec8-452b-aa0b-af37a93bfc5a",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b8456a4a-bec8-452b-aa0b-af37a93bfc5a",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks62487fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11863",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "4ac60869-8569-43a1-8676-2afb7eb008f2",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:4ac60869-8569-43a1-8676-2afb7eb008f2",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "4ac60869-8569-43a1-8676-2afb7eb008f2",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfwb150680176/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11862",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5b1bea8b-a027-4ad7-ac8d-fee2980105c4",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:5b1bea8b-a027-4ad7-ac8d-fee2980105c4",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5b1bea8b-a027-4ad7-ac8d-fee2980105c4",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql87e85417fca/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11861",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8ca7f840-68b2-43d1-93d4-b524dfe2a8e0",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:8ca7f840-68b2-43d1-93d4-b524dfe2a8e0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8ca7f840-68b2-43d1-93d4-b524dfe2a8e0",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdepd1e9415070/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11860",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "1e0075d3-65c8-41c8-8ef1-286a8ebaa401",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:1e0075d3-65c8-41c8-8ef1-286a8ebaa401",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "1e0075d3-65c8-41c8-8ef1-286a8ebaa401",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrsdsib6926960a8/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:14 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11859",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "4b2c441a-c77b-4dd5-bc96-8cdf48b9b3cf",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:4b2c441a-c77b-4dd5-bc96-8cdf48b9b3cf",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "4b2c441a-c77b-4dd5-bc96-8cdf48b9b3cf",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdfw5158486360/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11858",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a01d0e93-b7eb-45b6-92ad-ce839e89d9a5",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:a01d0e93-b7eb-45b6-92ad-ce839e89d9a5",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a01d0e93-b7eb-45b6-92ad-ce839e89d9a5",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql811193190a3/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11857",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "9c99daf6-ce2c-4aeb-b6f7-e62ae8c3e01c",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022915Z:9c99daf6-ce2c-4aeb-b6f7-e62ae8c3e01c",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "9c99daf6-ce2c-4aeb-b6f7-e62ae8c3e01c",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdre485555594a/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11856",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5ed6f71e-5138-40a0-8742-2a880ae55dec",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:5ed6f71e-5138-40a0-8742-2a880ae55dec",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5ed6f71e-5138-40a0-8742-2a880ae55dec",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrssdrec906822537/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11855",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "17213813-d035-4656-8a7c-54d90590959a",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:17213813-d035-4656-8a7c-54d90590959a",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "17213813-d035-4656-8a7c-54d90590959a",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql686003036f7/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11854",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "6c9688b3-033e-4a00-9de9-26cbbd269b5f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:6c9688b3-033e-4a00-9de9-26cbbd269b5f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "6c9688b3-033e-4a00-9de9-26cbbd269b5f",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as40238fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11853",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "fca7bc16-e6ef-4973-abe3-467bfb912830",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:fca7bc16-e6ef-4973-abe3-467bfb912830",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "fca7bc16-e6ef-4973-abe3-467bfb912830",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as059417group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:15 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11852",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "68f59315-159e-4f95-bf6a-2a3218075e5f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:68f59315-159e-4f95-bf6a-2a3218075e5f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "68f59315-159e-4f95-bf6a-2a3218075e5f",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as52157fgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11851",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "925d17a2-1288-4a7f-ad70-14b11d8982f6",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:925d17a2-1288-4a7f-ad70-14b11d8982f6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "925d17a2-1288-4a7f-ad70-14b11d8982f6",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as26384agroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11850",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "4222a51f-9bf3-411e-8c99-cd851ed36075",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022916Z:4222a51f-9bf3-411e-8c99-cd851ed36075",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "4222a51f-9bf3-411e-8c99-cd851ed36075",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4c11524863308cbc/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11849",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "1990db86-321a-417f-a1e8-03104270e201",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:1990db86-321a-417f-a1e8-03104270e201",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "1990db86-321a-417f-a1e8-03104270e201",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgsql4195605300031760/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11848",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "4fd8b58c-1a30-4f9f-9484-3548e8adf9a9",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:4fd8b58c-1a30-4f9f-9484-3548e8adf9a9",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "4fd8b58c-1a30-4f9f-9484-3548e8adf9a9",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as80484cgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11847",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a75f1762-48fe-445d-98ad-eded437c95f2",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:a75f1762-48fe-445d-98ad-eded437c95f2",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a75f1762-48fe-445d-98ad-eded437c95f2",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as87545cgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11846",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a3f058ce-226f-4a1b-b75f-a7f25502e050",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:a3f058ce-226f-4a1b-b75f-a7f25502e050",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a3f058ce-226f-4a1b-b75f-a7f25502e050",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as335697group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11845",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a431a4bd-1d06-491a-ac58-0e0ec8606ec7",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:a431a4bd-1d06-491a-ac58-0e0ec8606ec7",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a431a4bd-1d06-491a-ac58-0e0ec8606ec7",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as22948dgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:16 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11844",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "bd74a70a-e835-4066-ba40-17b831cecda6",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:bd74a70a-e835-4066-ba40-17b831cecda6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "bd74a70a-e835-4066-ba40-17b831cecda6",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as11517bgroup/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:17 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11843",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "db55cede-5965-41d2-a67d-c5f8968357db",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022917Z:db55cede-5965-41d2-a67d-c5f8968357db",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "db55cede-5965-41d2-a67d-c5f8968357db",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/as906189group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:17 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11842",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8744b6d0-ab77-4d84-a507-15bde405c5a0",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:8744b6d0-ab77-4d84-a507-15bde405c5a0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8744b6d0-ab77-4d84-a507-15bde405c5a0",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:17 GMT",
+      "server" : "nginx",
+      "content-length" : "1870",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11841",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5da722ca-51ec-4512-8a40-7451b1b26521",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:5da722ca-51ec-4512-8a40-7451b1b26521",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b153e518-1e8e-4a68-988e-a96e7a8bb84d",
+      "Body" : "{\n  \"value\": [\n   {\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n    \"location\": \"eastus\",\n    \"name\": \"aks769349\",\n    \"tags\": {\n     \"tag1\": \"value1\"\n    },\n    \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n    \"properties\": {\n     \"provisioningState\": \"Succeeded\",\n     \"kubernetesVersion\": \"1.15.10\",\n     \"dnsPrefix\": \"dnsaks769349\",\n     \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n     \"agentPoolProfiles\": [\n      {\n       \"name\": \"apaks769349\",\n       \"count\": 1,\n       \"vmSize\": \"Standard_D2_v2\",\n       \"osDiskSizeGB\": 100,\n       \"maxPods\": 110,\n       \"type\": \"AvailabilitySet\",\n       \"provisioningState\": \"Succeeded\",\n       \"orchestratorVersion\": \"1.15.10\",\n       \"osType\": \"Linux\"\n      }\n     ],\n     \"linuxProfile\": {\n      \"adminUsername\": \"aksadmin\",\n      \"ssh\": {\n       \"publicKeys\": [\n        {\n         \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n        }\n       ]\n      }\n     },\n     \"servicePrincipalProfile\": {\n      \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n     },\n     \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n     \"enableRBAC\": false,\n     \"networkProfile\": {\n      \"networkPlugin\": \"kubenet\",\n      \"loadBalancerSku\": \"Basic\",\n      \"podCidr\": \"10.244.0.0/16\",\n      \"serviceCidr\": \"10.0.0.0/16\",\n      \"dnsServiceIP\": \"10.0.0.10\",\n      \"dockerBridgeCidr\": \"172.17.0.1/16\"\n     },\n     \"maxAgentPools\": 1\n    }\n   }\n  ]\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_aks769349group_aks769349_eastus/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:17 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11840",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "6023d55a-8842-4f23-a7cb-2d748a8b63dd",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:6023d55a-8842-4f23-a7cb-2d748a8b63dd",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "6023d55a-8842-4f23-a7cb-2d748a8b63dd",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chuxitest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:17 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11839",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8ebc7f79-0af7-4883-b424-7ceca7b65e74",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:8ebc7f79-0af7-4883-b424-7ceca7b65e74",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8ebc7f79-0af7-4883-b424-7ceca7b65e74",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_05d666493318/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11838",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "c858f39e-f885-4d72-b6b3-847787dd7255",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:c858f39e-f885-4d72-b6b3-847787dd7255",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "c858f39e-f885-4d72-b6b3-847787dd7255",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_be452811f671/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11837",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "b133e998-efbb-403d-b736-0faf60ab97fc",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022918Z:b133e998-efbb-403d-b736-0faf60ab97fc",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b133e998-efbb-403d-b736-0faf60ab97fc",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_6784645828e2/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11836",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "728bfd70-66cc-4f54-b36b-00d504bc4158",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:728bfd70-66cc-4f54-b36b-00d504bc4158",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "728bfd70-66cc-4f54-b36b-00d504bc4158",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_692871535b3c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11835",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "e38638d1-74f4-40d5-9cda-0aefaa38cad5",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:e38638d1-74f4-40d5-9cda-0aefaa38cad5",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "e38638d1-74f4-40d5-9cda-0aefaa38cad5",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_1c436623a98b/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11834",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "7ef12e56-d650-4a6b-ac7f-e79cd38c0db6",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:7ef12e56-d650-4a6b-ac7f-e79cd38c0db6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "7ef12e56-d650-4a6b-ac7f-e79cd38c0db6",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_43f60981a7e5/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11833",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "a96c0bd2-c6f4-4d15-b35d-aadcca3e9347",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:a96c0bd2-c6f4-4d15-b35d-aadcca3e9347",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "a96c0bd2-c6f4-4d15-b35d-aadcca3e9347",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_0d004902eead/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11832",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "319c1283-b53b-41f4-952a-678bb7ffe63f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:319c1283-b53b-41f4-952a-678bb7ffe63f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "319c1283-b53b-41f4-952a-678bb7ffe63f",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1nemv_15273952f18b/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:18 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11831",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "3557da0c-5c70-492d-bc2d-bb836106eaa6",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:3557da0c-5c70-492d-bc2d-bb836106eaa6",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "3557da0c-5c70-492d-bc2d-bb836106eaa6",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ddbRg351/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11830",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "2bcb20c2-66fc-47b7-8cdf-1c14747eca2d",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022919Z:2bcb20c2-66fc-47b7-8cdf-1c14747eca2d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "2bcb20c2-66fc-47b7-8cdf-1c14747eca2d",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9550a567-f994-46d1-9daf-1ad59f859512/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11829",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "905b9374-30fd-45bc-99f3-f6f6b637ab08",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:905b9374-30fd-45bc-99f3-f6f6b637ab08",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "905b9374-30fd-45bc-99f3-f6f6b637ab08",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-c3618515-cf08-4ba5-b4f7-ed450415c0ca/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11828",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "01931524-bd46-4d7a-ae15-87651dcc1603",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:01931524-bd46-4d7a-ae15-87651dcc1603",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "01931524-bd46-4d7a-ae15-87651dcc1603",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-ae130410-4a26-4259-b84f-d5543899e342/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11827",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8aba41dd-0efa-4a36-af7a-5c9a5b2b08f9",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:8aba41dd-0efa-4a36-af7a-5c9a5b2b08f9",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8aba41dd-0efa-4a36-af7a-5c9a5b2b08f9",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-9dc6421a-96f0-49be-b636-4b70aaea703d/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11826",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "481d8f3d-358f-4c13-8105-ce73f1ffea8f",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:481d8f3d-358f-4c13-8105-ce73f1ffea8f",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "481d8f3d-358f-4c13-8105-ce73f1ffea8f",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-2d782770-0242-41f1-84bf-54426c283420/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11825",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5c03127e-a73a-470e-89fa-fc029a12eef3",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:5c03127e-a73a-470e-89fa-fc029a12eef3",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5c03127e-a73a-470e-89fa-fc029a12eef3",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3c82a8ea-7f01-4d4e-937c-0d46d12a313c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:19 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11824",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "469d0e21-ddc4-4f7e-83f3-e049f59498df",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:469d0e21-ddc4-4f7e-83f3-e049f59498df",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "469d0e21-ddc4-4f7e-83f3-e049f59498df",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-3e20a383-cec0-4c34-9453-ec438d21b94f/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11823",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "b87ac4f6-ca3b-4473-bac2-d4ebedc95f17",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:b87ac4f6-ca3b-4473-bac2-d4ebedc95f17",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "b87ac4f6-ca3b-4473-bac2-d4ebedc95f17",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fileserverrg-a14aeca9-a33c-4a8a-b3b1-76ac930fff0c/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11822",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5d6948eb-c685-48f4-a3a5-1eeb3990e269",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022920Z:5d6948eb-c685-48f4-a3a5-1eeb3990e269",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5d6948eb-c685-48f4-a3a5-1eeb3990e269",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ty/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11821",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "44fa2c2b-7242-44cc-b62d-db2bc2101b76",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:44fa2c2b-7242-44cc-b62d-db2bc2101b76",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "44fa2c2b-7242-44cc-b62d-db2bc2101b76",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akstest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11820",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "e17fa374-dfc6-488a-a9e8-7efde1f0ed8d",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:e17fa374-dfc6-488a-a9e8-7efde1f0ed8d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "e17fa374-dfc6-488a-a9e8-7efde1f0ed8d",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg16682/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11819",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5a574cf7-eb50-4a1d-b11e-0cde1a85d96d",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:5a574cf7-eb50-4a1d-b11e-0cde1a85d96d",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5a574cf7-eb50-4a1d-b11e-0cde1a85d96d",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cleanupservice/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11818",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "60203241-54fc-4c7d-943e-c315c6ad0db0",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:60203241-54fc-4c7d-943e-c315c6ad0db0",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "60203241-54fc-4c7d-943e-c315c6ad0db0",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lenatest/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11817",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "1fec53dc-bc61-440b-b121-3b44965e52a2",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:1fec53dc-bc61-440b-b121-3b44965e52a2",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "1fec53dc-bc61-440b-b121-3b44965e52a2",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgac6642161bef4/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:20 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11816",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "88807c78-8040-4e48-a24a-1d816b551611",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:88807c78-8040-4e48-a24a-1d816b551611",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "88807c78-8040-4e48-a24a-1d816b551611",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg76a43058c8/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11815",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "fe0f5e2c-810b-434c-8587-4891ec409353",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022921Z:fe0f5e2c-810b-434c-8587-4891ec409353",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "fe0f5e2c-810b-434c-8587-4891ec409353",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tanyi/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11814",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "550ba328-1277-4342-bc35-9fbcaf44b9d8",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:550ba328-1277-4342-bc35-9fbcaf44b9d8",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "550ba328-1277-4342-bc35-9fbcaf44b9d8",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azfluent/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11813",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "95f9e06c-eb80-4480-8d5f-1f2dbf546002",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:95f9e06c-eb80-4480-8d5f-1f2dbf546002",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "95f9e06c-eb80-4480-8d5f-1f2dbf546002",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg24353080/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11812",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "d85da5b8-013a-44bb-b53c-01ecff819da1",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:d85da5b8-013a-44bb-b53c-01ecff819da1",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "d85da5b8-013a-44bb-b53c-01ecff819da1",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg79d65821/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11811",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8cc7e8ee-c56d-4ed7-912b-1fd7ae271484",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:8cc7e8ee-c56d-4ed7-912b-1fd7ae271484",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8cc7e8ee-c56d-4ed7-912b-1fd7ae271484",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rge0b12621/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11810",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "20782185-1134-458d-9477-d8fa35bc191a",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:20782185-1134-458d-9477-d8fa35bc191a",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "20782185-1134-458d-9477-d8fa35bc191a",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgbba97768/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:21 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11809",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "1c60fee8-7cab-4e09-ac62-611b0c3bf86b",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:1c60fee8-7cab-4e09-ac62-611b0c3bf86b",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "1c60fee8-7cab-4e09-ac62-611b0c3bf86b",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgdac67039/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:22 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11808",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "24f7ba98-ca1d-4791-bc02-e45e496098dd",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022922Z:24f7ba98-ca1d-4791-bc02-e45e496098dd",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "24f7ba98-ca1d-4791-bc02-e45e496098dd",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg6cd48621/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:22 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11807",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "85b47f10-165d-49e4-84fb-b2c64f0e1344",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022923Z:85b47f10-165d-49e4-84fb-b2c64f0e1344",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "85b47f10-165d-49e4-84fb-b2c64f0e1344",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg41d32337/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:22 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11806",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "fa3934eb-833b-45ea-8e1a-26df06da1147",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022923Z:fa3934eb-833b-45ea-8e1a-26df06da1147",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "fa3934eb-833b-45ea-8e1a-26df06da1147",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg78983294/providers/Microsoft.ContainerService/managedClusters?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:22 GMT",
+      "content-length" : "12",
+      "expires" : "-1",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11805",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "8aeb0997-a5a8-46fc-8c63-8bb423c3e449",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022923Z:8aeb0997-a5a8-46fc-8c63-8bb423c3e449",
+      "connection" : "keep-alive",
+      "content-type" : "application/json; charset=utf-8",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "8aeb0997-a5a8-46fc-8c63-8bb423c3e449",
+      "Body" : "{\"value\":[]}"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:22 GMT",
+      "server" : "nginx",
+      "content-length" : "1743",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11804",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "f58933aa-8fb2-4c78-a326-b2659cad8cbf",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022923Z:f58933aa-8fb2-4c78-a326-b2659cad8cbf",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "122ca336-a465-4473-bdfd-0a8166d701ae",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:24 GMT",
+      "server" : "nginx",
+      "content-length" : "1743",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11803",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "be249a99-f318-47c4-b005-6eff60e231fb",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022925Z:be249a99-f318-47c4-b005-6eff60e231fb",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "5fd3cd38-feee-499e-a3a2-11b2e924f95f",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag1\": \"value1\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 1,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+    }
+  }, {
+    "Method" : "PUT",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
+      "Content-Type" : "application/json; charset=utf-8"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:29:32 GMT",
       "server" : "nginx",
       "content-length" : "1760",
       "expires" : "-1",
@@ -2940,390 +5327,324 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "bf419781-3d26-44f7-8fb1-40f70a5a9f3d",
+      "x-ms-correlation-request-id" : "14d05960-6b9b-48f0-90b3-f274e4104a2c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050223Z:bf419781-3d26-44f7-8fb1-40f70a5a9f3d",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022932Z:14d05960-6b9b-48f0-90b3-f274e4104a2c",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "a95c4138-bc8a-412d-88c2-c96225d658de",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Scaling\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Scaling\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
-      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31"
+      "x-ms-request-id" : "9490d9a4-f414-40f3-830b-b0cded414bf5",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Scaling\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Scaling\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }",
+      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:22 GMT",
+      "date" : "Thu, 26 Mar 2020 02:29:32 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11890",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11802",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "34c1922e-21a8-4923-b7d5-e9618e5130ac",
+      "x-ms-correlation-request-id" : "ba159bce-84f9-4f3c-af0a-949de42e1622",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050223Z:34c1922e-21a8-4923-b7d5-e9618e5130ac",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T022932Z:ba159bce-84f9-4f3c-af0a-949de42e1622",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6c1d8a2b-1dd2-4d29-9677-b31218dd5f17",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "58e16edc-0299-4bba-94ab-ca3361d0eb6d",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:02:53 GMT",
+      "date" : "Thu, 26 Mar 2020 02:30:02 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11889",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11801",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "a0e63884-7aba-49aa-9d9b-e1f209e88160",
+      "x-ms-correlation-request-id" : "16a7368d-d4b7-49e4-b8a5-096af77cd7de",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050253Z:a0e63884-7aba-49aa-9d9b-e1f209e88160",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023002Z:16a7368d-d4b7-49e4-b8a5-096af77cd7de",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "aa175f33-19ba-42cd-97df-24b5be6b133b",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "7f84f6c1-24ab-49e3-8447-badb2445451e",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:03:24 GMT",
+      "date" : "Thu, 26 Mar 2020 02:30:32 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11888",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11800",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "71d46f65-a06b-4c99-821d-b3e44aa65e4a",
+      "x-ms-correlation-request-id" : "4964a63a-c86d-4b7a-9100-e275e82ec3e4",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050324Z:71d46f65-a06b-4c99-821d-b3e44aa65e4a",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023033Z:4964a63a-c86d-4b7a-9100-e275e82ec3e4",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "a67a1af0-943b-402c-91f3-250f43f4b7a4",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "c4a24849-ef39-48d6-a5a5-d0350e98001e",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:03:54 GMT",
+      "date" : "Thu, 26 Mar 2020 02:31:02 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11887",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11799",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "dbb586f1-7ee1-4714-a0db-64899132527a",
+      "x-ms-correlation-request-id" : "d04c81d7-f59f-48ca-907d-65f5b5aad46a",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050355Z:dbb586f1-7ee1-4714-a0db-64899132527a",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023103Z:d04c81d7-f59f-48ca-907d-65f5b5aad46a",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "421bf325-f209-4fcc-9177-cd870a4d7a1f",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "4d934562-52f5-45ce-9983-5330202eca03",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:04:24 GMT",
+      "date" : "Thu, 26 Mar 2020 02:31:33 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11886",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11798",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "9c76d269-d769-486d-b8ef-6bb0b0030f37",
+      "x-ms-correlation-request-id" : "a4ca0cac-d5ab-4e5c-a082-d544bfaf50e7",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050425Z:9c76d269-d769-486d-b8ef-6bb0b0030f37",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023134Z:a4ca0cac-d5ab-4e5c-a082-d544bfaf50e7",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c36bd9bf-7381-4c7d-a575-17014ed04341",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "ae137b3d-0baa-4fd3-a658-ed55295c7d27",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:04:55 GMT",
+      "date" : "Thu, 26 Mar 2020 02:32:03 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11885",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11797",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "603ee30c-a747-49c3-b706-2a1103e255c0",
+      "x-ms-correlation-request-id" : "a70ee25f-5e30-4aea-9b83-056080e1f4f3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050455Z:603ee30c-a747-49c3-b706-2a1103e255c0",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023204Z:a70ee25f-5e30-4aea-9b83-056080e1f4f3",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "edced338-773d-4e59-a258-23d5727099ee",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "16ec5987-e1eb-484e-a77b-a6eaf7337778",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:05:26 GMT",
+      "date" : "Thu, 26 Mar 2020 02:32:34 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11884",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11796",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "f6d18b93-9cfc-4507-b4e5-ad5a1f3c3bf3",
+      "x-ms-correlation-request-id" : "f35aa1ad-69c5-474c-a716-99232f7de591",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050527Z:f6d18b93-9cfc-4507-b4e5-ad5a1f3c3bf3",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023235Z:f35aa1ad-69c5-474c-a716-99232f7de591",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "a1ca7358-9a0b-40de-aee4-92fe6064ffac",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "3dfb1c2c-01e4-4ebb-9b27-9b65ba7f645c",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:05:56 GMT",
+      "date" : "Thu, 26 Mar 2020 02:33:05 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11883",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11795",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "b683dec7-9afa-4ab3-bd32-88ece06cc007",
+      "x-ms-correlation-request-id" : "d8bddde0-bada-4d56-baba-0346c78778e8",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050557Z:b683dec7-9afa-4ab3-bd32-88ece06cc007",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023305Z:d8bddde0-bada-4d56-baba-0346c78778e8",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9e323891-9707-4e62-a2c9-899888b4a204",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "e5f189c9-d99c-4539-a4f0-546b16d2101a",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:06:26 GMT",
+      "date" : "Thu, 26 Mar 2020 02:33:35 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11882",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11794",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0df9d77b-19c0-4322-b75d-d5af2588c8e0",
+      "x-ms-correlation-request-id" : "928a2d33-6fb1-4fd0-9593-02fb5b44a3d1",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050627Z:0df9d77b-19c0-4322-b75d-d5af2588c8e0",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023336Z:928a2d33-6fb1-4fd0-9593-02fb5b44a3d1",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6543a2c1-b503-468e-8c4c-c68b7268c63d",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
+      "x-ms-request-id" : "cd945478-9882-4597-acf1-a7f6c0bfc498",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/9490d9a4-f414-40f3-830b-b0cded414bf5?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:06:57 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11881",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5ed7862f-55d4-4bdf-92da-95b890ef222a",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050658Z:5ed7862f-55d4-4bdf-92da-95b890ef222a",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "70b71cd9-52d3-4ae8-b948-0b29f3a6c236",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
-    }
-  }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:07:28 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11880",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "4c6b76ca-d592-4222-a023-5bd3962d1aae",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050729Z:4c6b76ca-d592-4222-a023-5bd3962d1aae",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "db6a99a7-621e-43bf-95f9-5100ea13a794",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
-    }
-  }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:07:58 GMT",
-      "server" : "nginx",
-      "content-length" : "126",
-      "expires" : "-1",
-      "transfer-encoding" : "chunked",
-      "vary" : "Accept-Encoding",
-      "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11879",
-      "StatusCode" : "200",
-      "pragma" : "no-cache",
-      "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ace64636-208e-497e-8887-31d749ceee9b",
-      "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050759Z:ace64636-208e-497e-8887-31d749ceee9b",
-      "content-type" : "application/json",
-      "cache-control" : "no-cache",
-      "x-ms-request-id" : "514deef0-14da-4a5b-a58e-f3348eb9ca51",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\"\n }"
-    }
-  }, {
-    "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/a95c4138-bc8a-412d-88c2-c96225d658de?api-version=2017-08-31",
-    "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
-    },
-    "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:29 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:05 GMT",
       "server" : "nginx",
       "content-length" : "170",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11878",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11793",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "0230b624-2ac9-47b7-9340-30d1ec82056a",
+      "x-ms-correlation-request-id" : "60311673-0332-401f-950b-9d71417dd926",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050829Z:0230b624-2ac9-47b7-9340-30d1ec82056a",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023406Z:60311673-0332-401f-950b-9d71417dd926",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "706b242f-29f6-4566-b5ca-4d1a215eabb4",
-      "Body" : "{\n  \"name\": \"38415ca9-8abc-2d41-88c2-c96225d658de\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2019-10-23T05:02:21.4262078Z\",\n  \"endTime\": \"2019-10-23T05:08:26.5656574Z\"\n }"
+      "x-ms-request-id" : "9ca49409-0f6e-4983-a810-53262af39337",
+      "Body" : "{\n  \"name\": \"a4d99094-14f4-f340-830b-b0cded414bf5\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2020-03-26T02:29:28.9576733Z\",\n  \"endTime\": \"2020-03-26T02:33:45.3730679Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:30 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:06 GMT",
       "server" : "nginx",
       "content-length" : "1764",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11877",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11792",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "b5ceafbc-6247-4bd1-b646-e8060e732ea1",
+      "x-ms-correlation-request-id" : "0991193b-2946-45d0-acbc-3ca2f4520abb",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050830Z:b5ceafbc-6247-4bd1-b646-e8060e732ea1",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023407Z:0991193b-2946-45d0-acbc-3ca2f4520abb",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "d9d2b8d4-55a5-450a-849c-ec15b7cff6ab",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999\",\n  \"location\": \"eastus\",\n  \"name\": \"aks758999\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.13.11\",\n   \"dnsPrefix\": \"dnsaks758999\",\n   \"fqdn\": \"dnsaks758999-71ae5863.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks758999\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.13.11\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm5zuEwcqiSSWoqWL6li8A26GkyqOu+hPajp07GNw/oHZ4KilD/0mrcvHmv1OoXtB4cD7tLSygkwtB9LdECAvMt7uOl6VAGgOSCn1GYxx8nvGRWpDtIyaqLIbSSU3JsFUSrKZXtM5g12c8LUP6CFo7kb0SEF28GeVvi9vtGuKHcIwxoVvWsf7KuUiX9tRcbYGKPi1gUXpXbQ2+JvoKvcqZRaad0dEjH5MYLyfR+c5po/x7j+MUPenUv4ET4Q2B1lfiFkZv/+eSakR6/dIgrBSQiiXqzxL4fBNtVhj7BdsKy63fotPlatd2QXZHzofDM/pI1tskqGqgUJWTZxM2tGM3 \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"ad38138c-4c27-4cc1-bc68-b74f4f9780cc\"\n   },\n   \"nodeResourceGroup\": \"MC_aks758999group_aks758999_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
+      "x-ms-request-id" : "c7cdb7fe-257a-4fea-baed-569cd0ba53a7",
+      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349\",\n  \"location\": \"eastus\",\n  \"name\": \"aks769349\",\n  \"tags\": {\n   \"tag2\": \"value2\",\n   \"tag3\": \"value3\"\n  },\n  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.10\",\n   \"dnsPrefix\": \"dnsaks769349\",\n   \"fqdn\": \"dnsaks769349-c400071c.hcp.eastus.azmk8s.io\",\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"apaks769349\",\n     \"count\": 5,\n     \"vmSize\": \"Standard_D2_v2\",\n     \"osDiskSizeGB\": 100,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"1.15.10\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\": {\n    \"adminUsername\": \"aksadmin\",\n    \"ssh\": {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbm+MAVc83H5xMJehxmkm2e+eOJBBTFKsu/erVud62y7iR09swWsthK2CoQmc+txy24dltXlwgDd/dAI+hUvQJKecgpf0QIn6FYWqbbWQOoQ2UXXIyN2sYZBDnDzlWsV6KIPskHPqdec3zDu4pEodJQxuI6swl0kf8E5ouyIWl1w0xP6ZiG8KIEebpzv3KYoFpstqK8FFu0afXPoaqiDGiVFFEVVK0WsvGAqBn+l64nRncyrHtJqnPpEijuSzpnhe9C2WN1txOh9BN6LF4zlzn3tRqf+IyhJwOdVxIh+OndB14X4h2n1mhMW/DMMa3k4ivRvSU4KeF4cZ9B94Kt92t \"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"clientId\": \"e88ec677-253c-480a-81da-47e421007f93\"\n   },\n   \"nodeResourceGroup\": \"MC_aks769349group_aks769349_eastus\",\n   \"enableRBAC\": false,\n   \"networkProfile\": {\n    \"networkPlugin\": \"kubenet\",\n    \"loadBalancerSku\": \"Basic\",\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\n   },\n   \"maxAgentPools\": 1\n  }\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterAdminCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:30 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:07 GMT",
       "server" : "nginx",
-      "content-length" : "13115",
+      "content-length" : "12857",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -3332,25 +5653,26 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6adb1cd6-b0ae-4b94-8bad-d6d411fa2786",
+      "x-ms-correlation-request-id" : "b758ecb0-d506-471a-a859-5cc93dcfdc36",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050830Z:6adb1cd6-b0ae-4b94-8bad-d6d411fa2786",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023408Z:b758ecb0-d506-471a-a859-5cc93dcfdc36",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "5f282ee1-2061-4f06-8cef-9553bca771ef",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterAdmin\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterAdmin\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlckFkbWluX2Frczc1ODk5OWdyb3VwX2Frczc1ODk5OQogIG5hbWU6IGFrczc1ODk5OQpjdXJyZW50LWNvbnRleHQ6IGFrczc1ODk5OQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJBZG1pbl9ha3M3NTg5OTlncm91cF9ha3M3NTg5OTkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJZVUZFUldSSGNscExkM1YyWjFSdFUwTnJWVWxzUkVGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNFQxUkZkMDFxVFhkT1JFMHpUV3BTWVVaM01IbE5WRVYzVFdwSmQwNUVVVE5OYWxKaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJCWlRrd2VFZDZjVGhIYzNrelUzUk1WamRJYjFvS1dEVXdMeXRXWW1KT05DdFZNMkptU0RZeWEzWkNVbnBQYm14M1drRnZlalpxV2xVek5VdDBZelV4V0ZaT1lXUXJUbGhSZDFGUlNtdFVjRUpXV1haS05RcGlaREpLUm5KTmJEQTBXbUl4YlRka2RHSnZlV1ZzTHpOTk9GUkJNVnByU0hWMGNDOHlLemx4VFVNcmMxQkdkbEI2VHpsb01tNXdRbTl6YldOMFFWb3ZDamRuTDBKWGRGTjViV1JYV2tab2MwdHdjbTlIT1RSbWNqTlZhemM1YmprMWJFazNTMjE2YzNsaWFIVlBVR0lyWVZOdmNHcEpOSFJCVGxKSFdUZDZVbEFLYkdkdFlXTkNjM2hIWm5OTWVYbzJNRk42T1d0Q2JXaEpiSEpJVXpKVVF6bHplbmxWTURjM1dXWjRUbkYwWnpCS1oydDBWVUZLVnpKTVptbFRXR3gxY2dwU2JqTlRhamhFUkRkdlVGTnZlRlJJY1hJMVpraFFXRGREVGxSd01XZ3lZblp3TUVFdlNIaG1lRWRrV2tGNlpUY3dORXhhZURCUVZtRnpRbEpuTUZSb0NrOTVWVm8yT1hFdlUzQnRibkJpVjNocVlYRm5NRW81TkRWb1VVOU1kakoxTW1sUFJuRjJUVlkwZVV0MEx6aFdMM2wzZERsNlpWTjNORVU1TkhCS1JERUtRMUJ2T1d4dmRXcENMell4ZVVwME9WbEpaelZyVTFoaFpVNUhTRVphTUdsUk4xVkphMFpTT0VWRFRHUm1XRWxrTmxVelpGYzRaWFJaVTJscFNTdFpXUXB6UlVRMGRIRlFSR1ZGZHpGWVNuSkVTVkYxV2pGQk1URTFibk5zVkdoUlJGcFNSV2tyWWtZNGVuUTVNVTVGTUhwa2RpOUxhM1IxWkdvNGFsaG9UbmhUQ210YWJrUlNZa1FyU3pOV05XSTVPRWcyZUdaalYwNXhRMWRGUXpNM2QyVlZZV2hUTmtSQ2VFeHJVbG92T0RVeVNXUlBOVXhyTlROU1VUSlVVMlo0YTJVS01FMXlibFV4VjJwa2QwVmhVeTlzWWxKdlFrZG1UR2R4T1U5UVIzVlFXV1JPVFdoSVdra3hUaTloUTI1eVIyMUNVbFJvTkRCUk9HTjFhblozY1RaVk5Bb3lVVUZoWmxSS2RYcEZVakZEYTFsSlYwWjVWMngzU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLYTNsWFNrbEllRE0xV1VkbmNYRjVaM0EzYUZsTVQyUkJOSEZZVkhwUGMxWlJjeXRXTWtOdFp6WkhZVmcyY25SRmRXSnFhV052VldJMldsTnFUbXA0VHdwMmJVbFRRMll6YlRBelZuZFROVXN3YW5kQmRGTTFTSEJyUlVwMlowNUVXa1V2TjNaRWMwSlJNRXRTUzFkNWVuTjROM0ppVEZCUmVHUjJUMXAzWTNvMkNqbEVPVEZHZG1sT2NsaDJaRlJaYmxwYU4wc3JValY0ZWpaSk1tMUROV0ZOWkVSYWEzTkxiVGxJU2tGb1dtcGlZVFZqWXk5eGRuazFTMnhzUmxkVGFrNEtSMVZ6Y21nNE5GcDRkaXRDZERKdGEza3hjRGhGV1dSUWJscHhTRWxCWWs5SFNHSkRjRzFxYTFkUmFqaFBXR3BWYTJ0aFVHa3dVRmRqV2toT0sycG1Td3BGVTNaR2RHbHhOVVowTWtwMVVWUkxhSHA0WkRreEsyeDBOeTlGVFZOU1NHNTNSamN4YjFrMFNsVTROMnBvYm5neVJpdDNVVzlQYkdkdlIySjBVelpZQ210VFFtNWpabkJ6ZHpkVE1VZHdNVzUxVDJKVk9GbHFaVFZWVkRad1FWcHZlblV6TmtkM1pWQm5jMUExVlZWcGQzbHZlazVJY0dweE1sQkJlVXRIVFdRS1ZuWjZURVZ5Ym1SQ2RsSnRXWFJMU2tWNFZrUkxTRXAwZG5WRmNUTnJlRkZMUkhkemIxQlpPVWgyUm10VmJVVjNibk00YmxSSWNVeGpOR1Y2UlU5RWJ3cFFRMEZCV2pWemMyZ3pjMk5LV0M5dlIwRkZUa1IwUVU5MlNuRXhjR2gyZUdoeWNWTnFZbkJtWWxGM1dYQTNWbTlPV0ZkTlJFMW9VSHBsUkdSdVJscEtDbUl3TTJVemJpdE5UMFUxV2pFNVJtYzBXR0ZUYTNJMGMxVnhUaXRIYVVOcE5UbExZMmx5ZVZnMVdIZHpSMFpSUVhaUWExRjFlbHBuTkRCdk9HaHBaSElLTVM5TmVXSllja3A0UkRFdksyUllPREZwWjBOMU5Wb3lhV3Q0TDNvdldscDBVVlJ1TjA4M1VGRlpZbXhDYjJob1lVdFRWR0pFV1VOaWNUVmliSE5XY0FwdVZYazFZbWhxV25GbFNXTkViRE5ZWmxaa2RWaFpTRTVTV1VKUVJrNUhWMkYxU0hKaVpYTkRZWE5aUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZDBoMlpFMVNjeloyUW5KTmREQnlVekZsZURaSFZpdGtVQzlzVnpKNlpWQnNUakl6ZUN0MGNFeDNWV042Y0RWakNrZFJTMDByYnpKV1RpdFRjbGhQWkZZeFZGZHVabXBXTUUxRlJVTmFSVFpSVmxkTWVXVlhNMlJwVW1GNlNtUlBSMWM1V25VellsYzJUVzV3WmpsNlVFVUtkMDVYV2tJM2NtRm1PWFoyWVdwQmRuSkVlR0o2T0hwMldXUndObEZoVEVwdVRGRkhaaXMwVUhkV2NsVnpjRzVXYlZKWllrTnhZVFpDZG1WSU5qa3hTZ3BQTDFvdlpWcFRUM2x3Y3pkTmJUUmlhbW95TDIxcmNVdFplVTlNVVVSVlVtMVBPREJVTlZsS2JXNUJZazFTYmpkRE9ITXJkRVZ6TDFwQldtOVRTbUY0Q2pCMGEzZDJZazA0YkU1UEt6SklPRlJoY2xsT1ExbEtURlpCUTFaMGFUTTBhMncxWW5Fd1dqa3dieTlCZHlzMlJEQnhUVlY0Tm5FcldIaDZNU3QzYWxVS05tUlpaRzAzTm1SQlVIZzRXRGhTYmxkUlRUTjFPVTlETW1Oa1JERlhja0ZWV1U1Rk5GUnpiRWRsZG1GMk1IRmFjRFpYTVhOWk1uRnZUa05tWlU5WlZRcEVhVGM1Y25SdmFtaGhjbnBHWlUxcGNtWXZSbVk0YzB4bVl6TnJjMDlDVUdWTFUxRTVVV28yVUZwaFRHOTNaaXQwWTJsaVpsZERTVTlhUld3eWJtcFNDbWg0VjJSSmEwOHhRMHBDVldaQ1FXa3pXREY1U0dWc1RqTldka2h5VjBWdmIybFFiVWRNUWtFclRHRnFkek5vVFU1V2VXRjNlVVZNYldSUlRtUmxXamNLU2xVMFZVRXlWVkpKZG0xNFprMDNabVJVVWs1Tk0ySXZlWEJNWW01Wkwwa3hORlJqVlhCSFduY3dWM2N2YVhReFpWY3Zaa0lyYzFnelJtcGhaMnhvUVFwMEt6aEliRWR2VlhWbmQyTlROVVZYWmk5UFpHbElWSFZUTlU5a01GVk9hekJ1T0ZwSWRFUkxOVEZPVm04elkwSkhhM1kxVnpCaFFWSnVlVFJMZGxScUNuaHlhakpJVkZSSlVqSlRUbFJtTW1kd05uaHdaMVZWTkdWT1JWQklURzgzT0V0MWJFOU9hMEZIYmpCNVluTjRSV1JSY0VkRFJtaGpiSEJqUTBGM1JVRUtRVkZMUTBGblJVRjBkbVpJUkdKMlpHWkNkRnBvT0RRelZtbFRRU3RCWldObFkyaDRWMDVoWVhoS05YZzJWR05OWlVOaE5pdEhhM1ZGU2xGT1NVMXdaZ3BGYnpseGJWWm9TbXBsT1M5MFNXWndWakJyYTJ4bFltTmhiRFI0VFZZMVVFaE9XVmxIZUdaVUszYzFPWFZ2UkZwaGMzaExNWEpuSzBOcVVFRlZUVzA0Q21zMVpXdEpSMDlJYmxscFQyMWFkM0l6VHl0TFJWVlNSbk0xUTNCTlVXaENjamhJUVhRM2JHeG5hWGw1VEdSRVNYVnZRMjVyYm5nMU9XVmlaSGs1ZERnS1ZraHNNSEoyTldSalZIVm1Sek5LU2pBck1XZHRMM05YVEVSTlRtNWhNVFJ0V0dGQ1ZXODFiM2hvUWtGSVlTODVjRkEwTWs5UVNVOVFUMmMxTTJOck5BcERRbmw2Y1VOWk4yUmpPWGd5ZURCbmNqaDNVMmNyWkRGQ2RWWnpOMEZYU1RaNFR6ZzBSVXRyZVdsQk9WTTBUWGhxVlZsQ1UwMTRabGcxZDNBM2RtTnNDbFpXSzNOa2JtaERObE5yVnpOS1RURkxaME40Y1ZobVpFMXNOaXR3Um1OcksyTjNkVEpIU1dRMmRHMW5jVEIwVm5sUlVXRkhhMUk1YzB4MGFtNUhkM0FLUkU4MU5YaE1ObTFZV0dkU01sWmplalIyUzB0bVdFd3JWMGREYjBoRWEyeEJkWGxWUm1GUE0ycFJNak5TT0dsQ2RtNUxiRk0yTldjM2NqWjRObWh3ZVFvNGJ6UlZWM1JqZUc5V2NGbHBhME5PUWpaMVZuVjZZVTl6T1hBNFdFZDFWSEl4ZFhNM2VEaDNXbFZ2SzJaSWFVOXlWSHByT1dWUmRqaEdUamRZTkZGRENtOUxXRlJVZUVsa1kwSXdWVGgxVWxaa01tRlZiMFYxZHpkeE9XVXhjWE5IWTI4MlZ5OVhaVGRSYjJjelJXazFNbTFtWXpkSFRVeHBla2RPV1VwTWJtZ0tOa3BOUmxCc1FUaDFaRFo1SzBKU1UxQnRWVlo2VXpCRlpuWjNabmg1WTJsV2IxTkxkWEI1VFZOWFkwazBjRVk0ZERBNFduUlBVa1JtUjBOcWNGbFdUUXB4VUhGMlEydDNVbTF5TTFFMFVIcE5NVzlLTDI1blZISkhhbVpTU2twSVdFZGxWa05SY0hCMFRVRkxWR0ZCVVZwd01tdERaMmRGUWtGUVNuQnFkREZrQ2xJeWQwdE5Ua0kxYURObVJEZEpUbWhQWm01dVdTczVNM1o1UlVWVFJXWjJWbWRhVXpGNFZtOW1aMWRMZUdwQ2JFdDFOblZxT0habU5HRkRlWGR1TVhRS2VVazBlV2xuVmpSbU1qTmljWFJoZFhCVFlqaEVZWGxwY0d0QmMxcDBhSGswVkcxeU55ODVWRGxtYlM5WFlURmtMMlp6TmxZMFlYRlZNMFJaVmxoS2RBcFZNR2M1Y0dORE16ZDFSV0pvYjJoT1ZFVmpVSFF3V21kbVdtaDJiV1JOWWxFNVZqQlJRa2hFZVdZMFNHaHNOVGxCWm5wTE5tRlBiWGd5YUdkNVZEbEVDbEZrV2pGbU0xaHpka1l3WmtNeGFYQklNSEpaZG1sSGRWcFpXa0pZYURrNVdYRkxWVXROV2pGelFrOTJiRzFKVDFJNWMwbEthSFJJWkU5NlRsUldhM1VLV2pWdVRrVmxkR3A0VmpkWmRFWlRZVmxuVG1wWVRGVmFaR3BwUzNCQk9YQjBjamd5VEdWTlJISXJRbk53WVhCM1FrTnlVbTlpTkdnMlZGSjJZMkpvTVFveU9FUkNPV1pWT1RGUWJrOTJkMVZEWjJkRlFrRk5kRVl6YWk5eVRuUnFjWGQyTlUxTWRGbEJTV0Z2VFZVdmJqSktWR3huTWt0Sk1qZDRVemh3ZUc5a0NsZHZaM1puY205S1lYY3haV2hHYW5sV1MxTlNSbU5VYjA1S1NYaDNlV0pzUlZCdU0xbGhlWEJOTUhoRlRESTJjblIxTWpCSE9IWkxVelJKV1V0cWMzUUtkV05UTVZwMlZGTXpNVzFtWm0xbVJXNTJiR3h3UW05YVpUbHJaVXBSVkdaeVQzTlZRazlrT0RBeFJ6VnFWRVZPVEhoWWFWSkVhVWRuYnpKd1dqaHNSd3ByTWpSVFFuZEVVblZOY0c4NFdHUndkeXRIUmk5M2JESkJTVGhQTTNoVWVETlRabE5IS3pOa1ZFZGxNMGxEYzNkUGVuTklXR0ZPUlRjemJVNU5iakkyQ2xkelpFOVlkM1pOVWpkTVpGWnZUMlUwZVZsSFF6RnZlWFJyZVdSVlRHWkhiSEpSUlRoclkwTjRSRXAwVGk5c1ZVVkVka3RRTHpSNlVEVnVNbGRPUzBnS2FuWkRaRmx4V0hSRGVVdGxWV295Y3k5WWFpdDFZbnAyVlhORldWZEZkQzlVUTNkclN6WnRTVEpsYzBOblowVkJWMEl4UTJwMmFIWkZOMmxKYTJRM05nb3ZUeXM0YzNWNlQyUkRXa1o2ZVM5S2VUWnBVVEZaVlV3d1psTmxkR1YwY21zemQydEhhMlJNTW1OTFpVSnJPVEExYTB4VlN6RXJVMlpSTW13eVpVMDBDaTl4WmxGaE5GUkZRakl5Y2xWemN6Qm1lazFyYkhoNk5pOVZiV2RVVlVWd2MyZFNOa0p0YVZvdk5ETjJZbk5ZVHpKeUwyOUlNVmhhTldaS2VXODJRelFLVG1nNFdsRmpXa2hMWWxaMWRYbG5jblo0VFdnMlVHbExTMkpoT1RaNlkzUXplV0pDUlhWMVFtOHlMMjFwVmxGQlR6bExhV3hHY0ZGUWFrbHlhVXRRY1FwMlJHRnBiWHBIZFdKRWFHOTBSR3dyVFdSVWF6YzNSbFl2ZURZemVUVjJVSGwyWjFOUk9GcEtTRVJpVlVWNWNHZFBRWFJSVTBaQ2VqTkNXVTF2TTBZMkNuUnpWWGxzTWxsbGNHNXBhSEJFY1VSSVNEVlpjMFJ0VHpobFdYaDFPR3RHVkhsQ2RTODBjMFZIVFZKdFpFbFNSRVJ2Y0V3elpUaEtWMEZIYnpnclNISUtNMjV1YlU5UlMwTkJVVUpwY2xGdlZYTldVWGQyVGxodWNVbG1ZamR5YUc4eVp6aDRLMjFHWW14Nk0xTnJVMUpEVW5OdkwycFNlRlJ0SzNsNk4zSndMd3BDVUVSMVZrMVVkVVpzWjJjdlF5ODFRVUp6YVVkSVZFUlJNbTEzTjFodmRtWmlTV2MwVlRaME1sazNZM2RPYTJrd1ExSkJSV2hTY0M5Nk1UVm1OWGhaQ2pNeWJqTmhZVlpoYjBKTGJtTk9UMFZPU0ZBMFFqZFVhbU5TV205WlZtOWpRa0l3WTFGTVFXOTVWM2RuYmtoMGJqRlhURU5tU0ZrMVMzQnpiblJMWTJ3S05uZGxPREZwVkRKd05YVkZkR3B1VkU5SU4yMXdabkZpZVVFd2VYcFJhVFJIUm1WUVdEVjVRa3hVVVhobE9XUmphRVZUVFdOQ2FEbFJMMmQ2ZFM5cVlRcFNWVkZ2U2sxMFZIVXZPWEY1T0RsbVNtTmlNMVF6YmpnM1lVaElRWFp5U0VZcmJtbExVVXQzV1RVdmNFRkhkbEpwTlhKWGNVZFBiRkJ0UjFNNWNEQXZDazExWm5Sa1RIRm1URGxvZFdSVFkxSkJXVnB5VEN0TFJWVjRTeklyS3pNNVFXOUpRa0ZSUkZaa2IwYzRaM0o1VVZSdWRuWjViekF3ZDJSdGNFOU9kV0VLTm5WTEt6Wm5TRTU1ZUZjeVNFODRaWEJoVDJOdEsyUkJORzV2YURobWVXUm5RMlpHU21SdWRrcHlkMFpHTVhKb01VbGlZazAzY1hKQlRXMXVZbFZKWmdwS1dqVnhUVVE0TURCR2IybzNSVmh0UmxSemIzZERMMW93YTJOdmRsZFVRbk4zY1doaFRqSnRkMVl5YXpKUFQwNUZPVU5CYmxSR2RsaHNlVnByTlZWaENrRTNWRUZ6YkN0U2JrazJOMWg2VTJGME0ySXdVazVMVDFGa1YyWklZbWhqU1RSNmJqaHdhMHhUVW0wck1UZHRVWE5DWm5SSVRHNXJVRkZxUm5WUFVYY0tkRlpJVFZFelZEVTRPUzlOUVd4NVVsSlVWRkJUVUVvMVVVTXpNVzg1YkhocldrY3lNWE5CUTNoQ2VtbHRVSEJhVWpoTVdHMUtZVUV5YzNCa1lVTlVXQW94Um1aNU1EQlNRalJOZWxaV2VrNXhaSGszV1haTWQyYzFlRzFKZG1aQmRXZ3labXd2WlhNclNsZGhWVFZIU0hkSmFHaEJWakJWV21kYVdVa0tMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogbVA1aXZSd09MeGxlVlRNbFZDVWh4TnVoVlJUbU1Kb2lPRmN6NW82empKMXZjUmFDcmhjY0MxOFhvVEFybDBVUHJibUdKeEkwd1BmUTRaclM0aGY2SzI0Zk9aN3hCMXNqc0JHbHY4VE0yWVMwRlF3VmpKZGhGMXQ3c0hTSVpXMVQK\"\n  }\n }"
+      "x-ms-request-id" : "58a70246-cc8f-4c5d-8959-3f25c7cea4ff",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterAdmin\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyQWRtaW5fYWtzNzY5MzQ5Z3JvdXBfYWtzNzY5MzQ5CiAgbmFtZTogYWtzNzY5MzQ5CmN1cnJlbnQtY29udGV4dDogYWtzNzY5MzQ5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlckFkbWluX2Frczc2OTM0OWdyb3VwX2Frczc2OTM0OQogIHVzZXI6CiAgICBjbGllbnQtY2VydGlmaWNhdGUtZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVVXZSRU5EUVhWVFowRjNTVUpCWjBsUlZtd3liMFJWWVhNclNtdFNPVUZ1ZUhGNU5FeG9ha0ZPUW1kcmNXaHJhVWM1ZHpCQ1FWRnpSa0ZFUVU0S1RWRnpkME5SV1VSV1VWRkVSWGRLYWxsVVFXVkdkekI1VFVSQmVrMXFXWGROYWtWNlRYcEtZVVozTUhsTmFrRjZUV3BaZDAxcVNYcE5la3BoVFVSQmVBcEdla0ZXUW1kT1ZrSkJiMVJFYms0MVl6TlNiR0pVY0hSWldFNHdXbGhLZWsxU1ZYZEZkMWxFVmxGUlJFVjNlSFJaV0U0d1dsaEthbUpIYkd4aWJsRjNDbWRuU1dsTlFUQkhRMU54UjFOSllqTkVVVVZDUVZGVlFVRTBTVU5FZDBGM1oyZEpTMEZ2U1VOQlVVUlBWRmd3Y2xNclRWQmliMlJ2ZWtoUGRXUXZXbFlLVTB0dVJtc3JPR2RsZUZkdVQzQndXbk5JV21jM1dYWnJZWEpLWm0xUVZETkxiVU53TTBKcFpEWXJZMmh3T0hscmJrTXphMEZhZFZvd1pqQkJlak5XZUFweGMxZHVaMDh2VkZkSVJtSnNPRlp5YzFkVWFGQlJTMHQxVVhaRmVtTlNkemRFWlhKamQwUlpjR2RxYkU0clJtbHVUV1Z1T0dOaWFYZDJZbk50WldoVkNsSnFWMmh0ZDFGYVIwWjNVRzg1UjI1elRqVnZNREZDY3pnMWRrOXJka05HZDFOMFVISlpjRUl6YWtkQ1JrWnVkRXhMUmt0eldXRTBNSGg0U0dwb1UyMEthRTV6ZVRKRWVGRlVjbXBJVld0QlEzUk9TR015TlhsTmFXdHNWa3BrWTNkbVRUaHBMMWh2VEdSQmExbDVTbTlhUzAxcmFWbG5TSGQ1VW5aV2FWTmlUQW80VUdNMU1IZFRZVTVKZVRac1NtMXpaU3R6V1hVM05WZFBkRE5FUjBKR2NXdHJXblF6VDJRNGQyWm1TMHhXZUhWRldGRllhVlU0YkdreWMwdEdkR0Z2Q2taRmFHSmlVazFwTm1NME56aDVlbVJQZUZNM2RreHhkWGhKY2tjNGVXazFSVE53ZW5OcE1XeFVlblpwT0U5bWRFcEVSRFZXTVU1bVUyWmtTVVptUlZRS2JrSXJkRnB1Tnpod2MzWlFNVE13TmxkSmN6WkxjM0JVVUhOdVUzTTRSVFY0WVd0Q1V6UklUMDE1VWtSaVZVOTFWbGxGTVdaYWRqQmpOVmxtWVZCdWNncEROWEZMTlVneGQxVkpWa2xrTTNaaFQyc3liSGd5VVZkNFMzaDVXR3AwVVdSb1MybExPREoyWVhneVJWaE1NbGRFT0hkdk4zVnhNRUZVY2xsbkwwWTRDamQzY21kbFVHdGpRU3RUVUhkQmVEUTROV1pwTjFZNVJsWXpiVTQyY1M4MmVtdEdSekZKTVdkcVZqQXZiazVrUldWYWJESk9ja0ZtTjNaWk5HeDRjWGNLUlhwMmNrbDFOR2hJZWtKcmNtbGpTa00yWTBSaGFqRkxUVGRTUTB4WE9URlVUbTlGTmpKalJVSXlZMHBzVERGdEwyRjFRM1JtYjFBME4zZzJTMlEwV0FwUVNHRjNaRXBVZFRWS1ZIWnpia3AwY0U1TlN6bFJTVVJCVVVGQ2IzcFZkMDE2UVU5Q1owNVdTRkU0UWtGbU9FVkNRVTFEUW1GQmQwVjNXVVJXVWpCc0NrSkJkM2REWjFsSlMzZFpRa0pSVlVoQmQwbDNSRUZaUkZaU01GUkJVVWd2UWtGSmQwRkVRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRUtka1pGVEU1NVRDdExkSEJCWWtGd0x5OXpZbVpFV0dneE1uWk5UbHBUTW5CdFVYTllTbGRUT1hGUmRrSXpXazFCVEVaU2EydHFMM2hWWW5jMFYwa3hWZ281T0RsM1NGQnBTVWh6YlZkNksxRnhiR3hLVWxwdVQzVTBlbVphYm10UE9XTlJMMk14ZVZKSE9HZDFaMFJNWlhWMVNFbE9lSGhoY21wUlpuWnFVVlJWQ25sMlJFSm9XR1JLY3pOSE5rOVlSSFk1TkhGQmN6QkxZbGQxUjAxRFJrWk9NVTE2VmpkWWVFWnBVbFZ2T1dKbFowZHFTMkkwWjJwUmFIUkpUVmhIUjNFS1pHYzJZVkU0TDNGSGNFMUJaMHh6Um01R05VWndkMEoyZVdSdFdHTlJaV0ZuUkhOclNUTTNTMGxaY0RGeFFqRkliVXQwY3pReFFsTk9MMHRKYkd0SFVncHZObXQySzJoRWMzbEtiMDU0Y3pKUmRHcGxXRUpyVG1wbFFtVnZWbWh1V25Wa1VWZEdUR3NyYjJSaGFFSjNWa2t2UjJNNE9HcE9XRVZsTWs1a1RXMXBDbXc1ZUhWcFYwWkdZa1IxY21KeFEzQnFPRUV6T0VobmRtSkNTVGRDVWtaelpVNTRTMUpyUW1reFdVcE9UbXRoYUhOc2NXVmFjV1kzU1c5c2VubFBPR1FLV2tRMlNFNWlNMVIzVGtWSWJGSnNUVEkwYlRkM1ZsSkdXRVpCZHpWaVp6ZGFWM0pZV25KMVNrNUdaelZ2TkhBeVNsUk5aMHRwY0hseGMxVXpUV3M0VUFwMllWVndhR0pUYlhGT2FETllSRlYwYUhGRGVVVjFlVU5OYzA5bGJVcE1XVVZUUVUxUVQzcERibVZETTNKQ2FEY3ZhRzB5VDJkMVEydEJaV3c0YTA5ekNsTkxSM0ZLWWprMWIyZzJRMGxDU1VGTE4wNDNjeTkyY0ZsSVVUVnpjMlI0YjJnMlpWUkNLM0JyUVdOSkwwWlFkVVJMTWxGSEsyaG5XVzl0Y1ZsaGMxY0taVmhtVjIwMlRrdFdSRXgyZERKc1NFRnRjamwzWWpSQ1NsVnpkM1JRYkhsT2IzTkJlRzV1WjBSVlNtaDNVV3hEYWpVMllUUjBWMUJhWW1aRmEya3ZWZ3BQUnpsdlprSmhhRVZVVFVsck5EWmtabVo2TDFKellrbG5WV2t5TTBkd2VuUldUeXQyY3psUVlsaE5QUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBjbGllbnQta2V5LWRhdGE6IExTMHRMUzFDUlVkSlRpQlNVMEVnVUZKSlZrRlVSU0JMUlZrdExTMHRMUXBOU1VsS1MxRkpRa0ZCUzBOQlowVkJlbXN4T1Vzd2RtcEVNalpJWVUxNGVuSnVaakpXVldsd2VGcFFka2xJYzFad2VuRmhWMkpDTWxsUE1rdzFSM0Y1Q2xnMWFqQTVlWEJuY1dSM1dXNWxkbTVKWVdaTmNFcDNkRFZCUjJKdFpFZzVRVTA1TVdOaGNrWndORVIyTURGb2VGYzFaa1poTjBack5GUXdRMmx5YTB3S2VFMHpSV05QZHpOeE0wMUJNa3RaU1RWVVptaFpjSHBJY0M5SVJ6UnpUREkzU201dlZrVlpNVzlhYzBWSFVtaGpSRFpRVW5BM1JHVmhUazVSWWxCUFlncDZjRXgzYUdORmNsUTJNa3RSWkRSNFoxSlNXamRUZVdoVGNrZEhkVTVOWTFJME5GVndiMVJpVFhSbk9GVkZOalI0TVVwQlFYSlVVak5PZFdOcVNYQktDbFpUV0ZoTlNIcFFTWFl4TmtNelVVcEhUV2xoUjFOcVNrbHRTVUk0VFd0aU1WbHJiWGt2UkROUFpFMUZiV3BUVFhWd1UxcHlTSFp5UjB4MUsxWnFjbVFLZDNoblVtRndTa2RpWkhwdVprMUlNM2xwTVdOaWFFWXdSalJzVUVwWmRISkRhR0pYY1VKU1NWY3lNRlJKZFc1UFR5OU5jek5VYzFWMU4zazJjbk5UU3dwNGRrMXZkVkpPTm1NM1NYUmFWVGczTkhaRWJqZFRVWGNyVm1SVVdEQnVNMU5DV0hoRk5YZG1jbGRhS3k5TFlreDZPV1E1VDJ4cFRFOXBja3RWZWpkS0NqQnlVRUpQWTFkd1FWVjFRbnBxVFd0Uk1qRkVjbXhYUWs1WU1tSTVTRTlYU0RKcU5UWjNkV0ZwZFZJNVkwWkRSbE5JWkRjeWFuQk9jR05rYTBaelUzTUtZMncwTjFWSVdWTnZhWFpPY2pKelpHaEdlVGxzWnk5TlMwODNjWFJCUlRZeVNWQjRaazg0U3pSSWFqVklRVkJyYWpoQlRXVlFUMWcwZFRGbVVsWmtOUXBxWlhGMkszTTFRbEowVTA1WlNURmtVRFY2V0ZKSWJWcGthbUYzU0NzM01rOUtZMkZ6UWswM05ubE1kVWxTT0hkYVN6UnVRMUYxYmtFeWJ6bFRhazh3Q2xGcE1YWmtWWHBoUWs5MGJrSkJaRzVEV2xNNVduWXljbWR5V0RaRUswODRaV2x1WlVaNmVESnpTRk5WTjNWVFZUYzNTbmxpWVZSVVEzWlZRMEYzUlVFS1FWRkxRMEZuUVc1TFRqVlNhMW8wVVVZNVRITlBZVXhpZDNwdGJrSndkbnBRVW14MUswODBjbE5DZURCWFpVdGxhek5wZVdGMU5XYzFkeTlaZFhSeFR3cFpOVVJ2Y1ZKaEsyUk1UMHh4TTIxeGFHZFBZazU0YW01U2JtNXphMXBZYWt4aU5WbFNOMnc0ZDFad1owUjBVWFpVVURGdGFEWnRUVTlsVEVnM1NUZEZDbkJLWmsxb0wyVTBVM1J6YkdSTk1GSlBMM1ZqYmpWV2Rsa3JaVTR4TmxodFpuZzFVVUpUWlRCalJYZHFiMHBqV0VoelZuUmhVRUo1VkdOSlMwbGFhWFlLUkhsdWJsSjBNM1YxYjFrelZuWnNiWHBFZG1WaFdGRTRkMDlPTm0xRk1XcFpWbWhTYUdndll6bGxabWR0TmtsaFdXcFdaRWRCVEVSbWRVNVNLMDQzTkFweVZsTXhVamxzVTAxM1NFNU9UV2sxUm1oR05FOTZVbXhZUW5SYVMzVjRRM1JoVG5sQlptVlZhM2hDTkdoVE1HcEVUVUZqWW1sQllVbEVPWFZGTUZnM0NrcExkSE5MZDFZeVFYaGFRV0pzSzNrclFWWnRRWGRxVjJGWE9XeE5USFJQT0dsWmEyeHJiekJ1U21WM1Jtb3ZVVVo0VGxVeWVVeDZhVVZWUjBSQ1JEQUtTRzFuTUZCbFIxRkhSVFJhS3poeFNsWkpNMnhpY2pZM1ZuaFpabTB5T1VKc2NDOWhSRUpDVmpab09HNVpXRE5PSzJoVEwxZFZabXBtVFZoSU15OVNUd3BTU1V0d0x6bGpZVnA2YmxsVFkyaFVkRzg1Y1cxM2JHdEJiVXRhZUVGMlVIRkVUSHBuUW0xMGRUWkZaMlIwYWpGUmNXNVhjVzVKUlVvME1WZGFjMVpIQ204d1VWQlpkMlpSVjJ0U1JETmlOR05CYjNReVQzaENjbkpXTjNKQ1p6VlpObVpCYWpkM1p6QXJhbGhLY21WYUsxbzJlR0Z5WlZsSWFuaEdjbEpzTVdJS2IxUjViazh4TkRCc1ExTnhZV2MyZUd4T2VtdFhURUZwYkRoQ1VVRTRVRWhSUkRSQ1NIUnRiekY1T0hnME9FSnpibGhNU1hWQ2NtSkRaVFpwTVZCbGVBbzBUV29yT0hGQ1MweFhUVVo0TTB3dkx6ZDJTR05LUjNKR1ZFZDJSa0Z4YjBjMVJtbElVbWswUlhrelVVdzRSREpCVVV0RFFWRkZRVGwzV0ZwS1QwVkxDbXBVV21oS1dsaHZObWMzUW1nM1VVWlJXbTByYzIxU2EwRTJXV1pxYzNWNFpWWnpXV1ZLVVVJclMycHFhM05QYkdWSE5IUlZRMUZWUVRKWWFVSk5VblFLVjBzMmJVMXFXVTlTZW5wUVZIQTNXakpEZVc1T2RWRnpTVEJKZWpaak9XVkRVMWcwY2s1TksxVnlUR293Tkc1U2IxUnFjVXBIYW1aT1ZtZDRjWGREVXdvMWVIaHROeTh4TTI5SWRETTFkakpHTUZVMFMyUlNla3MxTTNsTGN5dElSeXRFVm04cmJWWmFTelp6TlM5SVRVWTRNbFo1YzA5UldISTFlSEZYZURZekNtTldkVEUxVkVST2JtbEhZVXBsYVRCWlRFODBla0oxVVVaUlRERTVaRTFwYjFJelQyaFdhbHBPUmpGRE1USlNhazFIV1VaM1V6VlllbVJRUldvMVMwZ0tUblZsWlROTU1XWlJUMFEwY1hKWFpsUk5ibE0yTXpGdlZHdzFMMjg0UTB3MFZUUnFWM3BsVDFoWU9EWjRVR2xQUkhoRldVRkphakZoU2pnMFRuRnJiZ3BFY3paeGNIUktkR3Q0TmxKRlVVdERRVkZGUVRGamVrOUZTRWx3YW05Q1FYVXJURUZ4YTBaSVVuVmFObVJZU1doT1pWQlFjMFl4VFVaaFJHUnpUMGR1Q2pJdlpGcGlkUzlqWm5OWmRHUlZTRWN5ZVhkMVpTOUNXa3hCWlZoNVVYTjBXV0Y2YUN0SlJrMXJaMlUwVmtsVmVsTXdhV2ROTmpoamFsVTBURmM1Y1VZS1dsQjBiRkJFTDAwdmMzQXZaRlZSUzBSd2FYbDZUVXQyUmtSd1NFNU5hemM1TTJNMGVWRndiRGhQU0ZsNmJFRmpjRWhCVDFJM1p6Vk9UbmxMT1ZOV1NBcHZTSEphVURVNVZsWlhkbEJuVW04NVRrMXZUblZuTWtRNFNUZG1SWGRoVEhoVWQxRkJkbkZQT0hkcFRHWkNkbE5aVjFwR2NqWTJUbVUxTVVJek5TOUJDbHBUZURKbVpHaGpTVXB3YmpKR1JtOU1XbmxDUVM5b05FcHJUM3B3TkdORFdXNVBSVEp5U0hwR1l6YzVaa3RtWWl0emNIaEJPVEJDV25KVVRVMHdhVXdLUlZRM09XTTNWSFpsYnpoaVRGUmxPRFZYWjJ0TVpIWlZWRzlUWVRkQ2MyTjVOa05YTmpaaVluQlJTME5CVVVWQmJXUlpjMmwzYTFST2VXODRhV1J0TkFwUFluVkRlblUxVUhJM1JEbDZOemg0WjJkM09EZDNUSFoyWWtnM2NGZDNXRnBxU2xoME5XcGpVR2R1ZG1Ock9XeHVNVUZrTVM5Wk1GZDBkelZoUmlzNUNuVkxUMjlRTUVGNVZIRjRVVmh4UkhVd0t6VjNkMmhYUVdKS1dWaE1hSEJKV0RsNFJXZG5URGhoUkdzemNVRkZabk5QYzBJd05ITkNPR0ZuUVdVd2ExRUtOMUZMTTJjd1ZYcDRNSFZuZFRWd05IbHVNRWhNUlhSYVZFVTJSekpDYlhneFREVklNa2MwVW5OTGFtNUxhalpEWldJd2FHaDViWG9yU1dGNU1uTTNkZ296Y1VSNWFrNVdSazFGZGpoMFJFRmxTazVsTlUxaFUxSnNiVVZ1YzIxbVNYSlNSeTlvVFVKb0wxVjNjMGhWYVhSTFpWQlBURGxQUkVoaVFsWm5VV0l5Q21kVlRWb3lZMXBQVGs1WmFqUnpRWGMyTURGNWJFSndabWR4Y2xVeloxQldVakpxY1hkeGVFRllRMWMzUjNWdmQxZDZNVGxHY0RFeFZUUldiRkpaYzJFS04yeHdSVFJSUzBOQlVVSjVkbUYxU200dmN6Rm5lR00yZG05TWRqTkpSRWxUUlVaSlluRjJjMHBCY2l0a09VOTRaRGxuUTJGa2FWRmpUSE5MYTNGblpncFZXRkp6UkZwVlVGbDZTeTlUVlhCVFIzWkZWemhIZVRKcmRsaHFWRWRGZG5KbWVqZFFNVVU0UVdkdldVMXpOVGM1TTNGYVNGUnRhRGRHYkRCalJHdDNDazVNVldFeGFEQm1iMFYxTVVsSVlXUjNTR3RsYkhwRlluRnNlRXhoVFRBd04yTkNVbGRUVmtkRGRURm1RMFIxVEZwNVJXTldOVzFPVVhWRU9VTkRTR1lLTm1wQkt6bFViMHczY2xKWVQxcEhjSFJOVGpkcWJsQk5jMjFPVm1SbGNuQXJOV2RCVkRFMGF6YzJTazl0Y25STWMwTllLMUZrYjJKamFsWldZa3A0YXdvd2RtdFJWM2RCZVVkdFFWUktXRWt4T1habFpqTlNSVzFxVTBOeWVtWjZURzh6TjJaUE5tTlFabFEwVWl0TVdXSjZUVkZoWTJOQ1VYcFRSbmQ1TlZsTENtcEhjbXhhV21neU9XVkZWWGt6YlhobFprVTJOMWxKVTNSdGFrbHdOVUZTUVc5SlFrRlJRekp2U2psemQwWk9WblE1SzJ0SmFVdDVOak0yTlcxaWJVRUtiaXRoWTJOWFJFOVhRbUpKWjFWb1IxWm5jMFZpY25Sck5rSnJkazlLYldGclp6WllaRGxqVkZCb1pHUndNRVJOWWs5UlJrRkJiV3BzVlRaMk1HUm5SQXBzU1dSR1VuaHBVbU5oTW00dk9VY3dkelJGYURCQ09YYzRMMGM0ZDJGVVIzWlJUVVJwY25GYVFXUmhiMGRXUzNCa2VFdHVaMlozSzJJMU9HcENiQ3N4Q25GbFVraDNZWE5ZYTNKTFFURnNXVzB4VFdZNVEyTkhXbWxHZUdacU1tcG1PRzloWlZaYU4zRlJValJ6Um10V2VFWTJiVGNyYTBKMFUyWkthV3R3WkU4S1EyTk1hSFZtWjI1RVJXcGpSV05LVEZObWNEbE5ZVUZZWW1SRlFtTnJSWEU0WW5jMVkydGpjRlV4ZUdWRlUwUkdhVGx4ZG1aaVVucHRWblJtWTAxbVVnb3JSM3BVYjFWV0wwbGpTR2hFV2tkaE4xSklla3RRTVRGc1JXRlRPVzV5VTNkdE5YRXZSMVZNZFd4V0sydEJSMVEwZERJMWVWcGFUbU5MTkdRS0xTMHRMUzFGVGtRZ1VsTkJJRkJTU1ZaQlZFVWdTMFZaTFMwdExTMEsKICAgIHRva2VuOiA3ZDJkYjBkMzFhNjNmNTAzOTAxMzc2MjY3NDViNjU5YTIwYTQyNTIyN2E5YTkxMTY2YWU3ZjRhY2Q4NTIzMmY5MjJhNzRlNmE3ZGQ3YTdlNzg3NGRlYjZkYWU0YjA3YmQ0M2FmZmM1ZGRiZTdjZDdlOGYyM2I3MGZmM2Q4YTMzNQo=\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "POST",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser/listCredential?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349/listClusterUserCredential?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:31 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:07 GMT",
       "server" : "nginx",
-      "content-length" : "13113",
+      "content-length" : "12852",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
@@ -3359,23 +5681,24 @@
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "baff8b97-2347-4680-ac75-c1b0e45e131b",
+      "x-ms-correlation-request-id" : "f9f2b6f5-293d-4256-9904-1e28e3348828",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050831Z:baff8b97-2347-4680-ac75-c1b0e45e131b",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023408Z:f9f2b6f5-293d-4256-9904-1e28e3348828",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "54e2876e-d17b-451c-ba89-437614e0c446",
-      "Body" : "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999/accessProfiles/clusterUser\",\n  \"location\": \"eastus\",\n  \"name\": \"clusterUser\",\n  \"type\": \"Microsoft.ContainerService/ManagedClusters/AccessProfiles\",\n  \"properties\": {\n   \"kubeConfig\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNGVrTkRRWEVyWjBGM1NVSkJaMGxSUjBkNmFFZDRZVVZrYzBOS1lXZEhUbFJ6WjBKRFJFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNREJQVkVWM1RWUlZkMDVFVVROTmFsSmhUVUV3ZUFwRGVrRktRbWRPVmtKQlRWUkJiVTVvVFVsSlEwbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGbk9FRk5TVWxEUTJkTFEwRm5SVUYzV0hSekNsSmFTM3BzTVZaaVEwWkZZWEJRYm5WWGNWcHlaV0ZrU1M5WFNYb3lWVTFSUm5GSmJHaEtORkpTYW1scVdHZzNNemxwUmpacFowNXdRMFEwYm1OVE9TOEtUVWxQVldWemVHMHZhbXhJVWtOU1IwdzNSMnRGV2pCdFVFODFSMDR5TmxOVGRYRXhZMjkyVG1wR1ZrTTVlbHBXWVhjMGJIRkdTWFp2ZFhRdlFrOVRNQXBDUjFsV00xZEdlV2t6VDJodFZtOWtNVVJXVTNGdmRXRkVjM2xoZW1adlIyMVRUbHBDUTI5NlNISjVRekpaYlVkUVdqRnBSVE5oYm5Wb1ZETjZNR1p1Q25oNlZTOTBTakJzU0U0d01YUlBNRGR1TVRaeUwwNVVaREZ6ZUZkV2RUUm9jVEpOWlhaQ1VYbENSaXRLV1djNE0xbDBWbFE1TmtkamFtY3hZbkYwZVM4S2JsZDRUV05rUTFKNlJWVlRRbEZ5V2pSSlJYZElUekV6WVdsNmMyTldVazVRVkZkc1lrSnpPVEYyU2padk1ERlBRMU41TURsV1puTnJUblU1Vm5NMFZBb3dWUzlLZFRJemRsbHFjbFpwTDBOaFpHSkZkakJFTmtzelFtVnBlSFUzY0ZWS1ZubE5jRkpvVDFGQlVFSmFlWFp5WlV4UFJVUmhiWEExYzBScFQwRm9DbWwzVUZwdlpVOUdRMkZOTjNadmJIbzJOVlYyYjBsMVdsUnRTR1kzYUVaTksxTmFUSE5QUVV0emVUaEZURU0wTURCMVUxWnVTMXBLV1ZKaVlrSmpURkVLVjJRdmFrTktkek4yUkZCWWJXSlhjVms0VVV0SlNYVkJTMG80YUVGd2Nua3JNVXR6T0VOMlFpOURVVmg2YjFjdmFWSXdMM0JKTm1RMk5VNXZkR2xYVWdveVNUVk1WVmxvYmxWRkswNHpNUzlvZGxvdmVEbERkMWRCZFc1Q2JFVktaWGtyTUZCWUwzZ3hkM0F2TkhwMWNsQm1iakZhVmxvNGJHODRSbFZ1WlhaeUNraFhibnBNU0VsUmJucGFWa2REZWtkV1JEQlFkak5EY3pkMk4wbDJjMHBQTTFkbFlWbHJWbms0UVRGd2JIUXhkbVJ2ZDA5c1NtZERaRnAxU3pOd1FURUtWWFJCVDNGRmVWUjJhRXhUTm5Gb1NsSjZlalIxWXpWMVFWZG1NM1l4Vkd4aFRGWjFSRU13UTBGM1JVRkJZVTFxVFVORmQwUm5XVVJXVWpCUVFWRklMd3BDUVZGRVFXZExhMDFCT0VkQk1WVmtSWGRGUWk5M1VVWk5RVTFDUVdZNGQwUlJXVXBMYjFwSmFIWmpUa0ZSUlV4Q1VVRkVaMmRKUWtGSlVYQnlUMnN2Q20xMWJ6SlZWMWx4WkRkdVJEUkJMemw1UjFwVWVHZE1VMWxOTTJVd1N6TjZWbVZTYUdGaVdVMUNSMXBaUVZsemRWbDBSSGhuZUd3eVZuVlBVRU5EUmpNS1FVZzBhRUlyU3pORmVVVnZXVmxJV0RKM09EZFdWMGg0YmxsaWIyRjFSakkyUjA1Tk1EZEhWWFF5WWxKeldqVXZRbWRMVWtsak9IQTNZVkJyZG05SVF3cDBTV0Z1UVV0MVNEbG1VVEphZVRoNmEyOUZMMGhxVlc5T1pVTllkMWxMVDNFM2FXTXlkM2RQV0ZnclRESllMMjg0UjJaUWNrUjZlV3RsVURJMVZ6WXlDa1ptYzJKemQyNXdOVmhOVW1RNWNESmFaRGN6WTFNdlNIcHBaak5OY25Sak4wUkhaVk12WmpVMVFYWk5Oa3B3WnpKcWNuZGpVVmx3UkdRMU9HTkxaR2tLTWtjMGNYbFlOMFV5UzFScU9FNW9ia2haVm5VNWRYZDNWRWRpUlZnelRFbFZlaXRSSzFnMmFVNVBhemMxU1RWWWEwSmtURVJ3YjB4M1pHNDNWMlpvYVFwWmRtTk5lRkp6Tkc5TFNrRjFNRVJwWTJGd1RFRkJUVFZGYm1WaFUxQm9jbFJ6WjJGNWREUjZabXhMUnl0TFkxbEtOalpHYzNKU1RIZFNZMWhYYWt0cUNsZDBNRVExTUhnd1NWY3lkVmRSWjNrdlQzQkZWa0ZRVURsaVdFTkRjVzVPV0VSdVlYUXZhbWN2Vm14TlJGaEViVmd3V2tjNFFWcEJjSHByWmtsbVUzZ0tVbTVvY3padFFYZG5TaXR6UmxGcVFuRk5iR0owZGpkUFRtZ3hTa0pLVGtReU1UQjVibEU1THpSTmFHVkRNbXBDYlUxUlNHcGFSemRCT1dsU2JHSllUZ294ZFUxVFlsTXZTekJTV0hoM1pXUTRaV3d6ZWtGdFJWQlhlblpGYUc5MFZsQTVVR3RTZVVKWFJITk9TSEJCZGpONU5tRlNaVTV6U0hsWWFWcFJTaXQ0Q21sTFlYWkxlbmxCZVZRMVExZHNTRGxUYW5SRVQzSkljR3B1ZEZsc2JuZHhhbW8zUjJKSmIyMUNVRGxVVW5odlFXZFFTRU5zWTBOak4xZE1lRUo2VVdnS1NFZ3hRMVJHVTFFelFYSkJZVlZNWnpnM2JuZHJTVzVYVUhCNU1reDVXVEZSWTNaS0NpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovL2Ruc2Frczc1ODk5OS03MWFlNTg2My5oY3AuZWFzdHVzLmF6bWs4cy5pbzo0NDMKICBuYW1lOiBha3M3NTg5OTkKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGFrczc1ODk5OQogICAgdXNlcjogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgbmFtZTogYWtzNzU4OTk5CmN1cnJlbnQtY29udGV4dDogYWtzNzU4OTk5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlclVzZXJfYWtzNzU4OTk5Z3JvdXBfYWtzNzU4OTk5CiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VVdlJFTkRRWFZUWjBGM1NVSkJaMGxSWVVGRVJXUkhjbHBMZDNWMloxUnRVME5yVlVsc1JFRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdWR2R6QjRUMVJGZDAxcVRYZE9SRTB6VFdwU1lVWjNNSGxOVkVWM1RXcEpkMDVFVVROTmFsSmhUVVJCZUFwR2VrRldRbWRPVmtKQmIxUkViazQxWXpOU2JHSlVjSFJaV0U0d1dsaEtlazFTVlhkRmQxbEVWbEZSUkVWM2VIUlpXRTR3V2xoS2FtSkhiR3hpYmxGM0NtZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSQlpUa3dlRWQ2Y1RoSGMza3pVM1JNVmpkSWIxb0tXRFV3THl0V1ltSk9OQ3RWTTJKbVNEWXlhM1pDVW5wUGJteDNXa0Z2ZWpacVdsVXpOVXQwWXpVeFdGWk9ZV1FyVGxoUmQxRlJTbXRVY0VKV1dYWktOUXBpWkRKS1JuSk5iREEwV21JeGJUZGtkR0p2ZVdWc0x6Tk5PRlJCTVZwclNIVjBjQzh5S3pseFRVTXJjMUJHZGxCNlR6bG9NbTV3UW05emJXTjBRVm92Q2pkbkwwSlhkRk41YldSWFdrWm9jMHR3Y205SE9UUm1jak5WYXpjNWJqazFiRWszUzIxNmMzbGlhSFZQVUdJcllWTnZjR3BKTkhSQlRsSkhXVGQ2VWxBS2JHZHRZV05DYzNoSFpuTk1lWG8yTUZONk9XdENiV2hKYkhKSVV6SlVRemx6ZW5sVk1EYzNXV1o0VG5GMFp6QktaMnQwVlVGS1Z6Sk1abWxUV0d4MWNncFNiak5UYWpoRVJEZHZVRk52ZUZSSWNYSTFaa2hRV0RkRFRsUndNV2d5WW5ad01FRXZTSGhtZUVka1drRjZaVGN3TkV4YWVEQlFWbUZ6UWxKbk1GUm9Dazk1VlZvMk9YRXZVM0J0Ym5CaVYzaHFZWEZuTUVvNU5EVm9VVTlNZGpKMU1tbFBSbkYyVFZZMGVVdDBMemhXTDNsM2REbDZaVk4zTkVVNU5IQktSREVLUTFCdk9XeHZkV3BDTHpZeGVVcDBPVmxKWnpWclUxaGhaVTVIU0VaYU1HbFJOMVZKYTBaU09FVkRUR1JtV0Vsa05sVXpaRmM0WlhSWlUybHBTU3RaV1FwelJVUTBkSEZRUkdWRmR6RllTbkpFU1ZGMVdqRkJNVEUxYm5Oc1ZHaFJSRnBTUldrcllrWTRlblE1TVU1Rk1IcGtkaTlMYTNSMVpHbzRhbGhvVG5oVENtdGFia1JTWWtRclN6TldOV0k1T0VnMmVHWmpWMDV4UTFkRlF6TTNkMlZWWVdoVE5rUkNlRXhyVWxvdk9EVXlTV1JQTlV4ck5UTlNVVEpVVTJaNGEyVUtNRTF5YmxVeFYycGtkMFZoVXk5c1lsSnZRa2RtVEdkeE9VOVFSM1ZRV1dST1RXaElXa2t4VGk5aFEyNXlSMjFDVWxSb05EQlJPR04xYW5aM2NUWlZOQW95VVVGaFpsUktkWHBGVWpGRGExbEpWMFo1VjJ4M1NVUkJVVUZDYjNwVmQwMTZRVTlDWjA1V1NGRTRRa0ZtT0VWQ1FVMURRbUZCZDBWM1dVUldVakJzQ2tKQmQzZERaMWxKUzNkWlFrSlJWVWhCZDBsM1JFRlpSRlpTTUZSQlVVZ3ZRa0ZKZDBGRVFVNUNaMnR4YUd0cFJ6bDNNRUpCVVhOR1FVRlBRMEZuUlVFS2EzbFhTa2xJZURNMVdVZG5jWEY1WjNBM2FGbE1UMlJCTkhGWVZIcFBjMVpSY3l0V01rTnRaelpIWVZnMmNuUkZkV0pxYVdOdlZXSTJXbE5xVG1wNFR3cDJiVWxUUTJZemJUQXpWbmRUTlVzd2FuZEJkRk0xU0hCclJVcDJaMDVFV2tVdk4zWkVjMEpSTUV0U1MxZDVlbk40TjNKaVRGQlJlR1IyVDFwM1kzbzJDamxFT1RGR2RtbE9jbGgyWkZSWmJscGFOMHNyVWpWNGVqWkpNbTFETldGTlpFUmFhM05MYlRsSVNrRm9XbXBpWVRWall5OXhkbmsxUzJ4c1JsZFRhazRLUjFWemNtZzRORnA0ZGl0Q2RESnRhM2t4Y0RoRldXUlFibHB4U0VsQllrOUhTR0pEY0cxcWExZFJhamhQV0dwVmEydGhVR2t3VUZkaldraE9LMnBtU3dwRlUzWkdkR2x4TlVaME1rcDFVVlJMYUhwNFpEa3hLMngwTnk5RlRWTlNTRzUzUmpjeGIxazBTbFU0TjJwb2JuZ3lSaXQzVVc5UGJHZHZSMkowVXpaWUNtdFRRbTVqWm5CemR6ZFRNVWR3TVc1MVQySlZPRmxxWlRWVlZEWndRVnB2ZW5Vek5rZDNaVkJuYzFBMVZWVnBkM2x2ZWs1SWNHcHhNbEJCZVV0SFRXUUtWblo2VEVWeWJtUkNkbEp0V1hSTFNrVjRWa1JMU0VwMGRuVkZjVE5yZUZGTFJIZHpiMUJaT1VoMlJtdFZiVVYzYm5NNGJsUkljVXhqTkdWNlJVOUVid3BRUTBGQldqVnpjMmd6YzJOS1dDOXZSMEZGVGtSMFFVOTJTbkV4Y0doMmVHaHljVk5xWW5CbVlsRjNXWEEzVm05T1dGZE5SRTFvVUhwbFJHUnVSbHBLQ21Jd00yVXpiaXROVDBVMVdqRTVSbWMwV0dGVGEzSTBjMVZ4VGl0SGFVTnBOVGxMWTJseWVWZzFXSGR6UjBaUlFYWlFhMUYxZWxwbk5EQnZPR2hwWkhJS01TOU5lV0pZY2twNFJERXZLMlJZT0RGcFowTjFOVm95YVd0NEwzb3ZXbHAwVVZSdU4wODNVRkZaWW14Q2IyaG9ZVXRUVkdKRVdVTmljVFZpYkhOV2NBcHVWWGsxWW1ocVduRmxTV05FYkROWVpsWmtkVmhaU0U1U1dVSlFSazVIVjJGMVNISmlaWE5EWVhOWlBRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIGNsaWVudC1rZXktZGF0YTogTFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcE5TVWxLUzFGSlFrRkJTME5CWjBWQmQwaDJaRTFTY3paMlFuSk5kREJ5VXpGbGVEWkhWaXRrVUM5c1Z6SjZaVkJzVGpJemVDdDBjRXgzVldONmNEVmpDa2RSUzAwcmJ6SldUaXRUY2xoUFpGWXhWRmR1Wm1wV01FMUZSVU5hUlRaUlZsZE1lV1ZYTTJScFVtRjZTbVJQUjFjNVduVXpZbGMyVFc1d1pqbDZVRVVLZDA1WFdrSTNjbUZtT1haMllXcEJkbkpFZUdKNk9IcDJXV1J3TmxGaFRFcHVURkZIWmlzMFVIZFdjbFZ6Y0c1V2JWSlpZa054WVRaQ2RtVklOamt4U2dwUEwxb3ZaVnBUVDNsd2N6ZE5iVFJpYW1veUwyMXJjVXRaZVU5TVVVUlZVbTFQT0RCVU5WbEtiVzVCWWsxU2JqZERPSE1yZEVWekwxcEJXbTlUU21GNENqQjBhM2QyWWswNGJFNVBLekpJT0ZSaGNsbE9RMWxLVEZaQlExWjBhVE0wYTJ3MVluRXdXamt3Ynk5QmR5czJSREJ4VFZWNE5uRXJXSGg2TVN0M2FsVUtObVJaWkcwM05tUkJVSGc0V0RoU2JsZFJUVE4xT1U5RE1tTmtSREZYY2tGVldVNUZORlJ6YkVkbGRtRjJNSEZhY0RaWE1YTlpNbkZ2VGtObVpVOVpWUXBFYVRjNWNuUnZhbWhoY25wR1pVMXBjbVl2Um1ZNGMweG1Zek5yYzA5Q1VHVkxVMUU1VVdvMlVGcGhURzkzWml0MFkybGlabGREU1U5YVJXd3libXBTQ21oNFYyUkphMDh4UTBwQ1ZXWkNRV2t6V0RGNVNHVnNUak5XZGtoeVYwVnZiMmxRYlVkTVFrRXJUR0ZxZHpOb1RVNVdlV0YzZVVWTWJXUlJUbVJsV2pjS1NsVTBWVUV5VlZKSmRtMTRaazAzWm1SVVVrNU5NMkl2ZVhCTVltNVpMMGt4TkZSalZYQkhXbmN3VjNjdmFYUXhaVmN2WmtJcmMxZ3pSbXBoWjJ4b1FRcDBLemhJYkVkdlZYVm5kMk5UTlVWWFppOVBaR2xJVkhWVE5VOWtNRlZPYXpCdU9GcElkRVJMTlRGT1ZtOHpZMEpIYTNZMVZ6QmhRVkp1ZVRSTGRsUnFDbmh5YWpKSVZGUkpVakpUVGxSbU1tZHdObmh3WjFWVk5HVk9SVkJJVEc4M09FdDFiRTlPYTBGSGJqQjVZbk40UldSUmNFZERSbWhqYkhCalEwRjNSVUVLUVZGTFEwRm5SVUYwZG1aSVJHSjJaR1pDZEZwb09EUXpWbWxUUVN0QlpXTmxZMmg0VjA1aFlYaEtOWGcyVkdOTlpVTmhOaXRIYTNWRlNsRk9TVTF3WmdwRmJ6bHhiVlpvU21wbE9TOTBTV1p3VmpCcmEyeGxZbU5oYkRSNFRWWTFVRWhPV1ZsSGVHWlVLM2MxT1hWdlJGcGhjM2hMTVhKbkswTnFVRUZWVFcwNENtczFaV3RKUjA5SWJsbHBUMjFhZDNJelR5dExSVlZTUm5NMVEzQk5VV2hDY2poSVFYUTNiR3huYVhsNVRHUkVTWFZ2UTI1cmJuZzFPV1ZpWkhrNWREZ0tWa2hzTUhKMk5XUmpWSFZtUnpOS1NqQXJNV2R0TDNOWFRFUk5UbTVoTVRSdFdHRkNWVzgxYjNob1FrRklZUzg1Y0ZBME1rOVFTVTlRVDJjMU0yTnJOQXBEUW5sNmNVTlpOMlJqT1hneWVEQm5jamgzVTJjclpERkNkVlp6TjBGWFNUWjRUemcwUlV0cmVXbEJPVk0wVFhocVZWbENVMDE0WmxnMWQzQTNkbU5zQ2xaV0szTmtibWhETmxOclZ6TktUVEZMWjBONGNWaG1aRTFzTml0d1JtTnJLMk4zZFRKSFNXUTJkRzFuY1RCMFZubFJVV0ZIYTFJNWMweDBhbTVIZDNBS1JFODFOWGhNTm0xWVdHZFNNbFpqZWpSMlMwdG1XRXdyVjBkRGIwaEVhMnhCZFhsVlJtRlBNMnBSTWpOU09HbENkbTVMYkZNMk5XYzNjalo0Tm1od2VRbzRielJWVjNSamVHOVdjRmxwYTBOT1FqWjFWblY2WVU5ek9YQTRXRWQxVkhJeGRYTTNlRGgzV2xWdksyWklhVTl5Vkhwck9XVlJkamhHVGpkWU5GRkRDbTlMV0ZSVWVFbGtZMEl3VlRoMVVsWmtNbUZWYjBWMWR6ZHhPV1V4Y1hOSFkyODJWeTlYWlRkUmIyY3pSV2sxTW0xbVl6ZEhUVXhwZWtkT1dVcE1ibWdLTmtwTlJsQnNRVGgxWkRaNUswSlNVMUJ0VlZaNlV6QkZablozWm5oNVkybFdiMU5MZFhCNVRWTlhZMGswY0VZNGREQTRXblJQVWtSbVIwTnFjRmxXVFFweFVIRjJRMnQzVW0xeU0xRTBVSHBOTVc5S0wyNW5WSEpIYW1aU1NrcElXRWRsVmtOUmNIQjBUVUZMVkdGQlVWcHdNbXREWjJkRlFrRlFTbkJxZERGa0NsSXlkMHROVGtJMWFETm1SRGRKVG1oUFptNXVXU3M1TTNaNVJVVlRSV1oyVm1kYVV6RjRWbTltWjFkTGVHcENiRXQxTm5WcU9IWm1OR0ZEZVhkdU1YUUtlVWswZVdsblZqUm1Nak5pY1hSaGRYQlRZamhFWVhscGNHdEJjMXAwYUhrMFZHMXlOeTg1VkRsbWJTOVhZVEZrTDJaek5sWTBZWEZWTTBSWlZsaEtkQXBWTUdjNWNHTkRNemQxUldKb2IyaE9WRVZqVUhRd1dtZG1XbWgyYldSTllsRTVWakJSUWtoRWVXWTBTR2hzTlRsQlpucExObUZQYlhneWFHZDVWRGxFQ2xGa1dqRm1NMWh6ZGtZd1prTXhhWEJJTUhKWmRtbEhkVnBaV2tKWWFEazVXWEZMVlV0TldqRnpRazkyYkcxSlQxSTVjMGxLYUhSSVpFOTZUbFJXYTNVS1dqVnVUa1ZsZEdwNFZqZFpkRVpUWVZsblRtcFlURlZhWkdwcFMzQkJPWEIwY2pneVRHVk5SSElyUW5Od1lYQjNRa055VW05aU5HZzJWRkoyWTJKb01Rb3lPRVJDT1daVk9URlFiazkyZDFWRFoyZEZRa0ZOZEVZemFpOXlUblJxY1hkMk5VMU1kRmxCU1dGdlRWVXZiakpLVkd4bk1rdEpNamQ0VXpod2VHOWtDbGR2WjNabmNtOUtZWGN4WldoR2FubFdTMU5TUm1OVWIwNUtTWGgzZVdKc1JWQnVNMWxoZVhCTk1IaEZUREkyY25SMU1qQkhPSFpMVXpSSldVdHFjM1FLZFdOVE1WcDJWRk16TVcxbVptMW1SVzUyYkd4d1FtOWFaVGxyWlVwUlZHWnlUM05WUWs5a09EQXhSelZxVkVWT1RIaFlhVkpFYVVkbmJ6SndXamhzUndwck1qUlRRbmRFVW5WTmNHODRXR1J3ZHl0SFJpOTNiREpCU1RoUE0zaFVlRE5UWmxOSEt6TmtWRWRsTTBsRGMzZFBlbk5JV0dGT1JUY3piVTVOYmpJMkNsZHpaRTlZZDNaTlVqZE1aRlp2VDJVMGVWbEhRekZ2ZVhScmVXUlZUR1pIYkhKUlJUaHJZME40UkVwMFRpOXNWVVZFZGt0UUx6UjZVRFZ1TWxkT1MwZ0thblpEWkZseFdIUkRlVXRsVldveWN5OVlhaXQxWW5wMlZYTkZXVmRGZEM5VVEzZHJTelp0U1RKbGMwTm5aMFZCVjBJeFEycDJhSFpGTjJsSmEyUTNOZ292VHlzNGMzVjZUMlJEV2taNmVTOUtlVFpwVVRGWlZVd3dabE5sZEdWMGNtc3pkMnRIYTJSTU1tTkxaVUpyT1RBMWEweFZTekVyVTJaUk1td3laVTAwQ2k5eFpsRmhORlJGUWpJeWNsVnpjekJtZWsxcmJIaDZOaTlWYldkVVZVVndjMmRTTmtKdGFWb3ZORE4yWW5OWVR6SnlMMjlJTVZoYU5XWktlVzgyUXpRS1RtZzRXbEZqV2toTFlsWjFkWGxuY25aNFRXZzJVR2xMUzJKaE9UWjZZM1F6ZVdKQ1JYVjFRbTh5TDIxcFZsRkJUemxMYVd4R2NGRlFha2x5YVV0UWNRcDJSR0ZwYlhwSGRXSkVhRzkwUkd3clRXUlVhemMzUmxZdmVEWXplVFYyVUhsMloxTlJPRnBLU0VSaVZVVjVjR2RQUVhSUlUwWkNlak5DV1Uxdk0wWTJDblJ6Vlhsc01sbGxjRzVwYUhCRWNVUklTRFZaYzBSdFR6aGxXWGgxT0d0R1ZIbENkUzgwYzBWSFRWSnRaRWxTUkVSdmNFd3paVGhLVjBGSGJ6Z3JTSElLTTI1dWJVOVJTME5CVVVKcGNsRnZWWE5XVVhkMlRsaHVjVWxtWWpkeWFHOHlaemg0SzIxR1lteDZNMU5yVTFKRFVuTnZMMnBTZUZSdEszbDZOM0p3THdwQ1VFUjFWazFVZFVac1oyY3ZReTgxUVVKemFVZElWRVJSTW0xM04xaHZkbVppU1djMFZUWjBNbGszWTNkT2Eya3dRMUpCUldoU2NDOTZNVFZtTlhoWkNqTXliak5oWVZaaGIwSkxibU5PVDBWT1NGQTBRamRVYW1OU1dtOVpWbTlqUWtJd1kxRk1RVzk1VjNkbmJraDBiakZYVEVObVNGazFTM0J6Ym5STFkyd0tObmRsT0RGcFZESndOWFZGZEdwdVZFOUlOMjF3Wm5GaWVVRXdlWHBSYVRSSFJtVlFXRFY1UWt4VVVYaGxPV1JqYUVWVFRXTkNhRGxSTDJkNmRTOXFZUXBTVlZGdlNrMTBWSFV2T1hGNU9EbG1TbU5pTTFRemJqZzNZVWhJUVhaeVNFWXJibWxMVVV0M1dUVXZjRUZIZGxKcE5YSlhjVWRQYkZCdFIxTTVjREF2Q2sxMVpuUmtUSEZtVERsb2RXUlRZMUpCV1ZweVRDdExSVlY0U3pJckt6TTVRVzlKUWtGUlJGWmtiMGM0WjNKNVVWUnVkblo1YnpBd2QyUnRjRTlPZFdFS05uVkxLelpuU0U1NWVGY3lTRTg0WlhCaFQyTnRLMlJCTkc1dmFEaG1lV1JuUTJaR1NtUnVka3B5ZDBaR01YSm9NVWxpWWswM2NYSkJUVzF1WWxWSlpncEtXalZ4VFVRNE1EQkdiMm8zUlZodFJsUnpiM2RETDFvd2EyTnZkbGRVUW5OM2NXaGhUakp0ZDFZeWF6SlBUMDVGT1VOQmJsUkdkbGhzZVZwck5WVmhDa0UzVkVGemJDdFNia2syTjFoNlUyRjBNMkl3VWs1TFQxRmtWMlpJWW1oalNUUjZiamh3YTB4VFVtMHJNVGR0VVhOQ1puUklURzVyVUZGcVJuVlBVWGNLZEZaSVRWRXpWRFU0T1M5TlFXeDVVbEpVVkZCVFVFbzFVVU16TVc4NWJIaHJXa2N5TVhOQlEzaENlbWx0VUhCYVVqaE1XRzFLWVVFeWMzQmtZVU5VV0FveFJtWjVNREJTUWpSTmVsWldlazV4WkhrM1dYWk1kMmMxZUcxSmRtWkJkV2d5Wm13dlpYTXJTbGRoVlRWSFNIZEphR2hCVmpCVldtZGFXVWtLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSwogICAgdG9rZW46IHNCVFoxeWdDcjYxN0pJMTNodlNoVmFFcndNZmxFY21XSWFxdE9xMFBvOWhwYzI0SXZDQ3dGWmpwbW9hcUpBZU1tUWxZTVRaNjZ0ZG9lMllrM1ZzeHRoYTVwUDdmbjNKRWFLSkdwVmdIWjhEdTNuMXQyN0RvZ2t0dUI2VFM1eUExCg==\"\n  }\n }"
+      "x-ms-request-id" : "bfef422d-07ca-4805-b79a-da4dfa5ae39a",
+      "Body" : "{\n  \"kubeconfigs\": [\n   {\n    \"name\": \"clusterUser\",\n    \"value\": \"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VWNVZFTkRRWEpIWjBGM1NVSkJaMGxSVEZRcmFEbFBVRU12YVRGRWFtSnhVM1ZwUlhKTWVrRk9RbWRyY1docmFVYzVkekJDUVZGelJrRkVRVTRLVFZGemQwTlJXVVJXVVZGRVJYZEthbGxVUVdkR2R6QjVUVVJCZWsxcVdYZE5ha1Y2VFhwS1lVZEJPSGxOUkZWM1RVUk5lVTVxUVhsTmFrMTZUV3h2ZHdwRVZFVk1UVUZyUjBFeFZVVkJlRTFEV1RKRmQyZG5TV2xOUVRCSFExTnhSMU5KWWpORVVVVkNRVkZWUVVFMFNVTkVkMEYzWjJkSlMwRnZTVU5CVVVSSENsVTRhaXRKWTJWcE5WSlllVTFZUTI5VWJXTkdjV0V4YzAxMGVsVllMMDFCVTJsblFrZFNVMVprWTBVekx6TnJhaXRzU2xaQlNXVm5ZVmhZVW1GaU5FMEtOR1F6WVU0eWFHdG9aVXhLY1dSNU1UVnFLemhYVXk4cmJ6QnVUM3BOVDAxeFZtTlVRbVpVUkZZeVIxbEJXVFJSYlRaalJtMHJjWFk0T1VwaFZXUXJOUXBLYm5Rclp6ZGtObFkzY1ZkdlJYbFVlR2REWTNoaU5EQlFVR3BLUjFONFZESnFVa05KWVZCblVUUkRUalo1VkUxcGNWVTFkVk13UlVJM09XZG1kU3N5Q2pkU00wMVhORVUyWWxoWE0wOXpURk53Tmk5bVYyaDFiM0Z5TTJwRlRqVllTRTVOTTFOdFFucEZhV2xvU1ROeVMwTkVXVkF2YlVoVVFsUjVjblJ6VFhNS1NuZERiRko1TUZGNE9WQkRVMGxUZGs4MGJYSlJkVmRVTkVsbFdrTXZZMUE1WkZaRVFXWndSV3RzWlVKR1lrNHlaVW81WldWV2EyZG5WRFZqVGxCaVdncEdjemRFZFRoTVNFUTNORzVCZUZGMGRqQnFVell5ZERad09VOUJVbEZNVlhaME5sRXdNamwxV2s4d2RXZFZNbXBRZWpWclJVaERkVmxsTlVJMFlYSlJDbGRFWTNBNVZERlFXRzlSYTBwTVdFRXdibkZSZDNaeFFsaERTMEV2Y21wMFFVZFVhRGRzTlcxV2IzVk5TRXhxWWxSU09UTjBUMFptTmpKa0syeEdVbFlLY0VGdVJGQnJkSEZOUjFOMlRHNTNWVkpKWTNwME1pdEtXbEpISzB4VU0zQnlNbVJOV0docFVtZHlTbW8xWlhaT2EyMDNObm95TWpORmJVaGxRMnRaU2dwbGRIRTFTRkZwY1d0WmRHcHlSbGQ1UTFoTmRWVTNhMlpxYmxCUlp6QktjMlIzWjA1WFdXRXlMMlk0TTBncmRXNWhaVUYzSzFkUk1XdGljbkIzVEc4MENrUkdWbVZtV1RORGFuUTBjVEFyWlRBeVkyWTRaSGsyTXpZNE1qRnhkVzh5V0RocVZtVm9ablpvV1hvNGFVRlhjV05yWm1GdU1uUXdNMEl4WVcxaUwwRUtjME5wSzB4SlJWYzBlUzloUlZoUGNUYzJhMDFhU1RGcU4zaGpaVmhDUVM5bFRVeEZUblZTUjJWUlNVUkJVVUZDYjNsTmQwbFVRVTlDWjA1V1NGRTRRZ3BCWmpoRlFrRk5RMEZ4VVhkRWQxbEVWbEl3VkVGUlNDOUNRVlYzUVhkRlFpOTZRVTVDWjJ0eGFHdHBSemwzTUVKQlVYTkdRVUZQUTBGblJVRjNVMEkwQ2pVcmRDdFJUV0Z3ZDBoVmRITXZVRFpSUXpOa1UyVk1SM2c1ZDBsSlJUVkdZVUZ3Y1Zvd1EwVlpja1ZpVjBsaVkwUnFTMFpqVUVaSWExaFdLMGRVTWxBS1MzVkpibVpHUld0dWJYZDZVRzFOT0ZocE1FY3habnBEYzFjM2NYUTNWbGhJYUZkaGRYTnhlRTl2UkRob1dXaGtRM1JvWkRVd2RsbzFWM28xZVV0MGVBcGxOWGQwT0hoWGNuQnVabFV5TlZSTk1tUktXVlo0YUdONVFVSXlZVkF3UzJ4b1dHeEdUWGhhT1RoMkszaENSa3cxVjFCNmJETjNUVXh6UlZsSVprOVNDbVJFUzBob2JYaEZOVTB4Y3pkbVdFbFpNQzlwU1RCUU1YaERNM2hxV0ZKMk0yaERNa1Y1ZFRWa2R6aHRTV051TURWRGRrWjNhbWQwTVc1QlVWbDNkelFLVlRKbmNUTlNUelIzZG1oWGEyMURXbGRqYmtrMlQwZGpXazFMYkZabVZIVXJOR2M1UldGVlpGbGxVRzB5VG01NU1UVTVRbmRNY0VGVGFHMWtaWFY2WVFwbmJEQXJUMmhJUkc1TWNteFlTMG81Vm5oME5uYzFlazFKTTB4U1VscHlOMFZNTkVkaWJDOWtXRlJYUkVWdVpubzRZM0ZMYWpGWksweHBUSFo1Y1drMENrSk9OM1U0UjJJM2NsSmtXWFZyWlhCd1ZrZDZWVzQ0YzI5TlNqWmFWRmRMTVRKcFFXczJURWR3Y0VwSVRqaHRPSGR4VGxkc1ZtSXJUSGczUWs4MU1GZ0thWE5TTVdaT1ZUVjJaa2RsTjFRdldXOUlRbk5JWlZOc1kyd3pMMFkxVkRCa01FNW9SMFIzUlU4d1NIcFJOMEZSSzNKMlVVTjVURXBJYkVaeVFscFNiQXBLT1hCRVQyUmxSbU5oZERkdmJDOWtNRGRZU1RaalZrYzRUVVZPSzNkWVRWRm5iR2xUVVRSVmNrMXJXa3RCY2s5dlQxQlBZbTVQWnpOalFsVk1ja0ZhQ2xOV2FuUkhkVlJVVEhJMGVXVk5lSFJvZVhWamREUnNlRFl2V213d1FqVlpLMjlzUlVaUlJHZzFXazlrVW14VGJrY3pkbUprVEZGUE0weENlSEozV0djS2RuTnZXa1pLTkRndllUWTBjV1pOZVZKRE0wbE9OVEUxU2tsblNYbDFkVFJVUjJReldIQTRQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZG5zYWtzNzY5MzQ5LWM0MDAwNzFjLmhjcC5lYXN0dXMuYXptazhzLmlvOjQ0MwogIG5hbWU6IGFrczc2OTM0OQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogYWtzNzY5MzQ5CiAgICB1c2VyOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICBuYW1lOiBha3M3NjkzNDkKY3VycmVudC1jb250ZXh0OiBha3M3NjkzNDkKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBjbHVzdGVyVXNlcl9ha3M3NjkzNDlncm91cF9ha3M3NjkzNDkKICB1c2VyOgogICAgY2xpZW50LWNlcnRpZmljYXRlLWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVVV2UkVORFFYVlRaMEYzU1VKQlowbFJWbXd5YjBSVllYTXJTbXRTT1VGdWVIRjVORXhvYWtGT1FtZHJjV2hyYVVjNWR6QkNRVkZ6UmtGRVFVNEtUVkZ6ZDBOUldVUldVVkZFUlhkS2FsbFVRV1ZHZHpCNVRVUkJlazFxV1hkTmFrVjZUWHBLWVVaM01IbE5ha0Y2VFdwWmQwMXFTWHBOZWtwaFRVUkJlQXBHZWtGV1FtZE9Wa0pCYjFSRWJrNDFZek5TYkdKVWNIUlpXRTR3V2xoS2VrMVNWWGRGZDFsRVZsRlJSRVYzZUhSWldFNHdXbGhLYW1KSGJHeGlibEYzQ21kblNXbE5RVEJIUTFOeFIxTkpZak5FVVVWQ1FWRlZRVUUwU1VORWQwRjNaMmRKUzBGdlNVTkJVVVJQVkZnd2NsTXJUVkJpYjJSdmVraFBkV1F2V2xZS1UwdHVSbXNyT0dkbGVGZHVUM0J3V25OSVdtYzNXWFpyWVhKS1ptMVFWRE5MYlVOd00wSnBaRFlyWTJod09IbHJia016YTBGYWRWb3daakJCZWpOV2VBcHhjMWR1WjA4dlZGZElSbUpzT0ZaeWMxZFVhRkJSUzB0MVVYWkZlbU5TZHpkRVpYSmpkMFJaY0dkcWJFNHJSbWx1VFdWdU9HTmlhWGQyWW5OdFpXaFZDbEpxVjJodGQxRmFSMFozVUc4NVIyNXpUalZ2TURGQ2N6ZzFkazlyZGtOR2QxTjBVSEpaY0VJemFrZENSa1p1ZEV4TFJrdHpXV0UwTUhoNFNHcG9VMjBLYUU1emVUSkVlRkZVY21wSVZXdEJRM1JPU0dNeU5YbE5hV3RzVmtwa1kzZG1UVGhwTDFodlRHUkJhMWw1U205YVMwMXJhVmxuU0hkNVVuWldhVk5pVEFvNFVHTTFNSGRUWVU1SmVUWnNTbTF6WlN0eldYVTNOVmRQZERORVIwSkdjV3RyV25RelQyUTRkMlptUzB4V2VIVkZXRkZZYVZVNGJHa3ljMHRHZEdGdkNrWkZhR0ppVWsxcE5tTTBOemg1ZW1SUGVGTTNka3h4ZFhoSmNrYzRlV2sxUlROd2VuTnBNV3hVZW5acE9FOW1kRXBFUkRWV01VNW1VMlprU1VabVJWUUtia0lyZEZwdU56aHdjM1pRTVRNd05sZEpjelpMYzNCVVVITnVVM000UlRWNFlXdENVelJJVDAxNVVrUmlWVTkxVmxsRk1XWmFkakJqTlZsbVlWQnVjZ3BETlhGTE5VZ3hkMVZKVmtsa00zWmhUMnN5YkhneVVWZDRTM2g1V0dwMFVXUm9TMmxMT0RKMllYZ3lSVmhNTWxkRU9IZHZOM1Z4TUVGVWNsbG5MMFk0Q2pkM2NtZGxVR3RqUVN0VFVIZEJlRFE0TldacE4xWTVSbFl6YlU0MmNTODJlbXRHUnpGSk1XZHFWakF2Yms1a1JXVmFiREpPY2tGbU4zWlpOR3g0Y1hjS1JYcDJja2wxTkdoSWVrSnJjbWxqU2tNMlkwUmhhakZMVFRkU1EweFhPVEZVVG05Rk5qSmpSVUl5WTBwc1RERnRMMkYxUTNSbWIxQTBOM2cyUzJRMFdBcFFTR0YzWkVwVWRUVktWSFp6YmtwMGNFNU5TemxSU1VSQlVVRkNiM3BWZDAxNlFVOUNaMDVXU0ZFNFFrRm1PRVZDUVUxRFFtRkJkMFYzV1VSV1VqQnNDa0pCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMGwzUkVGWlJGWlNNRlJCVVVndlFrRkpkMEZFUVU1Q1oydHhhR3RwUnpsM01FSkJVWE5HUVVGUFEwRm5SVUVLZGtaRlRFNTVUQ3RMZEhCQllrRndMeTl6WW1aRVdHZ3hNblpOVGxwVE1uQnRVWE5ZU2xkVE9YRlJka0l6V2sxQlRFWlNhMnRxTDNoVlluYzBWMGt4VmdvNU9EbDNTRkJwU1VoemJWZDZLMUZ4Ykd4S1VscHVUM1UwZW1aYWJtdFBPV05STDJNeGVWSkhPR2QxWjBSTVpYVjFTRWxPZUhoaGNtcFJablpxVVZSVkNubDJSRUpvV0dSS2N6TkhOazlZUkhZNU5IRkJjekJMWWxkMVIwMURSa1pPTVUxNlZqZFllRVpwVWxWdk9XSmxaMGRxUzJJMFoycFJhSFJKVFZoSFIzRUtaR2MyWVZFNEwzRkhjRTFCWjB4elJtNUdOVVp3ZDBKMmVXUnRXR05SWldGblJITnJTVE0zUzBsWmNERnhRakZJYlV0MGN6UXhRbE5PTDB0SmJHdEhVZ3B2Tm10MksyaEVjM2xLYjA1NGN6SlJkR3BsV0VKclRtcGxRbVZ2Vm1odVduVmtVVmRHVEdzcmIyUmhhRUozVmtrdlIyTTRPR3BPV0VWbE1rNWtUVzFwQ213NWVIVnBWMFpHWWtSMWNtSnhRM0JxT0VFek9FaG5kbUpDU1RkQ1VrWnpaVTU0UzFKclFta3hXVXBPVG10aGFITnNjV1ZhY1dZM1NXOXNlbmxQT0dRS1drUTJTRTVpTTFSM1RrVkliRkpzVFRJMGJUZDNWbEpHV0VaQmR6VmlaemRhVjNKWVduSjFTazVHWnpWdk5IQXlTbFJOWjB0cGNIbHhjMVV6VFdzNFVBcDJZVlZ3YUdKVGJYRk9hRE5ZUkZWMGFIRkRlVVYxZVVOTmMwOWxiVXBNV1VWVFFVMVFUM3BEYm1WRE0zSkNhRGN2YUcweVQyZDFRMnRCWld3NGEwOXpDbE5MUjNGS1lqazFiMmcyUTBsQ1NVRkxOMDQzY3k5MmNGbElVVFZ6YzJSNGIyZzJaVlJDSzNCclFXTkpMMFpRZFVSTE1sRkhLMmhuV1c5dGNWbGhjMWNLWlZobVYyMDJUa3RXUkV4MmRESnNTRUZ0Y2psM1lqUkNTbFZ6ZDNSUWJIbE9iM05CZUc1dVowUlZTbWgzVVd4RGFqVTJZVFIwVjFCYVltWkZhMmt2VmdwUFJ6bHZaa0poYUVWVVRVbHJORFprWm1aNkwxSnpZa2xuVldreU0wZHdlblJXVHl0MmN6bFFZbGhOUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgY2xpZW50LWtleS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJTVTBFZ1VGSkpWa0ZVUlNCTFJWa3RMUzB0TFFwTlNVbEtTMUZKUWtGQlMwTkJaMFZCZW1zeE9Vc3dkbXBFTWpaSVlVMTRlbkp1WmpKV1ZXbHdlRnBRZGtsSWMxWndlbkZoVjJKQ01sbFBNa3cxUjNGNUNsZzFhakE1ZVhCbmNXUjNXVzVsZG01SllXWk5jRXAzZERWQlIySnRaRWc1UVUwNU1XTmhja1p3TkVSMk1ERm9lRmMxWmtaaE4wWnJORlF3UTJseWEwd0tlRTB6UldOUGR6TnhNMDFCTWt0WlNUVlVabWhaY0hwSWNDOUlSelJ6VERJM1NtNXZWa1ZaTVc5YWMwVkhVbWhqUkRaUVVuQTNSR1ZoVGs1UllsQlBZZ3A2Y0V4M2FHTkZjbFEyTWt0UlpEUjRaMUpTV2pkVGVXaFRja2RIZFU1TlkxSTBORlZ3YjFSaVRYUm5PRlZGTmpSNE1VcEJRWEpVVWpOT2RXTnFTWEJLQ2xaVFdGaE5TSHBRU1hZeE5rTXpVVXBIVFdsaFIxTnFTa2x0U1VJNFRXdGlNVmxyYlhrdlJETlBaRTFGYldwVFRYVndVMXB5U0haeVIweDFLMVpxY21RS2QzaG5VbUZ3U2tkaVpIcHVaazFJTTNscE1XTmlhRVl3UmpSc1VFcFpkSEpEYUdKWGNVSlNTVmN5TUZSSmRXNVBUeTlOY3pOVWMxVjFOM2syY25OVFN3cDRkazF2ZFZKT05tTTNTWFJhVlRnM05IWkViamRUVVhjclZtUlVXREJ1TTFOQ1dIaEZOWGRtY2xkYUt5OUxZa3g2T1dRNVQyeHBURTlwY2t0VmVqZEtDakJ5VUVKUFkxZHdRVlYxUW5wcVRXdFJNakZFY214WFFrNVlNbUk1U0U5WFNESnFOVFozZFdGcGRWSTVZMFpEUmxOSVpEY3lhbkJPY0dOa2EwWnpVM01LWTJ3ME4xVklXVk52YVhaT2NqSnpaR2hHZVRsc1p5OU5TMDgzY1hSQlJUWXlTVkI0Wms4NFN6UklhalZJUVZCcmFqaEJUV1ZRVDFnMGRURm1VbFprTlFwcVpYRjJLM00xUWxKMFUwNVpTVEZrVURWNldGSkliVnBrYW1GM1NDczNNazlLWTJGelFrMDNObmxNZFVsU09IZGFTelJ1UTFGMWJrRXliemxUYWs4d0NsRnBNWFprVlhwaFFrOTBia0pCWkc1RFdsTTVXbll5Y21keVdEWkVLMDg0WldsdVpVWjZlREp6U0ZOVk4zVlRWVGMzU25saVlWUlVRM1pWUTBGM1JVRUtRVkZMUTBGblFXNUxUalZTYTFvMFVVWTVUSE5QWVV4aWQzcHRia0p3ZG5wUVVteDFLMDgwY2xOQ2VEQlhaVXRsYXpOcGVXRjFOV2MxZHk5WmRYUnhUd3BaTlVSdmNWSmhLMlJNVDB4eE0yMXhhR2RQWWs1NGFtNVNibTV6YTFwWWFreGlOVmxTTjJ3NGQxWndaMFIwVVhaVVVERnRhRFp0VFU5bFRFZzNTVGRGQ25CS1prMW9MMlUwVTNSemJHUk5NRkpQTDNWamJqVldkbGtyWlU0eE5saHRabmcxVVVKVFpUQmpSWGRxYjBwaldFaHpWblJoVUVKNVZHTkpTMGxhYVhZS1JIbHVibEowTTNWMWIxa3pWblpzYlhwRWRtVmhXRkU0ZDA5T05tMUZNV3BaVm1oU2FHZ3ZZemxsWm1kdE5rbGhXV3BXWkVkQlRFUm1kVTVTSzA0M05BcHlWbE14VWpsc1UwMTNTRTVPVFdrMVJtaEdORTk2VW14WVFuUmFTM1Y0UTNSaFRubEJabVZWYTNoQ05HaFRNR3BFVFVGalltbEJZVWxFT1hWRk1GZzNDa3BMZEhOTGQxWXlRWGhhUVdKc0sza3JRVlp0UVhkcVYyRlhPV3hOVEhSUE9HbFphMnhyYnpCdVNtVjNSbW92VVVaNFRsVXllVXg2YVVWVlIwUkNSREFLU0cxbk1GQmxSMUZIUlRSYUt6aHhTbFpKTTJ4aWNqWTNWbmhaWm0weU9VSnNjQzloUkVKQ1ZqWm9PRzVaV0ROT0syaFRMMWRWWm1wbVRWaElNeTlTVHdwU1NVdHdMemxqWVZwNmJsbFRZMmhVZEc4NWNXMTNiR3RCYlV0YWVFRjJVSEZFVEhwblFtMTBkVFpGWjJSMGFqRlJjVzVYY1c1SlJVbzBNVmRhYzFaSENtOHdVVkJaZDJaUlYydFNSRE5pTkdOQmIzUXlUM2hDY25KV04zSkNaelZaTm1aQmFqZDNaekFyYWxoS2NtVmFLMW8yZUdGeVpWbElhbmhHY2xKc01XSUtiMVI1Yms4eE5EQnNRMU54WVdjMmVHeE9lbXRYVEVGcGJEaENVVUU0VUVoUlJEUkNTSFJ0YnpGNU9IZzBPRUp6YmxoTVNYVkNjbUpEWlRacE1WQmxlQW8wVFdvck9IRkNTMHhYVFVaNE0wd3ZMemQyU0dOS1IzSkdWRWQyUmtGeGIwYzFSbWxJVW1rMFJYa3pVVXc0UkRKQlVVdERRVkZGUVRsM1dGcEtUMFZMQ21wVVdtaEtXbGh2Tm1jM1FtZzNVVVpSV20wcmMyMVNhMEUyV1dacWMzVjRaVlp6V1dWS1VVSXJTMnBxYTNOUGJHVkhOSFJWUTFGVlFUSllhVUpOVW5RS1YwczJiVTFxV1U5U2VucFFWSEEzV2pKRGVXNU9kVkZ6U1RCSmVqWmpPV1ZEVTFnMGNrNU5LMVZ5VEdvd05HNVNiMVJxY1VwSGFtWk9WbWQ0Y1hkRFV3bzFlSGh0Tnk4eE0yOUlkRE0xZGpKR01GVTBTMlJTZWtzMU0zbExjeXRJUnl0RVZtOHJiVlphU3paek5TOUlUVVk0TWxaNWMwOVJXSEkxZUhGWGVEWXpDbU5XZFRFMVZFUk9ibWxIWVVwbGFUQlpURTgwZWtKMVVVWlJUREU1WkUxcGIxSXpUMmhXYWxwT1JqRkRNVEpTYWsxSFdVWjNVelZZZW1SUVJXbzFTMGdLVG5WbFpUTk1NV1pSVDBRMGNYSlhabFJOYmxNMk16RnZWR3cxTDI4NFEwdzBWVFJxVjNwbFQxaFlPRFo0VUdsUFJIaEZXVUZKYWpGaFNqZzBUbkZyYmdwRWN6WnhjSFJLZEd0NE5sSkZVVXREUVZGRlFURmplazlGU0Vsd2FtOUNRWFVyVEVGeGEwWklVblZhTm1SWVNXaE9aVkJRYzBZeFRVWmhSR1J6VDBkdUNqSXZaRnBpZFM5alpuTlpkR1JWU0VjeWVYZDFaUzlDV2t4QlpWaDVVWE4wV1dGNmFDdEpSazFyWjJVMFZrbFZlbE13YVdkTk5qaGphbFUwVEZjNWNVWUtXbEIwYkZCRUwwMHZjM0F2WkZWUlMwUndhWGw2VFV0MlJrUndTRTVOYXpjNU0yTTBlVkZ3YkRoUFNGbDZiRUZqY0VoQlQxSTNaelZPVG5sTE9WTldTQXB2U0hKYVVEVTVWbFpYZGxCblVtODVUazF2VG5Wbk1rUTRTVGRtUlhkaFRIaFVkMUZCZG5GUE9IZHBUR1pDZGxOWlYxcEdjalkyVG1VMU1VSXpOUzlCQ2xwVGVESm1aR2hqU1Vwd2JqSkdSbTlNV25sQ1FTOW9ORXByVDNwd05HTkRXVzVQUlRKeVNIcEdZemM1Wmt0bVlpdHpjSGhCT1RCQ1duSlVUVTB3YVV3S1JWUTNPV00zVkhabGJ6aGlURlJsT0RWWFoydE1aSFpWVkc5VFlUZENjMk41TmtOWE5qWmlZbkJSUzBOQlVVVkJiV1JaYzJsM2ExUk9lVzg0YVdSdE5BcFBZblZEZW5VMVVISTNSRGw2TnpoNFoyZDNPRGQzVEhaMllrZzNjRmQzV0ZwcVNsaDBOV3BqVUdkdWRtTnJPV3h1TVVGa01TOVpNRmQwZHpWaFJpczVDblZMVDI5UU1FRjVWSEY0VVZoeFJIVXdLelYzZDJoWFFXSktXVmhNYUhCSldEbDRSV2RuVERoaFJHc3pjVUZGWm5OUGMwSXdOSE5DT0dGblFXVXdhMUVLTjFGTE0yY3dWWHA0TUhWbmRUVndOSGx1TUVoTVJYUmFWRVUyUnpKQ2JYZ3hURFZJTWtjMFVuTkxhbTVMYWpaRFpXSXdhR2g1YlhvclNXRjVNbk0zZGdvemNVUjVhazVXUmsxRmRqaDBSRUZsU2s1bE5VMWhVMUpzYlVWdWMyMW1TWEpTUnk5b1RVSm9MMVYzYzBoVmFYUkxaVkJQVERsUFJFaGlRbFpuVVdJeUNtZFZUVm95WTFwUFRrNVphalJ6UVhjMk1ERjViRUp3Wm1keGNsVXpaMUJXVWpKcWNYZHhlRUZZUTFjM1IzVnZkMWQ2TVRsR2NERXhWVFJXYkZKWmMyRUtOMnh3UlRSUlMwTkJVVUo1ZG1GMVNtNHZjekZuZUdNMmRtOU1kak5KUkVsVFJVWkpZbkYyYzBwQmNpdGtPVTk0WkRsblEyRmthVkZqVEhOTGEzRm5aZ3BWV0ZKelJGcFZVRmw2U3k5VFZYQlRSM1pGVnpoSGVUSnJkbGhxVkVkRmRuSm1lamRRTVVVNFFXZHZXVTF6TlRjNU0zRmFTRlJ0YURkR2JEQmpSR3QzQ2s1TVZXRXhhREJtYjBWMU1VbElZV1IzU0d0bGJIcEZZbkZzZUV4aFRUQXdOMk5DVWxkVFZrZERkVEZtUTBSMVRGcDVSV05XTlcxT1VYVkVPVU5EU0dZS05tcEJLemxVYjB3M2NsSllUMXBIY0hSTlRqZHFibEJOYzIxT1ZtUmxjbkFyTldkQlZERTBhemMyU2s5dGNuUk1jME5ZSzFGa2IySmphbFpXWWtwNGF3b3dkbXRSVjNkQmVVZHRRVlJLV0VreE9YWmxaak5TUlcxcVUwTnllbVo2VEc4ek4yWlBObU5RWmxRMFVpdE1XV0o2VFZGaFkyTkNVWHBUUm5kNU5WbExDbXBIY214YVdtZ3lPV1ZGVlhremJYaGxaa1UyTjFsSlUzUnRha2x3TlVGU1FXOUpRa0ZSUXpKdlNqbHpkMFpPVm5RNUsydEphVXQ1TmpNMk5XMWliVUVLYml0aFkyTlhSRTlYUW1KSloxVm9SMVpuYzBWaWNuUnJOa0pyZGs5S2JXRnJaelpZWkRsalZGQm9aR1J3TUVSTllrOVJSa0ZCYldwc1ZUWjJNR1JuUkFwc1NXUkdVbmhwVW1OaE1tNHZPVWN3ZHpSRmFEQkNPWGM0TDBjNGQyRlVSM1pSVFVScGNuRmFRV1JoYjBkV1MzQmtlRXR1WjJaM0sySTFPR3BDYkNzeENuRmxVa2gzWVhOWWEzSkxRVEZzV1cweFRXWTVRMk5IV21sR2VHWnFNbXBtT0c5aFpWWmFOM0ZSVWpSelJtdFdlRVkyYlRjcmEwSjBVMlpLYVd0d1pFOEtRMk5NYUhWbVoyNUVSV3BqUldOS1RGTm1jRGxOWVVGWVltUkZRbU5yUlhFNFluYzFZMnRqY0ZVeGVHVkZVMFJHYVRseGRtWmlVbnB0Vm5SbVkwMW1VZ29yUjNwVWIxVldMMGxqU0doRVdrZGhOMUpJZWt0UU1URnNSV0ZUT1c1eVUzZHROWEV2UjFWTWRXeFdLMnRCUjFRMGRESTFlVnBhVG1OTE5HUUtMUzB0TFMxRlRrUWdVbE5CSUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLCiAgICB0b2tlbjogZmUwYjU0ZjIyYzhhMGM5OTc0MzBkZjdiNDdlY2MyN2MzZGQyOTBkNWNiNGZhNWRlNmI4Nzk4Mzk1NDJhNzdlYTI2NGU3MjBkZDliZjJlZjc1OTVlZWZkMTIxNWM3OWNjYTBlMmRhYjk2OGQ5ZmQyOWRjNDRmMDZjODVkNjcwYmUK\"\n   }\n  ]\n }"
     }
   }, {
     "Method" : "DELETE",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks758999group/providers/Microsoft.ContainerService/managedClusters/aks758999?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aks769349group/providers/Microsoft.ContainerService/managedClusters/aks769349?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:32 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:10 GMT",
       "content-length" : "0",
       "server" : "nginx",
       "expires" : "-1",
@@ -3384,440 +5707,592 @@
       "StatusCode" : "202",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "73e5e8d6-4572-40d9-a19f-4478fb32e450",
+      "x-ms-correlation-request-id" : "eb54a321-1a0a-4d4f-b538-64fc5aa312cc",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050832Z:73e5e8d6-4572-40d9-a19f-4478fb32e450",
-      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023410Z:eb54a321-1a0a-4d4f-b538-64fc5aa312cc",
+      "connection" : "keep-alive",
+      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162",
+      "x-ms-request-id" : "b349b437-c905-4222-a0cf-08dec238880b",
       "Body" : "",
-      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31"
+      "azure-asyncoperation" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:08:33 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:10 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11876",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11791",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e8a335f3-0bdc-4585-869f-e947c2c006f9",
+      "x-ms-correlation-request-id" : "37ad03fb-e9d1-4798-b304-dac7bec0db10",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050833Z:e8a335f3-0bdc-4585-869f-e947c2c006f9",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023410Z:37ad03fb-e9d1-4798-b304-dac7bec0db10",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "51028b9b-eb13-401a-bc85-382b3f39820e",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "c97f700b-6c32-4f80-9bd5-356769a0845a",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:09:03 GMT",
+      "date" : "Thu, 26 Mar 2020 02:34:40 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11875",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11790",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "e83e8ff0-81a1-4507-814a-2aaf1af1a8f3",
+      "x-ms-correlation-request-id" : "ca893351-03e9-441b-a612-46256209d57c",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050903Z:e83e8ff0-81a1-4507-814a-2aaf1af1a8f3",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023441Z:ca893351-03e9-441b-a612-46256209d57c",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "2849ca9c-5b55-4013-b228-e68d38e31e1a",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "56d860a7-2332-4470-b509-deaf5a628d7e",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:09:33 GMT",
+      "date" : "Thu, 26 Mar 2020 02:35:10 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11874",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11789",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6587aa5d-cf39-41f2-9be8-5c46bd7c1138",
+      "x-ms-correlation-request-id" : "36b6bb9c-28ab-4037-a059-ad5c9e242a2a",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T050934Z:6587aa5d-cf39-41f2-9be8-5c46bd7c1138",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023511Z:36b6bb9c-28ab-4037-a059-ad5c9e242a2a",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "a7fd7e13-6209-47d5-b6f1-6d5089c35674",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "5beff248-09ba-474f-b319-e58df0b529e9",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:10:04 GMT",
+      "date" : "Thu, 26 Mar 2020 02:35:42 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11873",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11788",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "aaf1ae7f-7369-40a9-91aa-824f11e5c969",
+      "x-ms-correlation-request-id" : "eabd599f-6dea-43bf-a9da-77c8c02b7b18",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051005Z:aaf1ae7f-7369-40a9-91aa-824f11e5c969",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023542Z:eabd599f-6dea-43bf-a9da-77c8c02b7b18",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "6818f89e-e82c-4305-a291-ab74bc66e504",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "3324670e-9cd2-49eb-88d7-cf09696c9cac",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:10:34 GMT",
+      "date" : "Thu, 26 Mar 2020 02:36:11 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11872",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11787",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "09ba0c64-6db8-406b-ae14-2be9f03eb338",
+      "x-ms-correlation-request-id" : "15d2f777-f6d7-4c51-850e-991ab04ccee3",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051035Z:09ba0c64-6db8-406b-ae14-2be9f03eb338",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023612Z:15d2f777-f6d7-4c51-850e-991ab04ccee3",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "201f7713-61d6-43dc-8935-86074724f382",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "a9cf4520-a9b5-4922-b3e3-585968e94d80",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:11:04 GMT",
+      "date" : "Thu, 26 Mar 2020 02:36:42 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11871",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11786",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "1bac29e3-54a8-461f-91e3-632e751ce6b6",
+      "x-ms-correlation-request-id" : "b09fc077-16f2-4bdf-a5d5-00ddfef818c9",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051105Z:1bac29e3-54a8-461f-91e3-632e751ce6b6",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023642Z:b09fc077-16f2-4bdf-a5d5-00ddfef818c9",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "90219b66-da92-42bc-9395-65e57b71ca15",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "352e2dcc-7524-428b-86dc-320fd57c69fc",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:11:36 GMT",
+      "date" : "Thu, 26 Mar 2020 02:37:13 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11870",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11785",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "4099204b-f0ec-4b2b-8f86-d50f5c71d581",
+      "x-ms-correlation-request-id" : "2cf8b6db-0d27-4f1b-b763-2624398f6fc9",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051137Z:4099204b-f0ec-4b2b-8f86-d50f5c71d581",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023713Z:2cf8b6db-0d27-4f1b-b763-2624398f6fc9",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "7bb13224-5bd2-4419-919f-d94053b55340",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "da4bcc57-1b81-4f51-aacc-2f1097d3f947",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:12:06 GMT",
+      "date" : "Thu, 26 Mar 2020 02:37:43 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11869",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11784",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "da5bb725-9ca8-4d96-a049-e0b6156e1dcd",
+      "x-ms-correlation-request-id" : "b3b6b769-0674-4e78-99c3-8224bf38eed9",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051207Z:da5bb725-9ca8-4d96-a049-e0b6156e1dcd",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023743Z:b3b6b769-0674-4e78-99c3-8224bf38eed9",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "efb1fda8-21d2-41c4-ae3f-add42918e755",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "9742bd9b-311c-4615-87ac-6d3c6b16240e",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:12:37 GMT",
+      "date" : "Thu, 26 Mar 2020 02:38:13 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11868",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11783",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "7b6b4e29-1f17-45e7-8495-6c09ca5c02da",
+      "x-ms-correlation-request-id" : "ff4477e4-4d6a-4358-99e1-2275a3722c32",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051237Z:7b6b4e29-1f17-45e7-8495-6c09ca5c02da",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023814Z:ff4477e4-4d6a-4358-99e1-2275a3722c32",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "376253a9-6c01-4c82-bf10-8f6311a33585",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "13c7539f-4a1a-413e-8695-b2a13ede5a79",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:13:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:38:43 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11867",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11782",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "c6ade65e-798f-4b51-8da9-787720f7e723",
+      "x-ms-correlation-request-id" : "5e9fe463-672e-44bd-8f24-1662375ca664",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051308Z:c6ade65e-798f-4b51-8da9-787720f7e723",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023844Z:5e9fe463-672e-44bd-8f24-1662375ca664",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "9329624c-1cd5-42ed-af13-195e82050928",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "dfef975b-ffe6-42cb-9e3d-e1e894d49193",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:13:38 GMT",
+      "date" : "Thu, 26 Mar 2020 02:39:14 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11866",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11781",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "8549730a-3740-4c23-9b18-d5e0752a86ac",
+      "x-ms-correlation-request-id" : "0638c50d-7f99-42e1-88af-0a31dfb65acb",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051338Z:8549730a-3740-4c23-9b18-d5e0752a86ac",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023914Z:0638c50d-7f99-42e1-88af-0a31dfb65acb",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c9aa5c9c-563f-4d84-97e3-23104d7c22a9",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "9dab7d6b-a45e-45e2-8b1b-6e751fd04a7c",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:14:08 GMT",
+      "date" : "Thu, 26 Mar 2020 02:39:44 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11865",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11780",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "d6cab490-d83a-4190-99ae-cb13e00e9397",
+      "x-ms-correlation-request-id" : "3d4ebee0-92a9-4efc-a352-e49b1a782649",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051409Z:d6cab490-d83a-4190-99ae-cb13e00e9397",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T023945Z:3d4ebee0-92a9-4efc-a352-e49b1a782649",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "c16a497d-fbc1-4808-ba51-6bf8922be1a0",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "9f2317c0-e4c5-4536-92ba-797a59752225",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:14:39 GMT",
+      "date" : "Thu, 26 Mar 2020 02:40:15 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11864",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11779",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "a332719b-32e6-4a76-b006-fc7f6da7e8fc",
+      "x-ms-correlation-request-id" : "ab1a57c2-7066-48fb-afe2-7cb7b0079f85",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051439Z:a332719b-32e6-4a76-b006-fc7f6da7e8fc",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024016Z:ab1a57c2-7066-48fb-afe2-7cb7b0079f85",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "8b05ff70-c856-4e53-9ff3-54f2cb2eb725",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "6d4c19d1-8215-44f0-8c94-83a63d43201a",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:15:10 GMT",
+      "date" : "Thu, 26 Mar 2020 02:40:46 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11863",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11778",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "5f514ee8-f0e5-4d6f-97f0-dbe1b0ecf080",
+      "x-ms-correlation-request-id" : "1762ac06-f846-4943-b497-70389dbafaea",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051510Z:5f514ee8-f0e5-4d6f-97f0-dbe1b0ecf080",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024046Z:1762ac06-f846-4943-b497-70389dbafaea",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "04ac9ea1-d0fc-41c5-a414-da28529d17d2",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "bde8c6a5-df29-4bd9-bc89-61e82e17d61d",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:15:40 GMT",
+      "date" : "Thu, 26 Mar 2020 02:41:16 GMT",
       "server" : "nginx",
       "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11862",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11777",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "42abace4-a1eb-419c-9f2c-ccac78af1e3e",
+      "x-ms-correlation-request-id" : "3dc1f230-4a54-4d65-8b7b-a302895100ed",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051540Z:42abace4-a1eb-419c-9f2c-ccac78af1e3e",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024116Z:3dc1f230-4a54-4d65-8b7b-a302895100ed",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "fb1c000b-b039-421f-b782-101e1fc2d8d3",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\"\n }"
+      "x-ms-request-id" : "85bd004d-0417-4870-93e1-9b46d8f66851",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
     }
   }, {
     "Method" : "GET",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/7dfa6ac7-fa3b-42c5-a23a-fee0d9e66162?api-version=2017-08-31",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ContainerServiceManagementClient)"
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:16:11 GMT",
+      "date" : "Thu, 26 Mar 2020 02:41:47 GMT",
       "server" : "nginx",
-      "content-length" : "170",
+      "content-length" : "126",
       "expires" : "-1",
       "transfer-encoding" : "chunked",
       "vary" : "Accept-Encoding",
       "retry-after" : "0",
-      "x-ms-ratelimit-remaining-subscription-reads" : "11861",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11776",
       "StatusCode" : "200",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "6730dd1d-fcfb-4e95-85f7-81ae74082445",
+      "x-ms-correlation-request-id" : "58a81074-8986-423a-a08e-7ea7e8df071e",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051611Z:6730dd1d-fcfb-4e95-85f7-81ae74082445",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024147Z:58a81074-8986-423a-a08e-7ea7e8df071e",
+      "connection" : "keep-alive",
       "content-type" : "application/json",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "f0939014-6894-4655-b34a-ace137a68df3",
-      "Body" : "{\n  \"name\": \"c76afa7d-3bfa-c542-a23a-fee0d9e66162\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2019-10-23T05:08:32.7545589Z\",\n  \"endTime\": \"2019-10-23T05:15:42.7922031Z\"\n }"
+      "x-ms-request-id" : "f33a0a9c-d16b-4e45-987c-1c39c7a568ee",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:42:17 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11775",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "f1caf4c4-9943-4b6d-821c-e4af3a8a8117",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024217Z:f1caf4c4-9943-4b6d-821c-e4af3a8a8117",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "c5b4ff3d-55c9-4a71-ba04-7bb0c617ca2c",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:42:47 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11774",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "28c485e7-8226-461e-8784-aff296699021",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024248Z:28c485e7-8226-461e-8784-aff296699021",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "eaf34fc9-5b9c-4bef-b15c-02d42fc5045a",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:43:18 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11773",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "29e185b2-9f85-416e-9f09-af9e8c3b4650",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024319Z:29e185b2-9f85-416e-9f09-af9e8c3b4650",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "1f8df34b-38c7-4531-b94c-867fb66f2819",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:43:48 GMT",
+      "server" : "nginx",
+      "content-length" : "126",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11772",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "fca50d22-55ff-4124-bbc0-07f8edce5a75",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024349Z:fca50d22-55ff-4124-bbc0-07f8edce5a75",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "27892129-1fb3-42fa-aae5-1d53b521bcb4",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"InProgress\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\"\n }"
+    }
+  }, {
+    "Method" : "GET",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/b349b437-c905-4222-a0cf-08dec238880b?api-version=2017-08-31",
+    "Headers" : {
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ContainerServiceManagementClient)"
+    },
+    "Response" : {
+      "date" : "Thu, 26 Mar 2020 02:44:19 GMT",
+      "server" : "nginx",
+      "content-length" : "168",
+      "expires" : "-1",
+      "transfer-encoding" : "chunked",
+      "vary" : "Accept-Encoding",
+      "retry-after" : "0",
+      "x-ms-ratelimit-remaining-subscription-reads" : "11771",
+      "StatusCode" : "200",
+      "pragma" : "no-cache",
+      "strict-transport-security" : "max-age=31536000; includeSubDomains",
+      "x-ms-correlation-request-id" : "5125aa75-3e3a-40e8-ad20-64dafad65ac3",
+      "x-content-type-options" : "nosniff",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024420Z:5125aa75-3e3a-40e8-ad20-64dafad65ac3",
+      "connection" : "keep-alive",
+      "content-type" : "application/json",
+      "cache-control" : "no-cache",
+      "x-ms-request-id" : "7290336d-6197-434a-9433-7e2cf741defd",
+      "Body" : "{\n  \"name\": \"37b449b3-05c9-2242-a0cf-08dec238880b\",\n  \"status\": \"Succeeded\",\n  \"startTime\": \"2020-03-26T02:34:10.1257028Z\",\n  \"endTime\": \"2020-03-26T02:43:58.62132Z\"\n }"
     }
   }, {
     "Method" : "DELETE",
-    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks758999group?api-version=2019-08-01",
+    "Uri" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aks769349group?api-version=2019-08-01",
     "Headers" : {
-      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:d916ff2a485200f321d6cba23dc3377b781cd392a6e37bf910c332cb391ba0cc Java:1.8.0_202 (ResourceManagementClient, 2019-08-01)",
+      "User-Agent" : "Azure-SDK-For-Java/null OS:Windows 10/10.0 MacAddressHash:e538ec5e7628c3353ebc3f0672a746ef71c0b1433b0340c32a6ef3ab4a5d4d7f Java:1.8.0_231 (ResourceManagementClient, 2019-08-01)",
       "Content-Type" : "application/json; charset=utf-8"
     },
     "Response" : {
-      "date" : "Wed, 23 Oct 2019 05:16:17 GMT",
+      "date" : "Thu, 26 Mar 2020 02:44:24 GMT",
       "content-length" : "0",
       "expires" : "-1",
       "x-ms-ratelimit-remaining-subscription-deletes" : "14998",
@@ -3825,14 +6300,15 @@
       "StatusCode" : "202",
       "pragma" : "no-cache",
       "strict-transport-security" : "max-age=31536000; includeSubDomains",
-      "x-ms-correlation-request-id" : "ee8edaad-4896-407c-98fc-3c824ffa59e6",
+      "x-ms-correlation-request-id" : "0a807991-d767-4ab2-8df5-1c9ace600f64",
       "x-content-type-options" : "nosniff",
-      "x-ms-routing-request-id" : "SOUTHEASTASIA:20191023T051617Z:ee8edaad-4896-407c-98fc-3c824ffa59e6",
-      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1BS1M3NTg5OTlHUk9VUC1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2019-08-01",
+      "x-ms-routing-request-id" : "JAPANEAST:20200326T024425Z:0a807991-d767-4ab2-8df5-1c9ace600f64",
+      "connection" : "keep-alive",
+      "location" : "http://localhost:1234/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1BS1M3NjkzNDlHUk9VUC1FQVNUVVMiLCJqb2JMb2NhdGlvbiI6ImVhc3R1cyJ9?api-version=2019-08-01",
       "cache-control" : "no-cache",
-      "x-ms-request-id" : "ee8edaad-4896-407c-98fc-3c824ffa59e6",
+      "x-ms-request-id" : "0a807991-d767-4ab2-8df5-1c9ace600f64",
       "Body" : ""
     }
   } ],
-  "variables" : [ "758999", "66402edc-e5e2-4b2c-9762-e569607f43c6", "a61cbfbe-84b5-4086-a428-8ae3802a25cd", "e85d46e4-b9fe-4cdf-853f-3dcd7e110a4b", "730594d1-9308-4afc-a3f3-9eed620b25d7", "00ef7e3a-c528-4a1a-9ca5-563a37688ff4", "d973e438-3b4c-4677-920d-0632bf290f04", "c98afa7e-c7d0-4a84-b8c2-847c962cbf86", "48a4047b-28e9-45fb-b1b7-5ec47fff8dcc", "37b1eba4-9547-45cc-a0af-7e7a303777fe", "1ac3e182-281f-40c2-8dd4-647cb0449555", "91081ca6-f139-4de0-a29a-a0c5485b725c", "0e6b137a-8a15-497d-816e-78517e41c471", "79745a23-537a-4e7f-b703-1e8d5845964f", "f25188a4-1cd7-48a5-8fee-7ce77f3e5c41", "702699ce-b0b0-4650-82aa-7f3bbbcdfec9", "8fe74d9e-3f09-4712-8610-591d75f84775", "de74d79c-1187-42be-b14c-45538173a0b9", "f6ef514b-6465-4220-92d8-5612cc459c90", "e728e240-ae6e-4ce8-9193-b09edc851a1b", "6d64d95a-1b2d-47f3-a3c3-8036bf33e9ff", "57d03326-05b5-4ec9-9779-51e353416a5a", "583e4c08-f88b-4a45-b247-3326cfe8756a", "d064d5f6-ac20-46ee-ae7a-808800c7ac74", "fdd39fc4-c8bb-4ec3-ab25-a3fa9e627e33", "ff30a1f4-3133-4524-aec4-c4e52fd30638", "9bae85d2-fe97-42d4-9cf9-12671cb3f333", "f2db6ae3-5574-4844-bb14-b91a2f71b329", "d4f9820e-4ba5-4a9f-87b7-648e256ab3f2", "c56a5961-bc3e-43ac-968b-4fe3974f2ba1", "19e6e2ab-f780-428e-a579-1821f444d46d", "675fef11-f932-4e70-aac7-1d8961d30e7f", "7cda51b6-3fc4-44b3-a7ba-6c46e2a220f2", "52346038-2739-49a1-92df-8d89144150c6", "25a38420-64e9-4f49-8b83-d9b78a0ba3c0", "023a952a-b02c-4da2-9d4c-eaf3e5c21008", "7585e03d-8c60-429f-b022-7c5b04946f29", "5020073f-cc79-401b-82ff-bf2f63f9fc9a", "6830baa3-3de3-47f9-9497-6d433911a44f", "29b7f575-cadf-4056-9aa1-91feaee1a36c", "d3c0eb69-65fb-4107-9a21-6063982fa9b7", "bf8efad4-73aa-4100-9ad5-b2664c1ee7e0", "8bd0a4c7-c758-41f4-aebb-6fd0a762c830", "b9b7429b-c03c-4538-b600-d8eb20de8814", "b7fd5a77-0954-452b-9cd2-26e965989958", "38d54d0a-803e-41cd-ace6-36a973f4ac66", "ef5b9830-1c8a-48b0-b037-7a452b528b9a", "536576dc-87ae-4b61-a738-3e878743fd73", "423ba251-39db-4816-ab76-65c52f1629f1", "2932bc9e-9a65-4cce-85f8-7085adc87bcc", "185b6226-6800-4092-b054-3b748114b6bb", "1e4342fd-6e5f-4fb7-863c-49e4fdcf8998", "e2a8c332-3e7d-46d6-a6f9-412210d2c574", "b164531b-ed9c-4cf3-8a52-1389520fae13", "2ea2fc0c-5673-442b-8c0e-5a00517af545", "78797d3b-d413-46e9-9b22-b9449671c06a", "573b9678-99de-4a82-a9ba-7354e30df2cd", "86878120-a492-4ed7-9200-26a53eb44ca1", "d61318a6-0853-4721-9bbb-75318d23b9b2", "44ce34a4-dba2-4032-a246-382181e187b6", "c89b936d-b9b3-46a8-a737-40558ca0eb73", "5d28f8b3-d590-4051-bbf9-fac86f5b39ae", "81286b5e-e82b-4487-9a71-c79bb70f173b", "be07f59e-86fe-49b0-bb42-cf6fd54415dc", "8b7d142a-d995-459b-a923-d6322d796e2b", "d253ccda-f43d-485e-ab1f-35cf57b6355c", "6da1b019-f8d4-468a-9775-d7624464a98f", "a1821d76-52c0-423d-a114-34eecaf18aca", "6744aa6f-a299-4752-a1c4-0672dddbcdd9", "be7e745d-fcf4-4d30-844b-6202d4c7a8b7", "3535f851-4cea-4ea9-99c0-c51dc48e76c4", "c7a96312-ffa1-43e7-a8cd-f9616ce91ea9", "eea2e909-fdc3-4e56-a03d-9e1da284b044", "61295bea-d43f-4347-8fbe-8a5de8b35b01", "3191467f-d867-4871-8b35-a78543d97676", "cb8fdf00-3a9e-44b5-af39-0212f45c0351", "4b4383a5-de46-4199-a1c8-d9ff79134e7c", "067e3933-aac9-4680-8f41-e8c03a065dc1", "c43564bc-a3b6-4feb-b756-cf1c4e951b37", "0b05b2f3-8374-4134-9d90-8ddd083b346e" ]
+  "variables" : [ "769349", "1d0e3a1a-54f6-4dfd-8516-912fdb812bb2", "e89d7864-5a13-4059-b002-03e04d023d91", "0e4fdbc5-c412-4d26-aff0-22b8fc87aaf5", "497a4162-c103-4bab-b2a4-1a4ecb42d6d9", "7ef2ac02-5c24-4cd4-9d24-3bb4e6c6cb78", "0cd67d45-dfe1-43bb-85c5-c590b07d7841", "3d55923e-3e33-41f7-8abe-8e661f9c6ac8", "6703fe8c-fe62-438d-b570-109d25c69af4", "ae64945a-a39c-4d5e-bcba-347cb23253b6", "f68d408c-5e46-42b3-89cf-38e3d85064f5", "e8db7928-d9cd-4ef8-a28c-b7701068f25e", "402ac6e8-75dd-409d-8241-4d4e7c2d3249", "5f631e75-8654-4a17-989f-58ddcc3c0e04", "e7aec678-59a6-4374-99fd-0d070f04e2ee", "08fbd57f-1392-44be-9419-5c8d7190021b", "bfc8dce8-9254-4709-94d4-f3ef76f70a30", "b8817b69-1222-4f5a-b6f5-4531d3d0c11f", "1062d9b0-3df4-4a70-bb34-8d14d0395cc9", "c901ae22-75c8-4406-85ea-a52024727299", "be1bdb18-1db0-4150-b1d4-6f73265313df", "884d1c8f-137f-4188-a6de-597e88e5d7c2", "2ed133d3-ef99-485a-a0b0-ab6e649a110b", "ddfd52a1-e823-4d26-a57d-259a072c3a8d", "3936827c-6593-4fdd-a2e5-f8f791a49327", "ce634851-5167-43eb-8c99-404e64e9df0d", "53536ff4-37b3-4463-8594-351a393ce675", "c6271db0-603b-4c03-95b8-0b30d34ef298", "4ac366a3-c972-4e41-8f02-3cfd016fe920", "16b19b8d-0b16-4a13-b98f-023e9bfe6736", "adc34450-1471-458b-8398-291b15cf9b56", "1811a61a-c4fd-405e-9959-8b719fc935d0", "a8cf5e2e-f3c0-4bb7-ac62-97bb9d65ce76", "af93f98c-56dc-4662-b3d7-ced464430ae4", "735ad420-cc61-4e35-92ce-0241fd0ddd61", "32aabc55-c5a8-4cc9-b029-66b953b0aed9", "608613bc-f54a-41e7-a0af-8e3f2b52eef1", "1c627902-1c7c-4424-86fa-ff1d4c54da0e", "9e902d7e-8d15-4ec7-a227-203670506eda", "ddd359a5-cc79-4c5c-a01e-1281b1c491d8", "7f3d48c9-3922-4c10-a14a-be72f8e20163", "a7d94463-5d5f-419b-bdbf-ddacd20a41db", "98a660d6-e6f3-4cbe-817b-b06c2856118f", "fc581612-d37c-4f69-a3e7-0168aa0e9c24", "76daf809-7abe-4416-b2e1-8be7a623c0a4", "98dc80c8-ddd1-46c5-99c0-37dc1087ada8", "c48a363d-9b2f-4e3a-bfa4-6bb736dbf8f0", "6d8c484d-49d2-43bd-950e-3b4326497a4b", "e9d71250-08d8-4dab-a82c-a9c162b33deb", "35d4f9b4-52a9-4cd8-8dad-e78ca72712d0", "74b2f822-0946-4e60-9656-ee7adcf63964", "dc35157a-818d-4c18-b5cf-1da92bda09f7", "3bc9190c-b1ef-4b7d-8d70-939eb09b458f", "f0a40bb9-aedf-4772-992a-b531697d1943", "553a6424-9f7f-4aee-9f71-1f5d9ceca49c", "d6bcc34b-0436-45e6-aba1-80e841d88392", "e65f71c9-482b-4be2-bf77-b086ac924c12", "64b897a3-7264-4437-bada-3ffd1b56dea9", "4dbfef4d-1341-4f10-b98a-9ad78abf64ef", "d11ecfaa-011d-44a5-86e6-84e6507ca7ca", "65035fee-66b4-4938-ac31-ef3086524522", "d3395975-8ad5-4fbf-8fd5-a87adba0946b", "b624e84b-fc82-4906-9009-5b083f12160c", "559f7e57-f9de-47d0-808d-bdfa4d3a1508", "595c52c8-38e0-4647-bc0c-419e4c1c12cc", "12d00081-175c-48c1-a264-53cdbb6d4237", "b29430a1-1065-44cf-95ee-3e7fe7f8b894", "60518d4d-87b9-42aa-ab7a-3623a1ef84a0", "caa0d802-f737-4550-a9f2-199405d319dd", "f538414f-4298-42c4-911a-0c77fc7251ba", "9caf47f8-d5d7-4ca8-9f01-58923c74ffdd", "1651377a-061f-4ecd-a872-cc75b01c0547", "651ce690-0eb1-4992-b4dc-2190d85205db", "6d85536b-459b-4078-b78f-664e57c0ba99", "89b7f572-888c-4acf-87c6-a005db6ffbc5", "591daefa-70b5-4e8b-97d8-7675c6902fa8", "dceaa961-5db8-4a81-9497-91fb3c0f9a24", "d6343ab5-d651-4ba7-ab39-af8dc40ef100", "a32d1c45-171b-46db-ac08-f2f2f90d424b", "6ff3d52e-968a-4b62-a54d-81b6d74e49fb", "0279cd9e-2f5e-4d8a-ae2e-7f8187056aa1", "9aa00051-27fa-4fb6-bf04-17a397e16036", "e60532f7-d7ae-45b1-a264-89b8bfe949ca", "86a6babf-fbee-4ba4-8d5a-7d5f1c775bb6", "74fb807d-cc67-4e95-84fb-d0102bcc343f", "ddcb725e-37c1-44a2-8010-26ae2ad4a5d2", "10d7e3f4-e880-474a-be86-9180a7a56644", "d70b3f0e-c0d2-447f-b5c2-4a08e89cc501", "c22040e3-739a-42f6-99a4-f15f746e6118", "c069affc-57ad-4955-8b83-f96595828eee", "263f14ef-b85a-4497-a499-e41eb364153b", "7725d2d9-3b93-49c1-84f1-651064a3eb28", "554801e5-00cb-4e8c-b647-ace45685c8b8", "3bff9b72-dc3d-4e90-8d36-a16877b418d6", "b1228efd-495f-45be-b75a-4d42e568560e", "464ec67d-bbff-4596-b91b-8dc5fd2f5544", "f435d571-d292-4235-a5cd-cc5bad928edf", "214ccd38-b4ec-4442-8420-a5dd14f87c4f", "9df8ab9d-6094-475f-a8e1-e300452bb5fd", "c57660ba-513e-4e17-bbc7-cdec5bb4ca43", "1b90966a-6c0e-4c73-a21a-8726f1c8760a", "f9b82002-e5aa-4f73-b9b2-f569668882b9", "6bcf3ef3-dbe9-4247-9293-c53ecfda60f7", "94234baf-ada5-4ea5-9906-9661b07296b0", "d7e2c048-c46a-42d3-a977-976469a78d01", "6dbe9c18-962b-456e-8ddb-d676c80198fc", "09d5d841-edec-420f-8495-62138a372548", "32a6aa2f-c610-4608-852e-07365826014a", "8e822312-a8ae-4930-ba76-463170ef991b", "47aefb5a-17b1-4a82-bf4c-ad6895dc4829", "d6f616d8-3b9d-4d4d-8600-72682e58a963", "6e32bff4-94f8-4e27-8239-17344670262d", "79ae2edf-6d18-4095-9d70-de65defb68b7", "edb4da40-535e-4f26-82ec-6011a971b2b4", "d73af1f5-2e43-40e4-920c-d30429c38ceb", "0540ccfe-d7d8-4008-a99a-2c0e28d0a33c", "fac0f648-343a-4d4e-8843-ce70976a0d6e", "5b7e570d-f602-42f9-a111-8a5443d442aa", "0f618a61-ee05-4db8-9b70-a2f6026dcece", "7032ab7b-a254-4f92-8a8a-3403bccd0b21", "8632eab1-4213-48a0-9763-f0b07fdf65ed", "5538c69b-80dc-4cb3-b470-5cbc03ce81cb", "a07cc756-8ef7-42d9-a37a-8f95e3b61494", "809a7183-5197-4f9f-8fc5-1e0f0b21978d", "77f2622d-6233-48c9-b21a-f6a8aa3e1201", "7e544889-f181-45f5-bcc6-ee5b1e6c7ae6", "ea6ce03f-a410-4e0f-84c2-54cd359303b2", "1f6f0f45-37ac-419b-b0b9-b73f70067686", "73d46710-0ed5-483d-ba18-5f88c2ad54fa", "3aa5e378-9999-435a-b074-f23fedc33375", "d25a158c-9c5f-4233-8454-70ed2ac6c623", "7bbec85f-96cd-417b-8fa5-ea6e288aa200", "09feca7a-b345-4ffb-b8c4-2fe399e062b3", "7cef0bf7-48c3-44f8-a160-c8cadc294c71", "aa8264ef-10c4-4505-b9bb-1281d02cb8b8", "fef25c87-29a2-4657-b92e-c4ff4fb04db9", "11691eff-b4f5-4705-b640-787e1b04a500", "e4ec9a1b-d42a-467a-9dbd-bac31825442d", "c18ac3b6-26fe-487c-bc6e-644168b8a8e8", "2f5167a9-4abd-439a-9d5a-c0ccd8c6048e", "8245be62-21d8-4637-b195-7877f30d52f6", "f512c766-2a18-434d-b20f-70d72921e53b", "442bdee8-8bc0-4f3c-9c78-a34d32a69f7c", "638890ee-d2b1-4350-8aee-430a069588b9", "26ded5ca-e1d5-4386-aa5e-35364517e3ac", "2ea3c4da-9da8-4eba-a327-d07e9aa3799e", "8b31980d-1d39-42e9-8f2d-451d78428f37", "180fb639-a9e3-48e2-980b-d9f55403c5cc", "d3ebe99c-ade3-4e73-bb87-bd6d9c86c01e", "a5044703-6f81-4941-974c-71325fb20481", "9b2e1e85-dfee-44d1-be13-58ddabb7a8b0", "f4d7523e-c6ad-47b7-bcf2-6682e039a410", "ebbad763-1004-44e3-b9ae-a5f5b41ce4ad", "47d7d40c-da49-469a-acc8-d687f1c77f8f", "ccd59163-c229-4046-828e-797881169ce5", "be6d81e9-f2ae-47a8-83dd-367c5ebd02b1", "051972ef-54eb-47c1-9fae-4fa95939ac75", "504a3799-1a5e-42b7-9187-0747e256b7dc", "6f140e1d-98fc-4764-8e1c-f05c5448b9ab", "626003ef-fd4b-42b4-ab52-24779f3ac5db", "b2421e67-258a-4a49-aee4-8a9f5c2aceb2", "bc6407a2-7821-4fbc-92dc-908caddc8f94", "c1f7b5e4-ba27-4e11-a00f-7f92c9aca718", "d85ff09b-17a2-4140-b101-c0a4071967b6", "4941c5e8-9fc0-4dc2-a75d-87e57c6b7eed", "cfd5a70b-6ee1-4542-80d4-97a3b1d69089", "c57b77d2-da93-46f2-8556-2eb30999cbfc", "d17330c8-3ab9-419c-bd7e-2961e5d7b44c", "2681d5ae-6026-4507-8867-a91a499fe594", "597daf62-14a6-48cb-846b-667ee1c50631", "7fa24636-371e-4f4c-9694-9a0f1c012ecc", "35f0fb54-f074-4663-8595-b0b6d39cfa4f", "34719a2b-12eb-4a52-92ac-a14880f6e834", "b0ffbf5a-a3d6-4d09-a61d-71bfbc2f25ac", "24fbcf13-b555-4409-af53-8e8db681fca0", "a23ad58b-8807-4a21-b3ed-99b2c0285c9c", "eb1b952a-7260-4ad5-a934-a6dff7ea582a", "9e9bf17f-3473-4700-a5ec-dea284980593", "f49d1304-3071-4149-bbf5-115885b727dd", "53df716f-02f7-4c19-a258-10d9b9a98a44", "e4717399-1c45-49fe-9a6b-49f489132138", "32882f75-1e8a-4aac-acb5-6f78bb72d1d4", "b69055c1-1fbb-434d-b901-348485ebc904", "5b4c91b7-f8be-40d4-87d6-24b1780979f6", "53bb5400-3190-4a05-9236-fa2aaef50211", "bc6440b6-68fa-4908-9632-a84a8de00b6c", "c0b0adca-5de1-4c94-b349-b49747afc281" ]
 }


### PR DESCRIPTION
per AKS team's ask, deprecate getAccessProfile API, instead of using ListClusterAdminCredentials / ListClusterUserCredentials 
```
From: Ruchika Gupta <rucgupt@microsoft.com>
Sent: Wednesday, March 18, 2020 7:17
To: Tanyi Chen <Tanyi.Chen@microsoft.com>
Cc: Jorge Palma <Jorge.Palma@microsoft.com>
Subject: Update azure-libraries-for-net repo to not use AKS GetAccessProfile API 
 
Hi Tanyi,
 
I’m Ruchika, an engineer on Azure Kubernetes Service team. I got your contact from the azure-libraries-for-net github repo releases, please redirect me if you’re not the right contact. 
 
We are in the process to deprecate GetAccessProfile API and are reaching out to partners using this API. We noticed that this repo is using GetAccessProfile API to set the cluster user and cluster admin kubeconfigs https://github.com/Azure/azure-libraries-for-net/blob/12bf18bf4c6012791f357eb582fd4ae4a2f442f9/src/ResourceManagement/ContainerService/KubernetesClusterImpl.cs#L129-L148. 
 
We are recommending to use ListClusterAdminCredentials / ListClusterUserCredentials API instead. Can you help make that change? Or please add someone who can help change it?
 
Thanks,
Ruchika

```