### PR TITLE
ReturnRequestIdHeaderInterceptor

### DIFF
--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ReturnRequestIdHeaderInterceptor.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ReturnRequestIdHeaderInterceptor.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.management.resources.fluentcore.utils;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * An interceptor for requesting server return client-request-id in response headers.
+ * Optionally, fill-in the client-request-id, if server does not return it in response headers.
+ */
+public class ReturnRequestIdHeaderInterceptor implements Interceptor {
+
+    private static final String NAME_RETURN_CLIENT_REQUEST_ID = "x-ms-return-client-request-id";
+    private static final String NAME_CLIENT_REQUEST_ID = "x-ms-client-request-id";
+
+    private final boolean copyClientRequestIdInResponse;
+
+    /**
+     * Creates a new instance of ReturnRequestIdHeaderInterceptor.
+     * Sets "x-ms-return-client-request-id: true" in requests headers.
+     */
+    public ReturnRequestIdHeaderInterceptor() {
+        this(false);
+    }
+
+    /**
+     * Creates a new instance of ReturnRequestIdHeaderInterceptor.
+     * Sets "x-ms-return-client-request-id: true" in requests headers.
+     * Optionally fill-in the client-request-id if server does not return it in response headers.
+     *
+     * @param copyClientRequestIdInResponse whether to copy client-request-id in request headers to response headers, if server does not return client-request-id.
+     */
+    public ReturnRequestIdHeaderInterceptor(boolean copyClientRequestIdInResponse) {
+        this.copyClientRequestIdInResponse = copyClientRequestIdInResponse;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        String clientRequestId = request.header(NAME_CLIENT_REQUEST_ID);
+
+        // add header if absent
+        if (request.header(NAME_RETURN_CLIENT_REQUEST_ID) == null) {
+            request = chain.request().newBuilder()
+                    .header(NAME_RETURN_CLIENT_REQUEST_ID, "true")
+                    .build();
+        }
+
+        // send request
+        Response response = chain.proceed(request);
+
+        // optionally, add header if absent
+        if (copyClientRequestIdInResponse && clientRequestId != null && response.header(NAME_CLIENT_REQUEST_ID) == null) {
+            response = response.newBuilder()
+                    .addHeader(NAME_CLIENT_REQUEST_ID, clientRequestId)
+                    .build();
+        }
+
+        return response;
+    }
+}

--- a/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ReturnRequestIdHeaderInterceptor.java
+++ b/azure-mgmt-resources/src/main/java/com/microsoft/azure/management/resources/fluentcore/utils/ReturnRequestIdHeaderInterceptor.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.azure.management.resources.fluentcore.utils;
 
+import com.microsoft.rest.RestClient;
+import com.microsoft.rest.interceptors.RequestIdHeaderInterceptor;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -15,37 +17,58 @@ import java.io.IOException;
 /**
  * An interceptor for requesting server return client-request-id in response headers.
  * Optionally, fill-in the client-request-id, if server does not return it in response headers.
+ * <p>
+ * ReturnRequestIdHeaderInterceptor should be added after {@link RequestIdHeaderInterceptor}.
+ * By default, {@link RequestIdHeaderInterceptor} is added as first interceptor by {@link RestClient}.
+ *
+ * @see RequestIdHeaderInterceptor
  */
 public class ReturnRequestIdHeaderInterceptor implements Interceptor {
 
     private static final String NAME_RETURN_CLIENT_REQUEST_ID = "x-ms-return-client-request-id";
     private static final String NAME_CLIENT_REQUEST_ID = "x-ms-client-request-id";
 
-    private final boolean copyClientRequestIdInResponse;
+    private final Option option;
+
+    /**
+     * Additional client handling, if server does not return client-request-id in response headers.
+     */
+    public enum Option {
+        /**
+         * Default.
+         */
+        NONE,
+
+        /**
+         * Fill-in the client-request-id from request headers.
+         */
+        COPY_CLIENT_REQUEST_ID
+    }
 
     /**
      * Creates a new instance of ReturnRequestIdHeaderInterceptor.
      * Sets "x-ms-return-client-request-id: true" in requests headers.
      */
     public ReturnRequestIdHeaderInterceptor() {
-        this(false);
+        this(Option.NONE);
     }
 
     /**
      * Creates a new instance of ReturnRequestIdHeaderInterceptor.
      * Sets "x-ms-return-client-request-id: true" in requests headers.
+     * <p>
      * Optionally fill-in the client-request-id if server does not return it in response headers.
      *
-     * @param copyClientRequestIdInResponse whether to copy client-request-id in request headers to response headers, if server does not return client-request-id.
+     * @param option the option of additional client handling, if server does not return client-request-id in response headers.
      */
-    public ReturnRequestIdHeaderInterceptor(boolean copyClientRequestIdInResponse) {
-        this.copyClientRequestIdInResponse = copyClientRequestIdInResponse;
+    public ReturnRequestIdHeaderInterceptor(Option option) {
+        this.option = option;
     }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        String clientRequestId = request.header(NAME_CLIENT_REQUEST_ID);
+        final String clientRequestId = request.header(NAME_CLIENT_REQUEST_ID);
 
         // add header if absent
         if (request.header(NAME_RETURN_CLIENT_REQUEST_ID) == null) {
@@ -57,8 +80,9 @@ public class ReturnRequestIdHeaderInterceptor implements Interceptor {
         // send request
         Response response = chain.proceed(request);
 
-        // optionally, add header if absent
-        if (copyClientRequestIdInResponse && clientRequestId != null && response.header(NAME_CLIENT_REQUEST_ID) == null) {
+        // optionally, copy header from request, if absent in response
+        if (option == Option.COPY_CLIENT_REQUEST_ID
+                && clientRequestId != null && response.header(NAME_CLIENT_REQUEST_ID) == null) {
             response = response.newBuilder()
                     .addHeader(NAME_CLIENT_REQUEST_ID, clientRequestId)
                     .build();


### PR DESCRIPTION
to request server put x-ms-client-request-id in response

Sample usage:

```
        Azure azure = Azure.configure()
                .withInterceptor(new ReturnRequestIdHeaderInterceptor())
                .authenticate(...)
                ...
```

Header can be accessed in Exception.

```
        exception.response().headers().get("x-ms-client-request-id")
```