### PR TITLE
throttle base on subscriptionId and request method

### DIFF
--- a/azure-mgmt-resources/pom.xml
+++ b/azure-mgmt-resources/pom.xml
@@ -84,6 +84,12 @@
       <artifactId>httpcore</artifactId>
       <version>4.4.5</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>2.24.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptor.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptor.java
@@ -42,7 +42,7 @@ public class ResourceManagerThrottlingInterceptor implements Interceptor {
         if (subscriptionId == null) {
             subscriptionId = "global";
         }
-        String subscriptionAndMethod = subscriptionId + "|" + chain.request().method().toLowerCase(Locale.ROOT);
+        final String subscriptionAndMethod = subscriptionId + "|" + chain.request().method().toLowerCase(Locale.ROOT);
         REENTRANT_LOCK_MAP.putIfAbsent(subscriptionAndMethod, new ReentrantLock());
         try {
             synchronized (REENTRANT_LOCK_MAP.get(subscriptionAndMethod)) {

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptor.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptor.java
@@ -18,6 +18,7 @@ import org.joda.time.Duration;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -41,11 +42,12 @@ public class ResourceManagerThrottlingInterceptor implements Interceptor {
         if (subscriptionId == null) {
             subscriptionId = "global";
         }
-        REENTRANT_LOCK_MAP.putIfAbsent(subscriptionId, new ReentrantLock());
+        String subscriptionAndMethod = subscriptionId + "|" + chain.request().method().toLowerCase(Locale.ROOT);
+        REENTRANT_LOCK_MAP.putIfAbsent(subscriptionAndMethod, new ReentrantLock());
         try {
-            synchronized (REENTRANT_LOCK_MAP.get(subscriptionId)) {
-                if (REENTRANT_LOCK_MAP.get(subscriptionId).isLocked()) {
-                    REENTRANT_LOCK_MAP.get(subscriptionId).wait();
+            synchronized (REENTRANT_LOCK_MAP.get(subscriptionAndMethod)) {
+                if (REENTRANT_LOCK_MAP.get(subscriptionAndMethod).isLocked()) {
+                    REENTRANT_LOCK_MAP.get(subscriptionAndMethod).wait();
                 }
             }
         } catch (InterruptedException e) {
@@ -57,13 +59,13 @@ public class ResourceManagerThrottlingInterceptor implements Interceptor {
         }
 
         try {
-            synchronized (REENTRANT_LOCK_MAP.get(subscriptionId)) {
-                if (REENTRANT_LOCK_MAP.get(subscriptionId).isLocked()) {
+            synchronized (REENTRANT_LOCK_MAP.get(subscriptionAndMethod)) {
+                if (REENTRANT_LOCK_MAP.get(subscriptionAndMethod).isLocked()) {
                     response.close();
-                    REENTRANT_LOCK_MAP.get(subscriptionId).wait();
+                    REENTRANT_LOCK_MAP.get(subscriptionAndMethod).wait();
                     return chain.proceed(chain.request());
                 } else {
-                    REENTRANT_LOCK_MAP.get(subscriptionId).lock();
+                    REENTRANT_LOCK_MAP.get(subscriptionAndMethod).lock();
                 }
             }
         } catch (InterruptedException e) {
@@ -112,9 +114,9 @@ public class ResourceManagerThrottlingInterceptor implements Interceptor {
             throw new IOException(t);
         } finally {
             response.close();
-            synchronized (REENTRANT_LOCK_MAP.get(subscriptionId)) {
-                REENTRANT_LOCK_MAP.get(subscriptionId).unlock();
-                REENTRANT_LOCK_MAP.get(subscriptionId).notifyAll();
+            synchronized (REENTRANT_LOCK_MAP.get(subscriptionAndMethod)) {
+                REENTRANT_LOCK_MAP.get(subscriptionAndMethod).unlock();
+                REENTRANT_LOCK_MAP.get(subscriptionAndMethod).notifyAll();
             }
         }
     }

--- a/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptorTests.java
+++ b/azure-mgmt-resources/src/test/java/com/microsoft/azure/management/resources/fluentcore/utils/ResourceManagerThrottlingInterceptorTests.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.management.resources.fluentcore.utils;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.microsoft.rest.LogLevel;
+import com.microsoft.rest.interceptors.LoggingInterceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+import rx.Observable;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class ResourceManagerThrottlingInterceptorTests {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8765);
+
+    @Test
+    public void testThrottlingOnHttpMethods() throws Exception {
+        stubFor(put(urlMatching("/subscriptions/[0-9-]+/resourcegroups/[a-z0-9]+"))
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "5")));
+
+        stubFor(get(urlMatching("/subscriptions/[0-9-]+/resourcegroups/[a-z0-9]+"))
+                .willReturn(ok()));
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(new ResourceManagerThrottlingInterceptor())
+                .addInterceptor(new LoggingInterceptor(LogLevel.BODY_AND_HEADERS))
+                .build();
+        Retrofit retrofit = new Retrofit.Builder()
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .client(client)
+                .baseUrl("http://localhost:8765/")
+                .build();
+        final ResourceGroupsService service = retrofit.create(ResourceGroupsService.class);
+
+        final String ZERO_SUBSCRIPTION = "00000000-0000-0000-0000-000000000000";
+
+        final long[] putCompleteTime = new long[1];
+        final long[] getCompleteTime = new long[1];
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        pool.submit(new Runnable() {
+            @Override
+            public void run() {
+                ResponseBody response = service.createOrUpdate("rg", ZERO_SUBSCRIPTION).toBlocking().single().body();
+                putCompleteTime[0] = System.nanoTime() / (long) 1E6;
+            }
+        });
+        Thread.sleep(2000);
+        pool.submit(new Runnable() {
+            @Override
+            public void run() {
+                ResponseBody response = service.get("rg", ZERO_SUBSCRIPTION).toBlocking().single().body();
+                getCompleteTime[0] = System.nanoTime() / (long) 1E6;
+            }
+        });
+        pool.shutdown();
+        pool.awaitTermination(30, TimeUnit.SECONDS);
+
+        // PUT will retry due to 429, GET will success, hence GET would finish before PUT
+        Assert.assertTrue(getCompleteTime[0] < putCompleteTime[0]);
+    }
+
+    interface ResourceGroupsService {
+        @Headers({"Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.management.resources.ResourceGroups createOrUpdate"})
+        @PUT("subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}")
+        Observable<Response<ResponseBody>> createOrUpdate(@Path("resourceGroupName") String resourceGroupName, @Path("subscriptionId") String subscriptionId);
+
+        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.management.resources.ResourceGroups get" })
+        @GET("subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}")
+        Observable<Response<ResponseBody>> get(@Path("resourceGroupName") String resourceGroupName, @Path("subscriptionId") String subscriptionId);
+    }
+}


### PR DESCRIPTION
fix https://github.com/Azure/azure-libraries-for-java/issues/1251

ratelimit could have different limit on write/read/delete
https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling

Hence it likely helps to separate them (to avoid the case that a throttle write blocks a subsequent delete or read).

Pending mock server test.